### PR TITLE
Add OWL and missing symbols and decimals

### DIFF
--- a/schema/gnosis_dfusion/view_tokens.sql
+++ b/schema/gnosis_dfusion/view_tokens.sql
@@ -1,13 +1,39 @@
 CREATE OR REPLACE VIEW gnosis_dfusion.view_tokens AS
+WITH 
+token_names as (
+    SELECT * FROM (VALUES
+        (14, 'aDAI', 18),
+        (17, 'PAXG', 18)
+    ) as t (token_id, symbol, decimals)
+),
+tokens as (
+    SELECT
+        ROW_NUMBER() OVER (ORDER BY transactions.block_number, transactions.index) as token_id,
+        tokens.token,
+        erc20.symbol,
+        erc20.decimals,
+        transactions.block_time as add_date
+    FROM gnosis_dfusion."BatchExchange_call_addToken" tokens
+    JOIN ethereum."transactions" transactions
+      ON transactions.hash=tokens.call_tx_hash
+      AND transactions.success=true
+    LEFT OUTER JOIN erc20."tokens" as erc20
+      ON erc20.contract_address = tokens.token
+)
 SELECT
-    ROW_NUMBER() OVER (ORDER BY transactions.block_number, transactions.index) as token_id,
+    tokens.token_id,
     tokens.token,
-    erc20.symbol,
-    erc20.decimals,
-    transactions.block_time as add_date
-FROM gnosis_dfusion."BatchExchange_call_addToken" tokens
-JOIN ethereum."transactions" transactions
-  ON transactions.hash=tokens.call_tx_hash
-  AND transactions.success=true
-LEFT OUTER JOIN erc20."tokens" as erc20
-  ON erc20.contract_address = tokens.token;
+    COALESCE(tokens.symbol, token_names.symbol) as symbol,
+    COALESCE(tokens.decimals, token_names.decimals) as decimals,
+    tokens.add_date
+FROM tokens
+LEFT OUTER JOIN token_names
+    ON tokens.token_id = token_names.token_id
+UNION all (
+    SELECT
+        0 as token_id,
+        '\x1a5f9352af8af974bfc03399e3767df6370d82e4' as token_address,
+        'OWL' as symbol,
+        18 as decimals,
+        '2020-01-23 20:30:00.000' as add_date
+);


### PR DESCRIPTION
Adds OWL token (implicit in the protocol)
Also adds the symbol and decimals for two tokens that are missing in the ERC20 tokens table.

----
I've checked that:

* [X] the folder name matches the schema name
* [X] the schemaname exists in Dune
* [X] the view name starts with `view_`
* [X] each file has only one view defined  
* [X] column names are `lowercase_snake_cased`
