### PR TITLE
Add event information solution

### DIFF
--- a/schema/gnosis_protocol/view_trades.sql
+++ b/schema/gnosis_protocol/view_trades.sql
@@ -1,55 +1,55 @@
 CREATE MATERIALIZED VIEW gnosis_protocol.view_trades AS
-WITH reverts as (
+WITH reverts AS (
 SELECT
     reversion.owner,
-    reversion."orderId" as order_id,
-    reversion.evt_block_time as block_time,
+    reversion."orderId" AS order_id,
+    reversion.evt_block_time AS block_time,
     RANK() OVER (
         PARTITION BY solution."batchId", reversion.owner, reversion."orderId"
         ORDER BY reversion.evt_block_number, reversion.evt_index
-    ) as trade_sub_id,
-    solution."batchId" as batch_id
+    ) AS trade_sub_id,
+    solution."batchId" AS batch_id
 FROM gnosis_protocol."BatchExchange_evt_TradeReversion" reversion
 JOIN gnosis_protocol."BatchExchange_call_submitSolution" solution
     ON solution.call_tx_hash=reversion.evt_tx_hash
     AND solution.call_success = true
 ),
-trades as (
+trades AS (
 SELECT
 	  -- id
     floor(extract(epoch from solution.evt_block_time) / 300) - 1 AS batch_id, -- The event time tells us the batch. Between minute 0-4 is resolved batch N-1
     trades."owner" AS trader_hex,    
-    trades."orderId" as order_id,
+    trades."orderId" AS order_id,
     RANK() OVER (
         PARTITION BY solution.evt_block_time, trades.owner, trades."orderId"
         ORDER BY trades.evt_block_number, trades.evt_index
-    ) as trade_sub_id,
+    ) AS trade_sub_id,
     -- Event index
     trades.evt_index AS evt_index_trades,
     solution.evt_index AS evt_index_solution,
     -- dates & block info
     solution.evt_block_number,
-    solution.evt_block_time as block_time,
+    solution.evt_block_time AS block_time,
     to_timestamp((floor(extract(epoch from solution.evt_block_time) / 300)) * 300) AS trade_date,
     -- sell token
-    trades."sellToken" as sell_token_id,
-    sell_token."token" as sell_token,
-    sell_token."symbol" as sell_token_symbol,
-    sell_token."decimals" as sell_token_decimals,
+    trades."sellToken" AS sell_token_id,
+    sell_token."token" AS sell_token,
+    sell_token."symbol" AS sell_token_symbol,
+    sell_token."decimals" AS sell_token_decimals,
     -- sell amounts
-    trades."executedSellAmount" as sell_amount_atoms,
-    trades."executedSellAmount" / 10^(sell_token.decimals) as sell_amount,
+    trades."executedSellAmount" AS sell_amount_atoms,
+    trades."executedSellAmount" / 10^(sell_token.decimals) AS sell_amount,
     -- buy token
-    trades."buyToken" as buy_token_id,
-    buy_token.token as buy_token,    
-    buy_token.symbol as buy_token_symbol,
-    buy_token.decimals as buy_token_decimals,
+    trades."buyToken" AS buy_token_id,
+    buy_token.token AS buy_token,    
+    buy_token.symbol AS buy_token_symbol,
+    buy_token.decimals AS buy_token_decimals,
     -- buy amounts
-    trades."executedBuyAmount" as buy_amount_atoms,
-    trades."executedBuyAmount" / 10^(buy_token.decimals) as buy_amount,
+    trades."executedBuyAmount" AS buy_amount_atoms,
+    trades."executedBuyAmount" / 10^(buy_token.decimals) AS buy_amount,
     -- Tx and block info
-    trades.evt_block_number as block_number,
-    trades.evt_tx_hash as tx_hash
+    trades.evt_block_number AS block_number,
+    trades.evt_tx_hash AS tx_hash
 FROM gnosis_protocol."BatchExchange_evt_Trade" trades
 JOIN gnosis_protocol."BatchExchange_evt_SolutionSubmission" solution
     ON solution.evt_tx_hash=trades.evt_tx_hash
@@ -60,7 +60,7 @@ JOIN gnosis_protocol.view_tokens sell_token
 )
 SELECT
 	trades.*,
-	reverts.block_time as revert_time
+	reverts.block_time AS revert_time
 FROM trades
 LEFT OUTER JOIN reverts
     ON trades.trader_hex = reverts.owner

--- a/schema/gnosis_protocol/view_trades.sql
+++ b/schema/gnosis_protocol/view_trades.sql
@@ -16,8 +16,7 @@ JOIN gnosis_protocol."BatchExchange_call_submitSolution" solution
 ),
 trades as (
 SELECT
-	-- id
-    --solution."batchId" as batch_id,
+	  -- id
     floor(extract(epoch from solution.evt_block_time) / 300) - 1 AS batch_id, -- The event time tells us the batch. Between minute 0-4 is resolved batch N-1
     trades."owner" AS trader_hex,    
     trades."orderId" as order_id,

--- a/schema/gnosis_protocol/view_trades.sql
+++ b/schema/gnosis_protocol/view_trades.sql
@@ -17,7 +17,7 @@ JOIN gnosis_protocol."BatchExchange_call_submitSolution" solution
 trades AS (
 SELECT
 	  -- id
-    floor(extract(epoch from solution.evt_block_time) / 300) - 1 AS batch_id, -- The event time tells us the batch. Between minute 0-4 is resolved batch N-1
+    FLOOR(EXTRACT(epoch from solution.evt_block_time) / 300) - 1 AS batch_id, -- The event time tells us the batch. Between minute 0-4 is resolved batch N-1
     trades."owner" AS trader_hex,    
     trades."orderId" AS order_id,
     RANK() OVER (
@@ -30,7 +30,7 @@ SELECT
     -- dates & block info
     solution.evt_block_number,
     solution.evt_block_time AS block_time,
-    to_timestamp((floor(extract(epoch from solution.evt_block_time) / 300)) * 300) AS trade_date,
+    TO_TIMESTAMP((FLOOR(EXTRACT(epoch from solution.evt_block_time) / 300)) * 300) AS trade_date,
     -- sell token
     trades."sellToken" AS sell_token_id,
     sell_token."token" AS sell_token,

--- a/schema/gnosis_protocol/view_trades.sql
+++ b/schema/gnosis_protocol/view_trades.sql
@@ -78,12 +78,12 @@ ORDER BY
 
 
 CREATE UNIQUE INDEX IF NOT EXISTS view_trades_id ON gnosis_protocol.view_trades (batch_id, trader_hex, order_id, trade_sub_id);
-CREATE INDEX view_trades_1 ON gnosis_protocol.view_trades (trade_date);
-CREATE INDEX view_trades_2 ON gnosis_protocol.view_trades (sell_token_symbol);
-CREATE INDEX view_trades_3 ON gnosis_protocol.view_trades (sell_token);
-CREATE INDEX view_trades_4 ON gnosis_protocol.view_trades (buy_token_symbol);
-CREATE INDEX view_trades_5 ON gnosis_protocol.view_trades (buy_token);
-CREATE INDEX view_trades_6 ON gnosis_protocol.view_trades (trader_hex, order_id);
+CREATE INDEX view_trades_idx_1 ON gnosis_protocol.view_trades (trade_date);
+CREATE INDEX view_trades_idx_2 ON gnosis_protocol.view_trades (sell_token_symbol);
+CREATE INDEX view_trades_idx_3 ON gnosis_protocol.view_trades (sell_token);
+CREATE INDEX view_trades_idx_4 ON gnosis_protocol.view_trades (buy_token_symbol);
+CREATE INDEX view_trades_idx_5 ON gnosis_protocol.view_trades (buy_token);
+CREATE INDEX view_trades_idx_6 ON gnosis_protocol.view_trades (trader_hex, order_id);
 
 
 

--- a/schema/gnosis_protocol/view_trades.sql
+++ b/schema/gnosis_protocol/view_trades.sql
@@ -79,12 +79,13 @@ ORDER BY
 
 
 CREATE UNIQUE INDEX IF NOT EXISTS view_trades_id ON gnosis_protocol.view_trades (batch_id, trader_hex, order_id, trade_sub_id);
-CREATE INDEX view_trades_1 ON gnosis_protocol.view_trades (batch_id);
+CREATE INDEX view_trades_1 ON gnosis_protocol.view_trades (trade_date);
 CREATE INDEX view_trades_2 ON gnosis_protocol.view_trades (sell_token_symbol);
 CREATE INDEX view_trades_3 ON gnosis_protocol.view_trades (sell_token);
 CREATE INDEX view_trades_4 ON gnosis_protocol.view_trades (buy_token_symbol);
 CREATE INDEX view_trades_5 ON gnosis_protocol.view_trades (buy_token);
 CREATE INDEX view_trades_6 ON gnosis_protocol.view_trades (trader_hex, order_id);
+
 
 
 SELECT cron.schedule('0-59 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_trades');


### PR DESCRIPTION
This PR improves the trade view:

It still return the same number of registries but it:
* Adds a trade date
* Fixes an issue with the batch ID: It was not the correct number
* Return the events index for the trade and the solution. Becomes relevant to JOIN with the new table for prices
* Restructure the query a bit: Simplifies the last query, moves some parts to the temp "trades"

Aditionally, regarding the indexes, updates `view_trades_1`:
* Removes the index by `batch_id` since it's not needed (it's derived by the PK index)
* Adds an index by `trade_date` 