### PR TITLE
Add rewards and handle edge withdraw cases

### DIFF
--- a/schema/gnosis_protocol/view_balances.sql
+++ b/schema/gnosis_protocol/view_balances.sql
@@ -5,6 +5,7 @@ WITH
 last_movement as (
     SELECT 
         MAX(batch_id) as batch_id,
+        MAX(movement_date) as movement_date,
         trader,
         token
     FROM gnosis_protocol.view_movement
@@ -19,7 +20,9 @@ SELECT
     movement.balance_deposited,
     movement.balance_deposited_atoms,
     movement.balance_actual,
-    movement.balance_actual_atoms
+    movement.balance_actual_atoms,
+    last_movement.movement_date as last_movement_date,
+    last_movement.batch_id as last_movement_batch_id
 FROM last_movement
 JOIN gnosis_protocol.view_movement movement
     ON movement.batch_id = last_movement.batch_id

--- a/schema/gnosis_protocol/view_balances.sql
+++ b/schema/gnosis_protocol/view_balances.sql
@@ -12,10 +12,14 @@ last_movement as (
 )
 SELECT
     movement.trader,
-    movement.balance,
     movement.token_symbol,
     movement.token,
-    movement.decimals
+    movement.decimals,
+    movement.balance,
+    movement.balance_deposited,
+    movement.balance_deposited_atoms,
+    movement.balance_actual,
+    movement.balance_actual_atoms
 FROM last_movement
 JOIN gnosis_protocol.view_movement movement
     ON movement.batch_id = last_movement.batch_id

--- a/schema/gnosis_protocol/view_movement.sql
+++ b/schema/gnosis_protocol/view_movement.sql
@@ -184,18 +184,21 @@ SELECT
     trader,
     operations,
     balances.amount_atoms/10^(balances.decimals) as amount,
-    token_symbol,
+    amount_atoms,
+    token_symbol,    
+    token,
+    decimals,
+    -- Balance: Available balance from user perspective (cannot be negative, and accounts for locked balance)
     CASE 
         WHEN balances.balance_atoms > 0 THEN balances.balance_atoms/10^(balances.decimals)
         ELSE 0
     END as balance,
+    -- Balance deposited: Balance in the contract (can be available or not)
     balances.balance_deposited_atoms/10^(balances.decimals) as balance_deposited,
-    token,
-    decimals,
-    amount_atoms,
-    balance_atoms,
-    amount_deposited_atoms,
-    balances.balance_atoms/10^(balances.decimals) as balance_actual
+    balances.balance_deposited_atoms,
+    -- Actual balance: Can be negative
+    balances.balance_atoms/10^(balances.decimals) as balance_actual,
+    balance_atoms as balance_actual_atoms
 FROM balances;
 
 

--- a/schema/gnosis_protocol/view_movement.sql
+++ b/schema/gnosis_protocol/view_movement.sql
@@ -130,7 +130,14 @@ operations AS (
     -- Special Case Withdraw:
     --      Handle a withdraw as a counter-movement of the request. 
     --      It can be seen as a counter movement of the difference between what was withdrawn and what was requested
-    UNION SELECT operation, batch_id, trader, token, amount, amount-pending_withdraw FROM actual_withdraws
+    UNION SELECT 
+        operation, 
+        batch_id, 
+        trader, 
+        token, 
+        amount as amount_deposited, -- Deduct the amount from the deposited amount
+        amount - pending_withdraw as amount -- Revert the discounted amount from the request, update with the actual
+    FROM actual_withdraws
 ),
 operation_details AS (
     SELECT
@@ -194,12 +201,12 @@ SELECT
         WHEN balances.balance_atoms > 0 THEN balances.balance_atoms/10^(balances.decimals)
         ELSE 0
     END as balance,
-    -- Balance deposited: Balance in the contract (can be available or not)
-    balances.balance_deposited_atoms/10^(balances.decimals) as balance_deposited,
-    balances.balance_deposited_atoms,
     -- Actual balance: Can be negative
     balances.balance_atoms/10^(balances.decimals) as balance_actual,
-    balance_atoms as balance_actual_atoms
+    balance_atoms as balance_actual_atoms,
+    -- Balance deposited: Balance in the contract (can be available or not)
+    balances.balance_deposited_atoms/10^(balances.decimals) as balance_deposited,
+    balances.balance_deposited_atoms    
 FROM balances;
 
 

--- a/schema/gnosis_protocol/view_movement.sql
+++ b/schema/gnosis_protocol/view_movement.sql
@@ -180,6 +180,7 @@ balances AS (
     ) b
 )
 SELECT
+    TO_TIMESTAMP((batch_id + 1) * 300) AS movement_date,
     batch_id,
     trader,
     operations,

--- a/schema/gnosis_protocol/view_movement.sql
+++ b/schema/gnosis_protocol/view_movement.sql
@@ -5,7 +5,7 @@ WITH
 deposits as (
     SELECT
         'deposit' as operation,
-        "batchId"as batch_id,
+        "batchId" as batch_id, 
         "user" AS trader,
         token,
         amount
@@ -17,11 +17,12 @@ withdraw_request AS (
         batch_id,
         trader,
         token,
-        amount
+        amount,
+        RANK() OVER (PARTITION BY trader, token ORDER BY batch_id) as rank
     FROM (
         SELECT
             'withdraw-request' as operation,
-            "batchId" as batch_id,
+            "batchId" as batch_id, 
             "user" as trader,
             token,
             -amount as amount,
@@ -33,6 +34,45 @@ withdraw_request AS (
         WHERE 
             "batchId" < (floor(extract(epoch from now()) / 300)::INTEGER) -- discard future withdrawals
     ) w WHERE withdraw_sub_id = 1
+),
+withdraw AS (
+    -- emited both, on a new request, or in an actual withdraw
+    SELECT
+        operation,
+        batch_id,
+        trader,
+        token,
+        SUM(amount) as amount, -- although it's strange, there could be multiple withdraws in a batch (with amount 0), we don't duplicated registries
+        RANK() OVER (PARTITION BY trader, token ORDER BY batch_id) as rank
+    FROM (
+        SELECT
+            'withdraw' as operation,
+            (floor(extract(epoch from evt_block_time) / 300)::INTEGER) as batch_id,
+            "user" as trader,
+            token,
+            -amount as amount
+        FROM gnosis_protocol."BatchExchange_evt_Withdraw" withdraw
+    ) w
+    GROUP BY
+        operation,
+        batch_id,
+        trader,
+        token
+),
+actual_withdraws as (
+    SELECT
+        withdraw.operation,
+        withdraw.batch_id,
+        withdraw.trader,
+        withdraw.token,
+        withdraw.amount,
+        withdraw_request.batch_id as batch_id_request,
+        withdraw_request.amount as pending_withdraw
+    FROM withdraw
+    JOIN withdraw_request
+        ON withdraw.trader = withdraw_request.trader
+        AND withdraw.token = withdraw_request.token
+        AND withdraw.rank = withdraw_request.rank
 ),
 sell AS (
     SELECT
@@ -56,7 +96,7 @@ buy AS (
 ),
 rewards as (
     SELECT
-        'solver reward' as operation,
+        'solver-reward' as operation,
         batch_id,
         submitter as trader,
         decode('1a5f9352af8af974bfc03399e3767df6370d82e4', 'hex') as token, -- OWL
@@ -77,11 +117,20 @@ rewards as (
     WHERE rank = 1
 ),
 operations AS (
-    SELECT * FROM deposits
-    UNION SELECT * FROM withdraw_request
-    UNION SELECT * FROM buy
-    UNION SELECT * FROM sell
-    UNION SELECT * FROM rewards
+    -- Amounts: 
+    --      amount_deposited: Takes only add operations, actual withdraws, and trades (but not the requests)
+    --      amount:           Amount considered for balance, can be negative, includes the "withdraw request" but not the actual withdraw
+    -- Basic Add operartions:
+    SELECT operation, batch_id, trader, token, amount as amount_deposited, amount as amount FROM deposits
+    UNION SELECT operation, batch_id, trader, token, amount, amount FROM buy
+    UNION SELECT operation, batch_id, trader, token, amount, amount FROM rewards
+    -- Basic Substract operation:
+    UNION SELECT operation, batch_id, trader, token, 0, amount FROM withdraw_request
+    UNION SELECT operation, batch_id, trader, token, amount, amount FROM sell
+    -- Special Case Withdraw:
+    --      Handle a withdraw as a counter-movement of the request. 
+    --      It can be seen as a counter movement of the difference between what was withdrawn and what was requested
+    UNION SELECT operation, batch_id, trader, token, amount, amount-pending_withdraw FROM actual_withdraws
 ),
 operation_details AS (
     SELECT
@@ -89,10 +138,11 @@ operation_details AS (
         operations.batch_id,
         operations.trader,
         operations.token,
+        operations.amount_deposited,
         operations.amount,
         token.token_id,
-        token.symbol as token_symbol,
-        token.decimals
+        COALESCE(token.symbol, 'TOKEN-' || token.token_id) as token_symbol,
+        COALESCE(token.decimals, 18) as decimals
     FROM operations
     JOIN gnosis_protocol."view_tokens" token
         ON token.token = operations.token
@@ -100,6 +150,11 @@ operation_details AS (
 balances AS (
     SELECT
         b.*,
+        SUM(amount_deposited_atoms) OVER (
+            PARTITION BY trader, token
+            ORDER BY batch_id
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) as balance_deposited_atoms,
         SUM(amount_atoms) OVER (
             PARTITION BY trader, token
             ORDER BY batch_id
@@ -110,6 +165,7 @@ balances AS (
             batch_id,
             trader,
             string_agg(operation, ', ') as operations,
+            SUM(amount_deposited) as amount_deposited_atoms,
             SUM(amount) as amount_atoms,
             token_symbol,
             token,
@@ -123,10 +179,23 @@ balances AS (
             decimals
     ) b
 )
-SELECT 
-    balances.*,
+SELECT
+    batch_id,
+    trader,
+    operations,
     balances.amount_atoms/10^(balances.decimals) as amount,
-    balances.balance_atoms/10^(balances.decimals) as balance
+    token_symbol,
+    CASE 
+        WHEN balances.balance_atoms > 0 THEN balances.balance_atoms/10^(balances.decimals)
+        ELSE 0
+    END as balance,
+    balances.balance_deposited_atoms/10^(balances.decimals) as balance_deposited,
+    token,
+    decimals,
+    amount_atoms,
+    balance_atoms,
+    amount_deposited_atoms,
+    balances.balance_atoms/10^(balances.decimals) as balance_actual
 FROM balances;
 
 

--- a/schema/gnosis_protocol/view_movement.sql
+++ b/schema/gnosis_protocol/view_movement.sql
@@ -5,7 +5,7 @@ WITH
 deposits as (
     SELECT
         'deposit' as operation,
-        "batchId" + 1 as batch_id, -- batch id when it's credited
+        "batchId"as batch_id,
         "user" AS trader,
         token,
         amount
@@ -21,7 +21,7 @@ withdraw_request AS (
     FROM (
         SELECT
             'withdraw-request' as operation,
-            "batchId" + 1 as batch_id, -- batch id when it's credited
+            "batchId" as batch_id,
             "user" as trader,
             token,
             -amount as amount,
@@ -37,7 +37,7 @@ withdraw_request AS (
 sell AS (
     SELECT
         'sell' as operation,
-        batch_id, -- sells are available right away
+        batch_id, 
         "trader_hex" as trader,
         sell_token as token,
         -sell_amount_atoms as amount
@@ -47,7 +47,7 @@ sell AS (
 buy AS (
     SELECT
         'buy' as operation,
-        batch_id, -- sells are available right away
+        batch_id,
         "trader_hex" as trader,
         buy_token as token,
         buy_amount_atoms as amount


### PR DESCRIPTION
This PR includes:
* Add Gnosis Protocol OWL rewards for solvers
* Handle edge cases for the withdraw of token
* Exposes the effective balance, the actual balance and the deposited balance, both in the `view_movement` table and the `view_deposit` one

Therefore, modifies 2 views:
* `view_movement`
* `view_deposit`

## More details

**Add Gnosis Protocol OWL rewards for solvers**
The table movements tracks the balance changes of the users for all the tokens.
When a solver submit a solution, he is rewarded with OWL token. 

**Handle edge cases for the withdraw of token**
Gnosis Protocol withdraws are complex because:
* Withdrawing tokens is a two steps process and requires to let the request to mature
* You can ask to withdraw more than what you have. You enter in a negative balance. You account for future trades.
* When you do a second withdraw, the contract first do the actual withdraw of any previous request
* You can request several withdraws in the same batch, only the last one is valid (they override within the same batch)

This PR makes sure the balances always reflect the actual state of the contract.

**Expose balances: Efective, Actual and Deposited**
The PR exposed several balances, so it can be seen for any moment in time:
- Your effective balance (no negative, it's the available balance an user would expect to see)
- Your actual balance: can be negative if you have a previous withdraw request higher than your balance
- Your deposited balance: The tokens you have in the contract, can be available or not