### PR TITLE
Remove UBOMB Uniswap wash trading

### DIFF
--- a/schema/dex/view_trades.sql
+++ b/schema/dex/view_trades.sql
@@ -98,6 +98,7 @@ FROM (
     FROM
         uniswap_v2."Pair_evt_Swap" t
     INNER JOIN uniswap_v2."Factory_evt_PairCreated" f ON f.pair = t.contract_address
+    WHERE t.contract_address != '\xed9c854cb02de75ce4c9bba992828d6cb7fd5c71' --Remove WETH-UBOMB wash trading pair
     
     UNION
 


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
