### PR TITLE
Add old BancorNetwork and BancorConverterRegistry

### DIFF
--- a/schema/bancornetwork/view_add_convertible_token.sql
+++ b/schema/bancornetwork/view_add_convertible_token.sql
@@ -1,4 +1,20 @@
 CREATE OR REPLACE VIEW bancornetwork.view_add_convertible_token AS
+WITH convertible_tokens AS (
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v3_evt_ConvertibleTokenAdded"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v4_evt_ConvertibleTokenAdded"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v5_evt_ConvertibleTokenAdded"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v6_evt_ConvertibleTokenAdded"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v7_evt_ConvertibleTokenAdded"
+)
 SELECT "_convertibleToken" AS convertible_token,
        symbol,
        decimals,
@@ -6,6 +22,6 @@ SELECT "_convertibleToken" AS convertible_token,
        s.contract_address,
        evt_tx_hash AS tx_hash,
        evt_block_time AS block_time
-FROM bancornetwork."ConverterRegistry_evt_ConvertibleTokenAdded" s
+FROM convertible_tokens s
 LEFT JOIN erc20.tokens t ON s."_convertibleToken" = t.contract_address
 ;

--- a/schema/bancornetwork/view_add_liquidity_pool.sql
+++ b/schema/bancornetwork/view_add_liquidity_pool.sql
@@ -1,4 +1,20 @@
 CREATE OR REPLACE VIEW bancornetwork.view_add_liquidity_pool AS
+WITH liquidity_pool_added AS (
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v3_evt_LiquidityPoolAdded"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v4_evt_LiquidityPoolAdded"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v5_evt_LiquidityPoolAdded"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v6_evt_LiquidityPoolAdded"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v7_evt_LiquidityPoolAdded"
+)
 SELECT r."exchange_token",
        r."exchange_token_symbol",
        r."exchange_token_decimals",
@@ -9,26 +25,26 @@ SELECT r."exchange_token",
        q.contract_address,
        q.evt_tx_hash AS tx_hash,
        q.evt_block_time AS block_time
-FROM bancornetwork."ConverterRegistry_evt_LiquidityPoolAdded" q
+FROM liquidity_pool_added q
 LEFT JOIN
-  (SELECT DISTINCT ON (s."_smartToken") s."_convertibleToken" AS "exchange_token",
+  (SELECT DISTINCT ON (s.smart_token) s.convertible_token AS "exchange_token",
                       t2.symbol AS "exchange_token_symbol",
                       t2.decimals AS "exchange_token_decimals",
-                      p."_convertibleToken" AS "base_token",
+                      p.convertible_token AS "base_token",
                       p.symbol AS "base_token_symbol",
                       p.decimals AS "base_token_decimals",
-                      s."_smartToken" AS smart_token
-   FROM bancornetwork."ConverterRegistry_evt_ConvertibleTokenAdded" s
+                      s.smart_token
+   FROM bancornetwork.view_add_convertible_token s
    INNER JOIN
      (SELECT *
-      FROM bancornetwork."ConverterRegistry_evt_ConvertibleTokenAdded"
-      LEFT JOIN erc20.tokens t1 ON "_convertibleToken" = t1.contract_address) p ON s."_smartToken" = p."_smartToken"
-   AND s."_convertibleToken" != p."_convertibleToken"
-   AND (s."_convertibleToken" NOT IN ('\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c',
+      FROM bancornetwork.view_add_convertible_token
+     ) p ON s.smart_token = p.smart_token
+   AND s.convertible_token != p.convertible_token
+   AND (s.convertible_token NOT IN ('\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c',
                                       '\x309627af60f0926daa6041b8279484312f2bf060')
-        OR (s."_convertibleToken" = '\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c'
-            AND p."_convertibleToken" = '\x309627af60f0926daa6041b8279484312f2bf060'))
-   LEFT JOIN erc20.tokens t2 ON s."_convertibleToken" = t2.contract_address) r ON q."_liquidityPool" = r.smart_token
+        OR (s.convertible_token = '\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c'
+            AND p.convertible_token = '\x309627af60f0926daa6041b8279484312f2bf060'))
+   LEFT JOIN erc20.tokens t2 ON s.convertible_token = t2.contract_address) r ON q."_liquidityPool" = r.smart_token
 ;
 
 -- use BNT and USDB as base token for convenience

--- a/schema/bancornetwork/view_add_smart_token.sql
+++ b/schema/bancornetwork/view_add_smart_token.sql
@@ -37,7 +37,7 @@ LEFT JOIN
    FROM bancornetwork.view_add_convertible_token s
    INNER JOIN
      (SELECT *
-      FROM bancornetwork."ConverterRegistry_evt_ConvertibleTokenAdded"
+      FROM bancornetwork.view_add_convertible_token
      ) p ON s.smart_token = p.smart_token
    AND s.convertible_token != p.convertible_token
    AND (s.convertible_token NOT IN ('\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c',

--- a/schema/bancornetwork/view_add_smart_token.sql
+++ b/schema/bancornetwork/view_add_smart_token.sql
@@ -1,4 +1,20 @@
 CREATE OR REPLACE VIEW bancornetwork.view_add_smart_token AS
+WITH smart_token_added AS (
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v3_evt_SmartTokenAdded"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v4_evt_SmartTokenAdded"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v5_evt_SmartTokenAdded"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v6_evt_SmartTokenAdded"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v7_evt_SmartTokenAdded"
+)
 SELECT r."exchange_token",
        r."exchange_token_symbol",
        r."exchange_token_decimals",
@@ -9,26 +25,26 @@ SELECT r."exchange_token",
        q.contract_address,
        q.evt_tx_hash AS tx_hash,
        q.evt_block_time AS block_time
-FROM bancornetwork."ConverterRegistry_evt_SmartTokenAdded" q
+FROM smart_token_added q
 LEFT JOIN
-  (SELECT DISTINCT ON (s."_smartToken") s."_convertibleToken" AS "exchange_token",
+  (SELECT DISTINCT ON (s.smart_token) s.convertible_token AS "exchange_token",
                       t2.symbol AS "exchange_token_symbol",
                       t2.decimals AS "exchange_token_decimals",
-                      p."_convertibleToken" AS "base_token",
+                      p.convertible_token AS "base_token",
                       p.symbol AS "base_token_symbol",
                       p.decimals AS "base_token_decimals",
-                      s."_smartToken" AS smart_token
-   FROM bancornetwork."ConverterRegistry_evt_ConvertibleTokenAdded" s
+                      s.smart_token
+   FROM bancornetwork.view_add_convertible_token s
    INNER JOIN
      (SELECT *
       FROM bancornetwork."ConverterRegistry_evt_ConvertibleTokenAdded"
-      LEFT JOIN erc20.tokens t1 ON "_convertibleToken" = t1.contract_address) p ON s."_smartToken" = p."_smartToken"
-   AND s."_convertibleToken" != p."_convertibleToken"
-   AND (s."_convertibleToken" NOT IN ('\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c',
+     ) p ON s.smart_token = p.smart_token
+   AND s.convertible_token != p.convertible_token
+   AND (s.convertible_token NOT IN ('\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c',
                                       '\x309627af60f0926daa6041b8279484312f2bf060')
-        OR (s."_convertibleToken" = '\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c'
-            AND p."_convertibleToken" = '\x309627af60f0926daa6041b8279484312f2bf060'))
-   LEFT JOIN erc20.tokens t2 ON s."_convertibleToken" = t2.contract_address) r ON q."_smartToken" = r.smart_token
+        OR (s.convertible_token = '\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c'
+            AND p.convertible_token = '\x309627af60f0926daa6041b8279484312f2bf060'))
+   LEFT JOIN erc20.tokens t2 ON s.convertible_token = t2.contract_address) r ON q."_smartToken" = r.smart_token
 ;
 
 -- use BNT and USDB as base token for convenience

--- a/schema/bancornetwork/view_convert.sql
+++ b/schema/bancornetwork/view_convert.sql
@@ -1,4 +1,20 @@
 CREATE OR REPLACE VIEW bancornetwork.view_convert AS
+WITH conversions AS (
+    SELECT *
+    FROM bancornetwork."BancorNetwork_v6_evt_Conversion"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorNetwork_v7_evt_Conversion"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorNetwork_v8_evt_Conversion"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorNetwork_v9_evt_Conversion"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorNetwork_v10_evt_Conversion"
+)
 SELECT "_smartToken" AS smart_token_address,
        "_fromToken" AS source_token_address,
        t1.symbol AS source_token_symbol,
@@ -13,7 +29,7 @@ SELECT "_smartToken" AS smart_token_address,
        evt_tx_hash AS tx_hash,
        evt_index,
        evt_block_time AS block_time
-FROM bancornetwork."BancorNetwork_evt_Conversion" s
+FROM conversions s
 LEFT JOIN erc20.tokens t1 ON s."_fromToken" = t1.contract_address
 LEFT JOIN erc20.tokens t2 ON s."_toToken" = t2.contract_address
 ;

--- a/schema/bancornetwork/view_remove_convertible_token.sql
+++ b/schema/bancornetwork/view_remove_convertible_token.sql
@@ -1,4 +1,20 @@
 CREATE OR REPLACE VIEW bancornetwork.view_remove_convertible_token AS
+WITH convertible_tokens AS (
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v3_evt_ConvertibleTokenRemoved"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v4_evt_ConvertibleTokenRemoved"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v5_evt_ConvertibleTokenRemoved"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v6_evt_ConvertibleTokenRemoved"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v7_evt_ConvertibleTokenRemoved"
+)
 SELECT "_convertibleToken" AS convertible_token,
        symbol,
        decimals,
@@ -6,6 +22,6 @@ SELECT "_convertibleToken" AS convertible_token,
        s.contract_address,
        evt_tx_hash AS tx_hash,
        evt_block_time AS block_time
-FROM bancornetwork."ConverterRegistry_evt_ConvertibleTokenRemoved" s
+FROM convertible_tokens s
 LEFT JOIN erc20.tokens t ON s."_convertibleToken" = t.contract_address
 ;

--- a/schema/bancornetwork/view_remove_liquidity_pool.sql
+++ b/schema/bancornetwork/view_remove_liquidity_pool.sql
@@ -1,4 +1,20 @@
 CREATE OR REPLACE VIEW bancornetwork.view_remove_liquidity_pool AS
+WITH liquidity_pool_removed AS (
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v3_evt_LiquidityPoolRemoved"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v4_evt_LiquidityPoolRemoved"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v5_evt_LiquidityPoolRemoved"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v6_evt_LiquidityPoolRemoved"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v7_evt_LiquidityPoolRemoved"
+)
 SELECT r."exchange_token",
        r."exchange_token_symbol",
        r."exchange_token_decimals",
@@ -9,26 +25,26 @@ SELECT r."exchange_token",
        q.contract_address,
        q.evt_tx_hash AS tx_hash,
        q.evt_block_time AS block_time
-FROM bancornetwork."ConverterRegistry_evt_LiquidityPoolRemoved" q
+FROM liquidity_pool_removed q
 LEFT JOIN
-  (SELECT DISTINCT ON (s."_smartToken") s."_convertibleToken" AS "exchange_token",
+  (SELECT DISTINCT ON (s.smart_token) s.convertible_token AS "exchange_token",
                       t2.symbol AS "exchange_token_symbol",
                       t2.decimals AS "exchange_token_decimals",
-                      p."_convertibleToken" AS "base_token",
+                      p.convertible_token AS "base_token",
                       p.symbol AS "base_token_symbol",
                       p.decimals AS "base_token_decimals",
-                      s."_smartToken" AS smart_token
-   FROM bancornetwork."ConverterRegistry_evt_ConvertibleTokenRemoved" s
+                      s.smart_token
+   FROM bancornetwork.view_remove_convertible_token s
    INNER JOIN
      (SELECT *
-      FROM bancornetwork."ConverterRegistry_evt_ConvertibleTokenRemoved"
-      LEFT JOIN erc20.tokens t1 ON "_convertibleToken" = t1.contract_address) p ON s."_smartToken" = p."_smartToken"
-   AND s."_convertibleToken" != p."_convertibleToken"
-   AND (s."_convertibleToken" NOT IN ('\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c',
+      FROM bancornetwork.view_remove_convertible_token
+     ) p ON s.smart_token = p.smart_token
+   AND s.convertible_token != p.convertible_token
+   AND (s.convertible_token NOT IN ('\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c',
                                       '\x309627af60f0926daa6041b8279484312f2bf060')
-        OR (s."_convertibleToken" = '\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c'
-            AND p."_convertibleToken" = '\x309627af60f0926daa6041b8279484312f2bf060'))
-   LEFT JOIN erc20.tokens t2 ON s."_convertibleToken" = t2.contract_address) r ON q."_liquidityPool" = r.smart_token
+        OR (s.convertible_token = '\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c'
+            AND p.convertible_token = '\x309627af60f0926daa6041b8279484312f2bf060'))
+   LEFT JOIN erc20.tokens t2 ON s.convertible_token = t2.contract_address) r ON q."_liquidityPool" = r.smart_token
 ;
 
 -- use BNT and USDB as base token for convenience

--- a/schema/bancornetwork/view_remove_smart_token.sql
+++ b/schema/bancornetwork/view_remove_smart_token.sql
@@ -1,4 +1,20 @@
 CREATE OR REPLACE VIEW bancornetwork.view_add_smart_token AS
+WITH smart_token_removed AS (
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v3_evt_SmartTokenRemoved"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v4_evt_SmartTokenRemoved"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v5_evt_SmartTokenRemoved"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v6_evt_SmartTokenRemoved"
+    UNION ALL
+    SELECT *
+    FROM bancornetwork."BancorConverterRegistry_v7_evt_SmartTokenRemoved"
+)
 SELECT r."exchange_token",
        r."exchange_token_symbol",
        r."exchange_token_decimals",
@@ -9,26 +25,26 @@ SELECT r."exchange_token",
        q.contract_address,
        q.evt_tx_hash AS tx_hash,
        q.evt_block_time AS block_time
-FROM bancornetwork."ConverterRegistry_evt_SmartTokenRemoved" q
+FROM smart_token_removed q
 LEFT JOIN
-  (SELECT DISTINCT ON (s."_smartToken") s."_convertibleToken" AS "exchange_token",
+  (SELECT DISTINCT ON (s.smart_token) s.convertible_token AS "exchange_token",
                       t2.symbol AS "exchange_token_symbol",
                       t2.decimals AS "exchange_token_decimals",
-                      p."_convertibleToken" AS "base_token",
+                      p.convertible_token AS "base_token",
                       p.symbol AS "base_token_symbol",
                       p.decimals AS "base_token_decimals",
-                      s."_smartToken" AS smart_token
-   FROM bancornetwork."ConverterRegistry_evt_ConvertibleTokenRemoved" s
+                      s.smart_token
+   FROM bancornetwork.view_remove_convertible_token s
    INNER JOIN
      (SELECT *
-      FROM bancornetwork."ConverterRegistry_evt_ConvertibleTokenRemoved"
-      LEFT JOIN erc20.tokens t1 ON "_convertibleToken" = t1.contract_address) p ON s."_smartToken" = p."_smartToken"
-   AND s."_convertibleToken" != p."_convertibleToken"
-   AND (s."_convertibleToken" NOT IN ('\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c',
+      FROM bancornetwork.view_remove_convertible_token
+     ) p ON s.smart_token = p.smart_token
+   AND s.convertible_token != p.convertible_token
+   AND (s.convertible_token NOT IN ('\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c',
                                       '\x309627af60f0926daa6041b8279484312f2bf060')
-        OR (s."_convertibleToken" = '\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c'
-            AND p."_convertibleToken" = '\x309627af60f0926daa6041b8279484312f2bf060'))
-   LEFT JOIN erc20.tokens t2 ON s."_convertibleToken" = t2.contract_address) r ON q."_smartToken" = r.smart_token
+        OR (s.convertible_token = '\x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c'
+            AND p.convertible_token = '\x309627af60f0926daa6041b8279484312f2bf060'))
+   LEFT JOIN erc20.tokens t2 ON s.convertible_token = t2.contract_address) r ON q."_smartToken" = r.smart_token
 ;
 
 -- use BNT and USDB as base token for convenience


### PR DESCRIPTION
Add old versions of Bancor contracts. Extends tracked history to Jan, 2020.

---
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
