### PR TITLE
Add BTC price to 1split and 1inch

### DIFF
--- a/schema/oneinch/view_swaps.sql
+++ b/schema/oneinch/view_swaps.sql
@@ -48,7 +48,8 @@ CREATE MATERIALIZED VIEW oneinch.view_swaps AS SELECT * FROM (
                     '\x0000000000085d4780B73119b644AE5ecd22b376', -- TUSD
                     '\x309627af60f0926daa6041b8279484312f2bf060', -- USDB
                     '\x8E870D67F660D95d5be530380D0eC0bd388289E1', -- PAX
-                    '\x57ab1e02fee23774580c119740129eac7081e9d3'  -- sUSD
+                    '\x57ab1e02fee23774580c119740129eac7081e9d3', -- sUSD 1
+                    '\x57Ab1ec28D129707052df4dF418D58a2D46d5f51'  -- sUSD 2
                 ) THEN (1/1e18)
                 ELSE (
                     SELECT p.price
@@ -97,7 +98,8 @@ CREATE MATERIALIZED VIEW oneinch.view_swaps AS SELECT * FROM (
                     '\x0000000000085d4780B73119b644AE5ecd22b376', -- TUSD
                     '\x309627af60f0926daa6041b8279484312f2bf060', -- USDB
                     '\x8E870D67F660D95d5be530380D0eC0bd388289E1', -- PAX
-                    '\x57ab1e02fee23774580c119740129eac7081e9d3'  -- sUSD
+                    '\x57ab1e02fee23774580c119740129eac7081e9d3', -- sUSD 1
+                    '\x57Ab1ec28D129707052df4dF418D58a2D46d5f51'  -- sUSD 2
                 ) THEN (1/1e18)
                 ELSE (
                     SELECT p.price

--- a/schema/oneinch/view_swaps.sql
+++ b/schema/oneinch/view_swaps.sql
@@ -27,6 +27,18 @@ CREATE MATERIALIZED VIEW oneinch.view_swaps AS SELECT * FROM (
                     LIMIT 1
                 )
                 WHEN from_token IN (
+                    '\xeb4c2781e4eba804ce9a9803c67d0893436bb27d', -- renBTC
+                    '\x2260fac5e5542a773aa44fbcfedf7c193bc2c599', -- WBTC
+                    '\xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'  -- sBTC
+                ) THEN (
+                    SELECT p.price/1e18
+                    FROM prices."usd" p
+                    WHERE p.contract_address is NULL
+                    ANd p.symbol = 'BTC'
+                    AND p.minute = date_trunc('minute', block_time)
+                    LIMIT 1
+                )
+                WHEN from_token IN (
                     '\xdac17f958d2ee523a2206206994597c13d831ec7', -- USDT (6)
                     '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'  -- USDC (6)
                 ) THEN (1/1e6)
@@ -61,6 +73,18 @@ CREATE MATERIALIZED VIEW oneinch.view_swaps AS SELECT * FROM (
                     WHERE p.contract_address is NULL
                     ANd p.symbol = 'ETH'
                     AND p.minute = date_trunc('minute', tmp.block_time)
+                    LIMIT 1
+                )
+                WHEN from_token IN (
+                    '\xeb4c2781e4eba804ce9a9803c67d0893436bb27d', -- renBTC
+                    '\x2260fac5e5542a773aa44fbcfedf7c193bc2c599', -- WBTC
+                    '\xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'  -- sBTC
+                ) THEN (
+                    SELECT p.price/1e18
+                    FROM prices."usd" p
+                    WHERE p.contract_address is NULL
+                    ANd p.symbol = 'BTC'
+                    AND p.minute = date_trunc('minute', block_time)
                     LIMIT 1
                 )
                 WHEN to_token IN (

--- a/schema/onesplit/view_swaps.sql
+++ b/schema/onesplit/view_swaps.sql
@@ -28,6 +28,18 @@ SELECT * FROM (
                     LIMIT 1
                 )
                 WHEN from_token IN (
+                    '\xeb4c2781e4eba804ce9a9803c67d0893436bb27d', -- renBTC
+                    '\x2260fac5e5542a773aa44fbcfedf7c193bc2c599', -- WBTC
+                    '\xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'  -- sBTC
+                ) THEN (
+                    SELECT p.price/1e18
+                    FROM prices."usd" p
+                    WHERE p.contract_address is NULL
+                    ANd p.symbol = 'BTC'
+                    AND p.minute = date_trunc('minute', block_time)
+                    LIMIT 1
+                )
+                WHEN from_token IN (
                     '\xdac17f958d2ee523a2206206994597c13d831ec7', -- USDT (6)
                     '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'  -- USDC (6)
                 ) THEN (1/1e6)
@@ -62,6 +74,18 @@ SELECT * FROM (
                     WHERE p.contract_address is NULL
                     ANd p.symbol = 'ETH'
                     AND p.minute = date_trunc('minute', tmp.block_time)
+                    LIMIT 1
+                )
+                WHEN from_token IN (
+                    '\xeb4c2781e4eba804ce9a9803c67d0893436bb27d', -- renBTC
+                    '\x2260fac5e5542a773aa44fbcfedf7c193bc2c599', -- WBTC
+                    '\xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'  -- sBTC
+                ) THEN (
+                    SELECT p.price/1e18
+                    FROM prices."usd" p
+                    WHERE p.contract_address is NULL
+                    ANd p.symbol = 'BTC'
+                    AND p.minute = date_trunc('minute', block_time)
                     LIMIT 1
                 )
                 WHEN to_token IN (

--- a/schema/onesplit/view_swaps.sql
+++ b/schema/onesplit/view_swaps.sql
@@ -49,7 +49,8 @@ SELECT * FROM (
                     '\x0000000000085d4780B73119b644AE5ecd22b376', -- TUSD
                     '\x309627af60f0926daa6041b8279484312f2bf060', -- USDB
                     '\x8E870D67F660D95d5be530380D0eC0bd388289E1', -- PAX
-                    '\x57ab1e02fee23774580c119740129eac7081e9d3'  -- sUSD
+                    '\x57ab1e02fee23774580c119740129eac7081e9d3', -- sUSD 1
+                    '\x57Ab1ec28D129707052df4dF418D58a2D46d5f51'  -- sUSD 2
                 ) THEN (1/1e18)
                 ELSE (
                     SELECT p.price
@@ -98,7 +99,8 @@ SELECT * FROM (
                     '\x0000000000085d4780B73119b644AE5ecd22b376', -- TUSD
                     '\x309627af60f0926daa6041b8279484312f2bf060', -- USDB
                     '\x8E870D67F660D95d5be530380D0eC0bd388289E1', -- PAX
-                    '\x57ab1e02fee23774580c119740129eac7081e9d3'  -- sUSD
+                    '\x57ab1e02fee23774580c119740129eac7081e9d3', -- sUSD 1
+                    '\x57Ab1ec28D129707052df4dF418D58a2D46d5f51'  -- sUSD 2
                 ) THEN (1/1e18)
                 ELSE (
                     SELECT p.price


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
