### PR TITLE
Fix faulty join

### DIFF
--- a/schema/compound/view_liquidate_borrow.sql
+++ b/schema/compound/view_liquidate_borrow.sql
@@ -78,5 +78,5 @@ LEFT JOIN compound.view_ctokens c ON events."cTokenCollateral" = c.contract_addr
 LEFT JOIN compound.view_ctokens c_repay ON repay.contract_address = c_repay.contract_address
 LEFT JOIN erc20.tokens t ON c_repay.underlying_token_address = t.contract_address
 LEFT JOIN prices.usd p ON p.minute = date_trunc('minute', events.evt_block_time)
-           AND p.contract_address = c.underlying_token_address
+AND p.contract_address = c_repay.underlying_token_address
 ;


### PR DESCRIPTION
USD prices is now joined with repay token as it should be to get repay usd value.

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
