### PR TITLE
Fix issue calculating the price when there's no price reference

### DIFF
--- a/schema/gnosis_protocol/view_price_batch.sql
+++ b/schema/gnosis_protocol/view_price_batch.sql
@@ -171,12 +171,12 @@ SELECT
   prices_in_usd.token_owl_price,
   COALESCE(
     best_owl_price.owl_usd_price,
-    prices_in_usd.token_owl_price * 0.8
+    0.95
   ) AS owl_usd_price,
   prices_in_usd.token_usd_price AS token_usd_price_external,
   prices_in_usd.token_owl_price * COALESCE(
     best_owl_price.owl_usd_price,
-    prices_in_usd.token_owl_price * 0.8
+    0.95
   ) AS token_usd_price
 FROM prices_in_usd
 LEFT OUTER JOIN best_owl_price ON best_owl_price.batch_id = prices_in_usd.batch_id


### PR DESCRIPTION
Corrects an error in the price calculation for the case when there's no external price reference.
For that it uses the OWL price submitted by the solver, and assumes every OWL is worth 0.8$

This PR fixes an issue where it was multiplying the price 2 times for this case, making prices to be very off.
Also, it changes the OWL estimation to 0.95 since now it trades almost 1:1

Example of one case:
![image](https://user-images.githubusercontent.com/2352112/88951345-21aaf200-d296-11ea-84d0-ccd90f5e3c54.png)

 Correction:
![image](https://user-images.githubusercontent.com/2352112/88951412-38514900-d296-11ea-9136-9ff65434c72f.png)

cc/ @fleupold