### PR TITLE
Added `tx_to` to onesplit and oneinch view_swaps

### DIFF
--- a/schema/oneinch/view_swaps.sql
+++ b/schema/oneinch/view_swaps.sql
@@ -3,6 +3,7 @@ DROP MATERIALIZED VIEW IF EXISTS oneinch.view_swaps;
 CREATE MATERIALIZED VIEW oneinch.view_swaps AS SELECT * FROM (
     SELECT
         tx."from" as tx_from,
+        tx."to" as tx_to,
         from_token,
         to_token,
         from_amount,

--- a/schema/onesplit/view_swaps.sql
+++ b/schema/onesplit/view_swaps.sql
@@ -4,6 +4,7 @@ CREATE MATERIALIZED VIEW onesplit.view_swaps AS
 SELECT * FROM (
     SELECT
         tx."from" as tx_from,
+        tx."to" as tx_to,
         from_token,
         to_token,
         from_amount,


### PR DESCRIPTION
I've checked that:

* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] the query produces the intended results
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
