### PR TITLE
Fix issue with price estimation

### DIFF
--- a/schema/gnosis_protocol/view_price_batch.sql
+++ b/schema/gnosis_protocol/view_price_batch.sql
@@ -76,7 +76,7 @@ prices_in_owl AS (
     tokens.symbol,
     tokens.decimals,
     -- price in OWL
-    solution.token_owl_price / 10 ^(36 - tokens.decimals) AS token_owl_price
+    solution.token_owl_price / 10 ^(36 - COALESCE(tokens.decimals, 18)) AS token_owl_price
   FROM (
   	SELECT * FROM solution 
   	UNION


### PR DESCRIPTION
The VIEW `view_price_batch` has an issue estimating the USD price for tokens that are not in `erc20.tokens` table

For example, in this batch, since XSTAR token was not added, then it was not showing the estimation:
![image](https://user-images.githubusercontent.com/2352112/92621070-a9d3dc80-f2c3-11ea-8d1f-993be7d8bf47.png)


This PR adds 18 as a default for the calculation.