### PR TITLE
fixed usd conversion for v2 fills

### DIFF
--- a/schema/zeroex/view_fills.sql
+++ b/schema/zeroex/view_fills.sql
@@ -79,7 +79,7 @@ WITH
                     WHEN mp.symbol = 'DAI' THEN (fills."makerAssetFilledAmount" / 1e18) * mp.price
                     WHEN tp.symbol = 'WETH' THEN (fills."takerAssetFilledAmount" / 1e18) * tp.price
                     WHEN mp.symbol = 'WETH' THEN (fills."makerAssetFilledAmount" / 1e18) * mp.price
-                    ELSE COALESCE((fills."makerAssetFilledAmount" / 1e18)*mp.price,(fills."takerAssetFilledAmount" / 1e18)*tp.price)
+                    ELSE COALESCE((fills."makerAssetFilledAmount" / (10^mt.decimals))*mp.price,(fills."takerAssetFilledAmount" / (10^tt.decimals))*tp.price)
                 END AS volume_usd
             , NULL::NUMERIC AS protocol_fee_paid_eth
         FROM zeroex_v2."Exchange2.1_evt_Fill" fills


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
