### PR TITLE
Add SKL to prices.ini

### DIFF
--- a/prices/prices.ini
+++ b/prices/prices.ini
@@ -1225,6 +1225,12 @@ symbol = ORBS
 address = 0xff56cc6b1e6ded347aa0b7676c85ab0b3d08b0fa
 decimals = 18
 
+[assets.skl-skale]
+id = skl-skale
+symbol = SKL
+address = 0x00c83aecc790e8a4453e5dd3b0b4b3680501a7a7
+decimals = 18
+
 [assets.ada_cardano]
 id = ada-cardano
 symbol = ADA


### PR DESCRIPTION
Adds prices to Dune for SKL using [CoinPaprika](https://coinpaprika.com/coin/skl-skale/)

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
