### PR TITLE
Remove useless price join

### DIFF
--- a/schema/stablecoin/burn.sql
+++ b/schema/stablecoin/burn.sql
@@ -74,11 +74,8 @@ WITH burn AS (
     ) burns
     INNER JOIN erc20.stablecoins st 
         ON st.contract_address = burns.contract_address
-    LEFT JOIN prices.usd p 
-        ON p.minute = date_trunc('minute', burns.evt_block_time)
-        AND p.contract_address = burns.contract_address
-        AND p.minute >= start_ts 
-        AND p.minute < end_ts
+    WHERE burns.evt_block_time >= start_ts
+        AND burns.evt_block_time < end_ts
 ),
 rows AS (
     INSERT INTO stablecoin.burn (

--- a/schema/stablecoin/mint.sql
+++ b/schema/stablecoin/mint.sql
@@ -75,11 +75,8 @@ WITH mint AS (
     ) mints
     INNER JOIN erc20.stablecoins st 
         ON st.contract_address = mints.contract_address
-    LEFT JOIN prices.usd p 
-        ON p.minute = date_trunc('minute', mints.evt_block_time) 
-        AND p.contract_address = mints.contract_address 
-        AND p.minute >= start_ts 
-        AND p.minute < end_ts
+    WHERE mints.evt_block_time >= start_ts
+        AND mints.evt_block_time < end_ts
 ),
 rows AS (
     INSERT INTO stablecoin.mint (


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
