### PR TITLE
Introduce tx_from indexes for 1inch/1split/1proto

### DIFF
--- a/schema/oneinch/swaps.sql
+++ b/schema/oneinch/swaps.sql
@@ -200,7 +200,7 @@ $function$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS oneinch_sswaps_unique_trace_address_idx ON oneinch.swaps (tx_hash, trace_address);
 CREATE UNIQUE INDEX IF NOT EXISTS oneinch_sswaps_unique_evt_index_idx ON oneinch.swaps (tx_hash, evt_index);
-CREATE INDEX IF NOT EXISTS oneinch_swaps_idx ON oneinch.swaps USING BRIN (block_time);
+CREATE INDEX IF NOT EXISTS oneinch_swaps_idx ON oneinch.swaps USING BRIN (block_time, tx_from);
 CREATE INDEX IF NOT EXISTS oneinch_swaps_idx_tx_from ON oneinch.swaps USING BRIN (tx_from);
 
 -- backfill

--- a/schema/oneinch/swaps.sql
+++ b/schema/oneinch/swaps.sql
@@ -201,6 +201,7 @@ $function$;
 CREATE UNIQUE INDEX IF NOT EXISTS oneinch_sswaps_unique_trace_address_idx ON oneinch.swaps (tx_hash, trace_address);
 CREATE UNIQUE INDEX IF NOT EXISTS oneinch_sswaps_unique_evt_index_idx ON oneinch.swaps (tx_hash, evt_index);
 CREATE INDEX IF NOT EXISTS oneinch_swaps_idx ON oneinch.swaps USING BRIN (block_time);
+CREATE INDEX IF NOT EXISTS oneinch_swaps_idx_tx_from ON oneinch.swaps USING BRIN (tx_from);
 
 -- backfill
 SELECT oneinch.insert_swap('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), (SELECT MAX(number) FROM ethereum.blocks)) WHERE NOT EXISTS (SELECT * FROM oneinch.swaps LIMIT 1);

--- a/schema/oneproto/swaps.sql
+++ b/schema/oneproto/swaps.sql
@@ -195,7 +195,7 @@ END
 $function$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS oneproto_swaps_unique_idx_1 ON oneproto.swaps (tx_hash, evt_index);
-CREATE INDEX IF NOT EXISTS oneproto_swaps_idx_1 ON oneproto.swaps USING BRIN (block_time);
+CREATE INDEX IF NOT EXISTS oneproto_swaps_idx_1 ON oneproto.swaps USING BRIN (block_time, tx_from);
 CREATE INDEX IF NOT EXISTS oneproto_swaps_idx_tx_from ON oneproto.swaps USING BRIN (tx_from);
 
 -- backfill

--- a/schema/oneproto/swaps.sql
+++ b/schema/oneproto/swaps.sql
@@ -196,6 +196,7 @@ $function$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS oneproto_swaps_unique_idx_1 ON oneproto.swaps (tx_hash, evt_index);
 CREATE INDEX IF NOT EXISTS oneproto_swaps_idx_1 ON oneproto.swaps USING BRIN (block_time);
+CREATE INDEX IF NOT EXISTS oneproto_swaps_idx_tx_from ON oneproto.swaps USING BRIN (tx_from);
 
 -- backfill
 SELECT oneproto.insert_swap('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), (SELECT MAX(number) FROM ethereum.blocks)) WHERE NOT EXISTS (SELECT * FROM oneproto.swaps LIMIT 1);

--- a/schema/onesplit/swaps.sql
+++ b/schema/onesplit/swaps.sql
@@ -208,6 +208,7 @@ $function$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS oonesplit_swaps_unique_idx ON onesplit.swaps (tx_hash, trace_address);
 CREATE INDEX IF NOT EXISTS onesplit_swaps_idx ON onesplit.swaps USING BRIN (block_time);
+CREATE INDEX IF NOT EXISTS onesplit_swaps_idx_tx_from ON onesplit.swaps USING BRIN (tx_from);
 
 --backfill
 SELECT onesplit.insert_swap('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), (SELECT MAX(number) FROM ethereum.blocks)) WHERE NOT EXISTS (SELECT * FROM onesplit.swaps LIMIT 1);

--- a/schema/onesplit/swaps.sql
+++ b/schema/onesplit/swaps.sql
@@ -207,7 +207,7 @@ END
 $function$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS oonesplit_swaps_unique_idx ON onesplit.swaps (tx_hash, trace_address);
-CREATE INDEX IF NOT EXISTS onesplit_swaps_idx ON onesplit.swaps USING BRIN (block_time);
+CREATE INDEX IF NOT EXISTS onesplit_swaps_idx ON onesplit.swaps USING BRIN (block_time, tx_from);
 CREATE INDEX IF NOT EXISTS onesplit_swaps_idx_tx_from ON onesplit.swaps USING BRIN (tx_from);
 
 --backfill


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
