### PR TITLE
Update async_art_v2_token_mapping.sql

### DIFF
--- a/schema/async_art_v2/async_art_v2_token_mapping.sql
+++ b/schema/async_art_v2/async_art_v2_token_mapping.sql
@@ -99,7 +99,7 @@ order by 1 asc
       custom_id:= CONCAT(r.token_id, '_', c);
     end if;
 
-    if r.token_type = 'controltoken' then 
+    if r.token_type = 'layer' then 
       c := c + 1;
       custom_id:= CONCAT(r.token_id, '_', c);
     end if;


### PR DESCRIPTION
fixing wrong variable

I've checked that:

* [X] the query produces the intended results
* [X] the folder name matches the schema name
* [X] the schema name exists in Dune
* [X] views are prefixed with `view_`, functions with `fn_`.
* [X ] the filename matches the defined view, table or function and ends with .sql
* [X ] each file has only one view, table or function defined  
* [X ] column names are `lowercase_snake_cased`
