### PR TITLE
add numeric2bytea and bytea2numeric

### DIFF
--- a/schema/public/bytea2numeric.sql
+++ b/schema/public/bytea2numeric.sql
@@ -1,0 +1,6 @@
+DROP FUNCTION bytea2numeric(bytea, boolean, text);
+CREATE FUNCTION bytea2numeric(a bytea, signed boolean = true, byteorder text = 'big')
+    RETURNS numeric
+AS $$
+    return int.from_bytes(a, byteorder=byteorder, signed=signed)
+$$ LANGUAGE plpython3u IMMUTABLE STRICT;

--- a/schema/public/numeric2bytea.sql
+++ b/schema/public/numeric2bytea.sql
@@ -1,0 +1,6 @@
+DROP FUNCTION numeric2bytea(numeric, integer, boolean, text);
+CREATE FUNCTION numeric2bytea (a numeric, _length integer = 32, signed boolean = true, byteorder text = 'big')
+  RETURNS bytea
+AS $$
+    return int(a).to_bytes(_length, byteorder=byteorder, signed=signed)
+$$ LANGUAGE plpython3u IMMUTABLE STRICT;


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
