### PR TITLE
fix Balancer trader_a

### DIFF
--- a/ethereum/dex/trades.sql
+++ b/ethereum/dex/trades.sql
@@ -657,7 +657,7 @@ WITH rows AS (
             'Balancer' AS project,
             '1' AS version,
             'DEX' AS category,
-            t.caller AS trader_a,
+            NULL::bytea AS trader_a, -- this relies on the outer query coalescing to tx."from"
             NULL::bytea AS trader_b,
             t."tokenAmountOut" AS token_a_amount_raw,
             t."tokenAmountIn" AS token_b_amount_raw,

--- a/ethereum/dex/trades.sql
+++ b/ethereum/dex/trades.sql
@@ -59,7 +59,7 @@ WITH rows AS (
         project,
         version,
         category,
-        coalesce(trader_a, tx."from") as trader_a,
+        coalesce(trader_a, tx."from") as trader_a, -- subqueries rely on this COALESCE to avoid redundant joins with the transactions table
         trader_b,
         token_a_amount_raw,
         token_b_amount_raw,


### PR DESCRIPTION
For consistency with other DEXs - caller is most often an intermediate smart contract, not the actual trader

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
