### PR TITLE
dex.trades: fix dYdX WETH-PUSD Perpetual

### DIFF
--- a/ethereum/dex/trades.sql
+++ b/ethereum/dex/trades.sql
@@ -434,7 +434,10 @@ WITH rows AS (
             taker AS trader_b,
             "positionAmount" AS token_a_amount_raw,
             "marginAmount" AS token_b_amount_raw,
-            NULL::numeric AS usd_amount,
+            CASE
+                WHEN contract_address = '\x09403FD14510F8196F7879eF514827CD76960B5d' THEN "positionAmount"/1e6
+                ELSE NULL::numeric
+            END AS usd_amount,
             CASE
                 WHEN contract_address = '\x1c50c582c7066049C560Bca20416b1d9E0dfb003' THEN '\x514910771af9ca656af840dff83e8264ecf986ca'::bytea
                 WHEN contract_address = '\x07aBe965500A49370D331eCD613c7AC47dD6e547' THEN '\x2260fac5e5542a773aa44fbcfedf7c193bc2c599'::bytea


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
