### PR TITLE
xdai.gnosis_protocol: add price views

### DIFF
--- a/xdai/gnosis_protocol/view_price_batch.sql
+++ b/xdai/gnosis_protocol/view_price_batch.sql
@@ -1,0 +1,194 @@
+BEGIN;
+DROP MATERIALIZED VIEW gnosis_protocol.view_price_batch;
+CREATE MATERIALIZED VIEW gnosis_protocol.view_price_batch AS
+WITH token_priorities AS (
+  SELECT * FROM (VALUES
+        (100, 7), -- DAI
+        (99, 2),  -- USDT
+        (98, 4),  -- USDC
+        (97, 3),  -- TUSD
+        (96, 5),  -- PAX
+        (95, 13), -- cDAI
+        (94, 15), -- SNX
+        (93, 17), -- PAXG
+        (92, 9),  -- sUSD
+        (91, 6),  -- GUSD
+        (90, 16), -- CHAI
+        (89, 1),  -- WETH
+        (88, 8),  -- sETH
+        (87, 11), -- sETH
+        (86, 10), -- sBTC
+        (85, 49), -- sEUR
+        (84, 18)  -- GNO
+    ) AS t (priority, token_id)
+    -- ALL TOKENS: 	SELECT token_id, symbol FROM gnosis_protocol.view_tokens
+),
+solution AS (
+  SELECT
+  	batch_id,
+  	evt_block_time,
+  	evt_index,
+  	token_id,
+  	token_owl_price,
+  	evt_block_number,
+  	evt_tx_hash
+  FROM (
+  	SELECT
+	  	FLOOR(EXTRACT(epoch FROM evt_block_time) / 300) - 1 AS batch_id,
+	    -- The event time tells us the batch. Between minute 0-4 is resolved batch N-1
+	    evt_block_time,
+	    evt_index,
+	    UNNEST(solution."tokenIdsForPrice") AS token_id,
+	    UNNEST(solution.prices) AS token_owl_price,
+	    evt_block_number,
+	    evt_tx_hash,
+	    RANK() OVER (
+	      PARTITION BY FLOOR(EXTRACT(epoch FROM evt_block_time) / 300)
+	      ORDER BY evt_block_time DESC, evt_index DESC
+	    ) AS solution_rank
+	  FROM gnosis_protocol. "BatchExchange_evt_SolutionSubmission" solution
+  ) AS unique_solutions
+  WHERE solution_rank = 1
+),
+solution_owl AS (
+	SELECT DISTINCT
+		batch_id,
+		evt_block_time,
+		evt_index,
+		0::NUMERIC AS token_id,
+		1000000000000000000::NUMERIC AS token_owl_price,
+		evt_block_number,
+		evt_tx_hash
+	FROM solution
+),
+prices_in_owl AS (
+  SELECT
+    -- id
+    solution.batch_id,
+    solution.evt_index,
+    tokens.token_id,
+    -- tx/block
+    solution.evt_block_number AS block_number,
+    solution.evt_block_time AS block_time,
+    solution.evt_tx_hash AS tx_hash,
+    -- token
+    tokens.token,
+    tokens.symbol,
+    tokens.decimals,
+    -- price in OWL
+    solution.token_owl_price / 10 ^(36 - COALESCE(tokens.decimals, 18)) AS token_owl_price
+  FROM (
+  	SELECT * FROM solution 
+  	UNION
+  	SELECT * FROM solution_owl
+  ) AS solution
+  JOIN gnosis_protocol.view_tokens tokens ON solution.token_id = tokens.token_id
+),
+prices_in_usd AS (
+  SELECT
+    -- id
+    batch_id,
+    evt_index,
+    token_id,
+    -- prices
+    token_owl_price,
+    -- price of the token in USD
+    usd_price.price AS token_usd_price,
+    -- price of OWL in USD (by comparing the OWL price of the batch, with the actual price of this token)
+    usd_price.price / token_owl_price AS owl_usd_price,
+    -- tx/block
+    block_number,
+    block_time,
+    tx_hash,
+    -- token
+    prices_in_owl.token,
+    prices_in_owl.symbol,
+    prices_in_owl.decimals
+  FROM prices_in_owl
+  LEFT OUTER JOIN prices.usd usd_price ON usd_price.contract_address = token
+    AND usd_price.minute = DATE_TRUNC('minute', block_time) -- TODO: It can be slighly improved if we use the time of the "official" trade (end of the batch) instead of submission, but also more costly query
+),
+best_owl_price AS (
+  SELECT
+    batch_id,
+    evt_index,
+    owl_usd_price
+  FROM (
+      SELECT
+        prices_in_usd.batch_id,
+        prices_in_usd.evt_index,
+        prices_in_usd.owl_usd_price,
+        RANK() OVER (
+          PARTITION BY batch_id,
+          evt_index
+          ORDER BY
+            COALESCE(priority, 0) DESC
+        ) AS price_rank
+      FROM prices_in_usd
+      LEFT OUTER JOIN token_priorities ON prices_in_usd.token_id = token_priorities.token_id
+      WHERE token_usd_price IS NOT NULL
+    ) AS ranked_owl_prices
+  WHERE
+    price_rank = 1
+)
+SELECT
+  -- id
+  prices_in_usd.batch_id,
+  prices_in_usd.evt_index,
+  prices_in_usd.token_id,
+  -- price date
+  TO_TIMESTAMP((prices_in_usd.batch_id + 1) * 300) AS price_date,
+  -- Block / tx
+  prices_in_usd.block_number AS block_number_solution,
+  prices_in_usd.block_time AS block_time_solution,
+  prices_in_usd.tx_hash AS tx_hash_solution,
+  -- Token
+  prices_in_usd.token,
+  prices_in_usd.symbol,
+  prices_in_usd.decimals,
+  --  ---------------------------------
+  --	Prices
+  --- ---------------------------------
+  --		"token_owl_price": TOKEN-OWL
+  --				* Internal price of the token in OWL, ditacted by the solver
+  --				* i.e Solver finds a solution saying WETH price is 210 OWL
+  --		"owl_usd_price": OWL-USD
+  --				* Best estimation price for OWL
+  --				* Considers the external prices for all tokens to calculate the OWL-USD according to that token
+  --				* For the tokens that the external price is known, selects the best price according to a defined token priority
+  --				* As a fallback, if no token has an estimation, we assume the OWL cost a constant value --> 0.8$
+  --				* i.e. OWL price according to DAI external source is 0.8$, according to WETH is 0.75$, then since DAI has more priority, we select 0.8$ as the price of OWL
+  --		"token_usd_price_external":	TOKEN-USD
+  --				* External price of the token in USD
+  --				* It can be NULL, meaning, there's no price at that time (or price for the token at all)
+  --				* i.e 250$ for WETH according to Binance
+  --		"token_usd_price": OWL-USD
+  --				* Is the best estimation we can give for the price in USD for the token
+  --				* All the other prices are nice to know, but this one is the one we are really interested in. The other prices help us calculate this one
+  --				* Calculates it using the price in OWL that reports the solver and our best estimate of OWL price in USD (owl_usd_price)
+  --				* token_usd_price = token_owl_price * owl_usd_price
+  --				* NOTE: Alternativelly, it could have been used the external token price if available, but it was prefered to use uniform OWL prices sol USD price are coherent with OWL prices (they keep the same proportion within the batch)
+  prices_in_usd.token_owl_price,
+  COALESCE(
+    best_owl_price.owl_usd_price,
+    0.95
+  ) AS owl_usd_price,
+  prices_in_usd.token_usd_price AS token_usd_price_external,
+  prices_in_usd.token_owl_price * COALESCE(
+    best_owl_price.owl_usd_price,
+    0.95
+  ) AS token_usd_price
+FROM prices_in_usd
+LEFT OUTER JOIN best_owl_price ON best_owl_price.batch_id = prices_in_usd.batch_id
+  AND best_owl_price.evt_index = prices_in_usd.evt_index;
+
+
+CREATE UNIQUE INDEX IF NOT EXISTS view_price_batch_id ON gnosis_protocol.view_price_batch (batch_id, token_id);
+CREATE INDEX view_price_batch_idx_1 ON gnosis_protocol.view_price_batch (token_id);
+CREATE INDEX view_price_batch_idx_2 ON gnosis_protocol.view_price_batch (symbol);
+CREATE INDEX view_price_batch_idx_3 ON gnosis_protocol.view_price_batch (price_date);
+
+INSERT INTO cron.job (schedule, command)
+VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_price_batch')
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+COMMIT;

--- a/xdai/gnosis_protocol/view_price_batch.sql
+++ b/xdai/gnosis_protocol/view_price_batch.sql
@@ -156,8 +156,8 @@ SELECT
   --				* Best estimation price for OWL
   --				* Considers the external prices for all tokens to calculate the OWL-USD according to that token
   --				* For the tokens that the external price is known, selects the best price according to a defined token priority
-  --				* As a fallback, if no token has an estimation, we assume the OWL cost a constant value --> 0.8$
-  --				* i.e. OWL price according to DAI external source is 0.8$, according to WETH is 0.75$, then since DAI has more priority, we select 0.8$ as the price of OWL
+  --				* AS a fallback, if no token has an estimation, we assume the OWL cost a constant value --> 0.8$
+  --				* i.e. OWL price according to DAI external source is 0.8$, according to WETH is 0.75$, then since DAI has more priority, we select 0.8$ AS the price of OWL
   --		"token_usd_price_external":	TOKEN-USD
   --				* External price of the token in USD
   --				* It can be NULL, meaning, there's no price at that time (or price for the token at all)

--- a/xdai/gnosis_protocol/view_price_batch.sql
+++ b/xdai/gnosis_protocol/view_price_batch.sql
@@ -1,5 +1,5 @@
 BEGIN;
-DROP MATERIALIZED VIEW gnosis_protocol.view_price_batch;
+DROP MATERIALIZED VIEW IF EXISTS gnosis_protocol.view_price_batch;
 CREATE MATERIALIZED VIEW gnosis_protocol.view_price_batch AS
 WITH token_priorities AS (
   SELECT * FROM (VALUES

--- a/xdai/gnosis_protocol/view_trade_stats.sql
+++ b/xdai/gnosis_protocol/view_trade_stats.sql
@@ -1,0 +1,79 @@
+BEGIN;
+DROP MATERIALIZED VIEW IF EXISTS gnosis_protocol.view_trade_stats;
+CREATE MATERIALIZED VIEW gnosis_protocol.view_trade_stats AS
+WITH trades as (
+    SELECT 
+        trades.trade_date,
+        trades.batch_id,
+        trades.trader_hex as trader,
+        trades.order_id,
+        trades.trade_sub_id,
+        trades.sell_amount,
+        trades.sell_token_symbol,
+        trades.sell_token_id,
+        trades.buy_amount,
+        trades.buy_token_symbol,
+        trades.buy_token_id,
+        (trades.sell_amount * price.token_usd_price) / 2 as usd_volume,
+        tx_hash as trade_tx_hash
+    FROM gnosis_protocol.view_trades trades
+    JOIN gnosis_protocol.view_price_batch price
+        ON trades.batch_id = price.batch_id
+        AND trades.sell_token = price.token
+),
+view_trade_stats as (
+    SELECT
+        trades.*,
+        "priceNumerator" as order_price_numerator,
+        "priceDenominator" as order_price_denominator,
+        tx.hash as order_tx,
+        data::bytea::text ~ 'dec0de\d{8}$' as has_analytics,
+        substring(data::bytea::text, 'dec0de(\d{8})$') as analytics
+    FROM trades
+    JOIN gnosis_protocol."BatchExchange_evt_OrderPlacement" orders
+        ON trades.trader = orders.owner
+        AND trades.order_id = orders.index
+    LEFT OUTER JOIN xdai.transactions tx
+        ON orders.evt_tx_hash = tx.hash
+),
+decoded_analalytics as (
+    SELECT 
+        trade_date,
+        batch_id,
+        trader,
+        order_id,
+        trade_sub_id,
+        regexp_matches( -- Regex matches applies a filter, this is why this regex cannot be done in view_trade_stats and needs to be LEFT OUTER joined
+            analytics,
+            '(\d{2})(\d{2})(\d{1})(\d{2})(\d{1})$'
+        ) as analytics
+    FROM view_trade_stats
+)
+SELECT
+    stats.*,
+    decoded.analytics[1] as app_id,
+    decoded.analytics[2] as provider,
+    CASE 
+        WHEN decoded.analytics[3] = '0' THEN true
+        WHEN decoded.analytics[3] = '1' THEN false
+        ELSE NULL
+    END as is_desktop,
+    decoded.analytics[4] as browser,
+    decoded.analytics[5] as screen_size
+FROM view_trade_stats stats
+LEFT OUTER JOIN decoded_analalytics decoded
+    ON stats.batch_id = decoded.batch_id
+      AND stats.trader = decoded.trader
+      AND stats.order_id = decoded.order_id
+      AND stats.trade_sub_id = decoded.trade_sub_id;
+
+
+CREATE UNIQUE INDEX IF NOT EXISTS view_trade_stats_id ON gnosis_protocol.view_trade_stats (batch_id, trader, order_id, trade_sub_id);
+CREATE INDEX view_trade_stats_idx_1 ON gnosis_protocol.view_trade_stats (app_id);
+CREATE INDEX view_trade_stats_idx_2 ON gnosis_protocol.view_trade_stats (trade_date);
+
+
+INSERT INTO cron.job (schedule, command)
+VALUES ('*/10 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_trades')
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+COMMIT;

--- a/xdai/gnosis_protocol/view_trade_stats.sql
+++ b/xdai/gnosis_protocol/view_trade_stats.sql
@@ -1,11 +1,11 @@
 BEGIN;
 DROP MATERIALIZED VIEW IF EXISTS gnosis_protocol.view_trade_stats;
 CREATE MATERIALIZED VIEW gnosis_protocol.view_trade_stats AS
-WITH trades as (
+WITH trades AS (
     SELECT 
         trades.trade_date,
         trades.batch_id,
-        trades.trader_hex as trader,
+        trades.trader_hex AS trader,
         trades.order_id,
         trades.trade_sub_id,
         trades.sell_amount,
@@ -14,21 +14,21 @@ WITH trades as (
         trades.buy_amount,
         trades.buy_token_symbol,
         trades.buy_token_id,
-        (trades.sell_amount * price.token_usd_price) / 2 as usd_volume,
-        tx_hash as trade_tx_hash
+        (trades.sell_amount * price.token_usd_price) / 2 AS usd_volume,
+        tx_hash AS trade_tx_hash
     FROM gnosis_protocol.view_trades trades
     JOIN gnosis_protocol.view_price_batch price
         ON trades.batch_id = price.batch_id
         AND trades.sell_token = price.token
 ),
-view_trade_stats as (
+view_trade_stats AS (
     SELECT
         trades.*,
-        "priceNumerator" as order_price_numerator,
-        "priceDenominator" as order_price_denominator,
-        tx.hash as order_tx,
-        data::bytea::text ~ 'dec0de\d{8}$' as has_analytics,
-        substring(data::bytea::text, 'dec0de(\d{8})$') as analytics
+        "priceNumerator" AS order_price_numerator,
+        "priceDenominator" AS order_price_denominator,
+        tx.hash AS order_tx,
+        data::bytea::text ~ 'dec0de\d{8}$' AS has_analytics,
+        substring(data::bytea::text, 'dec0de(\d{8})$') AS analytics
     FROM trades
     JOIN gnosis_protocol."BatchExchange_evt_OrderPlacement" orders
         ON trades.trader = orders.owner
@@ -36,7 +36,7 @@ view_trade_stats as (
     LEFT OUTER JOIN xdai.transactions tx
         ON orders.evt_tx_hash = tx.hash
 ),
-decoded_analalytics as (
+decoded_analalytics AS (
     SELECT 
         trade_date,
         batch_id,
@@ -46,20 +46,20 @@ decoded_analalytics as (
         regexp_matches( -- Regex matches applies a filter, this is why this regex cannot be done in view_trade_stats and needs to be LEFT OUTER joined
             analytics,
             '(\d{2})(\d{2})(\d{1})(\d{2})(\d{1})$'
-        ) as analytics
+        ) AS analytics
     FROM view_trade_stats
 )
 SELECT
     stats.*,
-    decoded.analytics[1] as app_id,
-    decoded.analytics[2] as provider,
+    decoded.analytics[1] AS app_id,
+    decoded.analytics[2] AS provider,
     CASE 
         WHEN decoded.analytics[3] = '0' THEN true
         WHEN decoded.analytics[3] = '1' THEN false
         ELSE NULL
-    END as is_desktop,
-    decoded.analytics[4] as browser,
-    decoded.analytics[5] as screen_size
+    END AS is_desktop,
+    decoded.analytics[4] AS browser,
+    decoded.analytics[5] AS screen_size
 FROM view_trade_stats stats
 LEFT OUTER JOIN decoded_analalytics decoded
     ON stats.batch_id = decoded.batch_id


### PR DESCRIPTION
Depends on #212 and #211 (which this is based on) and migrates the last of the existing views from mainnet to xdai. These views did not have any syntactic difference, so would eventually be better off without the code duplication. Hopefully at some point we can come to a more efficient solution which avoids these kinds of replications.

I have not yet tested the last of these views since they depend so heavily on existing views (hence the first box not being checked).


I've checked that:

* [ ] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`

