### PR TITLE
Add INDEX and DPI tokens

### DIFF
--- a/prices/prices.ini
+++ b/prices/prices.ini
@@ -1384,3 +1384,15 @@ id = 1inch-1inch
 symbol = 1INCH
 address = 0x111111111117dC0aa78b770fA6A738034120C302
 decimals = 18
+
+[assets.index_index_cooperative]
+id = index-index-cooperative
+symbol = INDEX
+address = 0x0954906da0Bf32d5479e25f46056d22f08464cab
+decimals = 18
+
+[assets.dpi_defi_pulse_index]
+id = dpi-defi-pulse-index
+symbol = DPI
+address = 0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b
+decimals = 18


### PR DESCRIPTION
Added Coinpaprika identifiers for Index Cooperative (INDEX) and DeFi Pulse Index (DPI).

I've followed the README.md instructions here: 
https://github.com/duneanalytics/abstractions/tree/master/prices