### PR TITLE
prices: derive token prices from dex.trades

### DIFF
--- a/ethereum/dex/view_token_prices.sql
+++ b/ethereum/dex/view_token_prices.sql
@@ -31,7 +31,7 @@ CREATE MATERIALIZED VIEW dex.view_token_prices AS (
         date_trunc('hour', block_time) as hour,
         contract_address,
         (PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY price)) AS median_price,
-        count(1) AS number_of_trades
+        count(1) AS sample_size
     FROM dex_trades
     GROUP BY 1, 2
     HAVING count(1) >= 2

--- a/ethereum/dex/view_token_prices.sql
+++ b/ethereum/dex/view_token_prices.sql
@@ -34,7 +34,6 @@ CREATE MATERIALIZED VIEW dex.view_token_prices AS (
         count(1) AS sample_size
     FROM dex_trades
     GROUP BY 1, 2
-    HAVING count(1) >= 2
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS dex_token_prices_unique ON dex.view_token_prices (hour, contract_address);

--- a/ethereum/dex/view_token_prices.sql
+++ b/ethereum/dex/view_token_prices.sql
@@ -1,0 +1,45 @@
+BEGIN;
+
+DROP MATERIALIZED VIEW IF EXISTS dex.view_token_prices;
+
+CREATE MATERIALIZED VIEW dex.view_token_prices AS (
+    WITH dex_trades AS (
+        SELECT 
+            token_a_address as contract_address, 
+            usd_amount/token_a_amount as price,
+            block_time
+        FROM dex.trades
+        WHERE 1=1
+        AND usd_amount  > 0
+        AND token_a_amount > 0
+        AND token_a_address NOT IN (SELECT DISTINCT contract_address FROM prices.usd)
+        
+        UNION ALL 
+        
+        SELECT 
+            token_b_address as contract_address, 
+            usd_amount/token_b_amount as price,
+            block_time
+        FROM dex.trades
+        WHERE 1=1
+        AND usd_amount  > 0
+        AND token_b_amount > 0
+        AND token_b_address NOT IN (SELECT DISTINCT contract_address FROM prices.usd)
+    ) 
+
+    SELECT 
+        date_trunc('hour', block_time) as hour,
+        contract_address,
+        (PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY price)) AS median_price,
+        count(1) AS number_of_trades
+    FROM dex_trades
+    GROUP BY 1, 2
+    HAVING count(1) >= 2
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS dex_token_prices_unique ON dex.view_token_prices (hour, contract_address);
+
+INSERT INTO cron.job(schedule, command)
+VALUES ('* 1 * * *', $$REFRESH MATERIALIZED VIEW CONCURRENTLY dex.view_token_prices$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+COMMIT;

--- a/ethereum/dex/view_token_prices.sql
+++ b/ethereum/dex/view_token_prices.sql
@@ -11,6 +11,7 @@ CREATE MATERIALIZED VIEW dex.view_token_prices AS (
         FROM dex.trades
         WHERE 1=1
         AND usd_amount  > 0
+        AND category = 'DEX'
         AND token_a_amount > 0
         AND token_a_address NOT IN (SELECT DISTINCT contract_address FROM prices.usd)
         
@@ -23,6 +24,7 @@ CREATE MATERIALIZED VIEW dex.view_token_prices AS (
         FROM dex.trades
         WHERE 1=1
         AND usd_amount  > 0
+        AND category = 'DEX'
         AND token_b_amount > 0
         AND token_b_address NOT IN (SELECT DISTINCT contract_address FROM prices.usd)
     ) 


### PR DESCRIPTION
There's a long tail of tokens for which there's no price feed in coinpaprika and therefore are not available via `prices.usd`. The goal with this materialized view is to provide performant access to estimated prices of tokens based on trades occurring in multiple DEXes (`dex.trades`). 

It indirectly uses the curated list of tokens in `erc20.tokens` because it only selects trades where `token_amount>0` (`token_amount` is computed from the `decimals` in `erc20.tokens` and will be `NULL` if the token is not among the curated ones).

Prices are aggregated based on the median so as to be more resistant to the influence of extreme prices. An additional field `number_of_trades` can help users eliminate infrequently traded tokens from their queries that make use of this materialized view, as for those the median would also risk being quite innacurate.

We have deployed a version of this materialized view in `dune_user_generated.view_token_prices` and [reimplemented the Balancer TVL](https://explore.duneanalytics.com/queries/19109) query making use of it as a complement to the information coming from `prices.usd`. This will be particularly relevant once wPE is added to `erc20.tokens` (#231).

Future iterations of this view might include estimating prices for hours where no trades occurred (forward filling? linear interpolation?) and adding different measures as price estimators (time weighted average, volume weighted average, etc). But in its current version I believe it will be a value-add to the Dune community.

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
