### PR TITLE
dex.trades: add tx.to

### DIFF
--- a/ethereum/dex/trades.sql
+++ b/ethereum/dex/trades.sql
@@ -17,7 +17,7 @@ CREATE TABLE dex.trades (
     exchange_contract_address bytea NOT NULL,
     tx_hash bytea NOT NULL,
     tx_from bytea NOT NULL,
-    tx_to bytea NOT NULL,
+    tx_to bytea,
     trace_address integer[],
     evt_index integer,
     trade_id integer

--- a/ethereum/dex/trades.sql
+++ b/ethereum/dex/trades.sql
@@ -17,6 +17,7 @@ CREATE TABLE dex.trades (
     exchange_contract_address bytea NOT NULL,
     tx_hash bytea NOT NULL,
     tx_from bytea NOT NULL,
+    tx_to bytea NOT NULL,
     trace_address integer[],
     evt_index integer,
     trade_id integer
@@ -46,6 +47,7 @@ WITH rows AS (
         exchange_contract_address,
         tx_hash,
         tx_from,
+        tx_to,
         trace_address,
         evt_index,
         trade_id
@@ -73,6 +75,7 @@ WITH rows AS (
         exchange_contract_address,
         tx_hash,
         tx."from" as tx_from,
+        tx."to" as tx_to,
         trace_address,
         evt_index,
         row_number() OVER (PARTITION BY tx_hash, evt_index, trace_address) AS trade_id
@@ -863,6 +866,7 @@ WITH rows AS (
         exchange_contract_address,
         tx_hash,
         tx."from" as tx_from,
+        tx."to" as tx_to,
         NULL AS trace_address,
         evt_index,
         trade_id
@@ -890,6 +894,7 @@ $function$;
 CREATE UNIQUE INDEX IF NOT EXISTS dex_trades_tr_addr_uniq_idx ON dex.trades (tx_hash, trace_address, trade_id);
 CREATE UNIQUE INDEX IF NOT EXISTS dex_trades_evt_index_uniq_idx ON dex.trades (tx_hash, evt_index, trade_id);
 CREATE INDEX IF NOT EXISTS dex_trades_tx_from_idx ON dex.trades (tx_from);
+CREATE INDEX IF NOT EXISTS dex_trades_tx_to_idx ON dex.trades (tx_to);
 CREATE INDEX IF NOT EXISTS dex_trades_project_idx ON dex.trades (project);
 CREATE INDEX IF NOT EXISTS dex_trades_block_time_idx ON dex.trades USING BRIN (block_time);
 CREATE INDEX IF NOT EXISTS dex_trades_token_a_idx ON dex.trades (token_a_address);


### PR DESCRIPTION
with more and more interfaces building on top of aggregators (eg Metamask), this should help detect where volume is coming from

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
