### PR TITLE
docs: fix typo on label

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Enjoy working with Dune? We're [hiring developers](https://careers.duneanalytics
 This repository tracks user-created abstractions to the Dune Analytics data platform. Contributions in the form of issues and pull requests are very much welcome here.
 
 ## Guidelines and conventions
-- Folders within the {ethereum/, xdai/} fodler maps to schemanames (project names) in the relevant Dune dataset. Make sure to get the right schema.
+- Folders within the {ethereum/, xdai/} folder maps to schema names (project names) in the relevant Dune dataset. Make sure to get the right schema.
 - Each file should only contain one table, view, materialized view or function declaration.
 - Files should have names matching their declared object. I.e. if a file declares `CREATE VIEW x.view_y`, the file should be `ethereum/x/view_y.sql`
 - Each file should be run in a transaction. I.e. either have one statement or be wrapped in `BEGIN;` and `COMMIT;`

--- a/labels/README.md
+++ b/labels/README.md
@@ -7,4 +7,4 @@ The query MUST return `address bytea`, `label text`, `type text`, `author text`.
 You can also optionally add a `{{timestamp}}` template variable which Dune will use to incrementally sync this label query. The timestamp will be replaced with the last timestamp a label was synced using this strategy.
 
 * Read more about labels in our docs [here](https://hackmd.io/k71ZUSTxQVKGqOcvR6OXnw?view#%F0%9F%93%A5-Adding-labels).
-* You can also browse addresses and add new ones at our [lables page](https://duneanalytics.com/labels) 
+* You can also browse addresses and add new ones at our [labels page](https://duneanalytics.com/labels) 


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
