### PR TITLE
prices: add prices for unit protocol collaterals

### DIFF
--- a/prices/prices.ini
+++ b/prices/prices.ini
@@ -1600,3 +1600,21 @@ id = xrt-robonomics-network
 symbol = XRT
 address = 0x7de91b204c1c737bcee6f000aaa6569cf7061cb7
 decimals = 9
+
+[assets.sushi_sushi]
+id = sushi-sushi
+symbol = SUSHI
+address = 0x6B3595068778DD592e39A122f4f5a5cF09C90fE2
+decimals = 18
+
+[assets.perp_perpetual_protocol]
+id = perp-perpetual-protocol
+symbol = PERP
+address = 0xbC396689893D065F41bc2C6EcbeE5e0085233447
+decimals = 18
+
+[assets.ftm_fantom]
+id = ftm-fantom
+symbol = FTM
+address = 0x4E15361FD6b4BB609Fa63C81A2be19d873717870
+decimals = 18


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
