### PR TITLE
dex.trades: add 1inch Liquidity Protocol swaps to dex.trades table

### DIFF
--- a/ethereum/dex/trades/insert_1inch_lp.sql
+++ b/ethereum/dex/trades/insert_1inch_lp.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION dex.insert_mooniswap(start_ts timestamptz, end_ts timestamptz=now(), start_block numeric=0, end_block numeric=9e18) RETURNS integer
+CREATE OR REPLACE FUNCTION dex.insert_1inch_lp(start_ts timestamptz, end_ts timestamptz=now(), start_block numeric=0, end_block numeric=9e18) RETURNS integer
 LANGUAGE plpgsql AS $function$
 DECLARE r integer;
 BEGIN
@@ -55,28 +55,28 @@ WITH rows AS (
         evt_index,
         row_number() OVER (PARTITION BY tx_hash, evt_index, trace_address) AS trade_id
     FROM (
-        -- Mooniswap
+        -- 1inch LP
         SELECT
-            evt_block_time as block_time,
-            'Mooniswap' AS project,
+            evt_block_time,
+            '1inch LP' AS project,
             '1' AS version,
             'DEX' AS category,
-            account AS trader_a,
+            sender AS trader_a,
             NULL::bytea AS trader_b,
             result AS token_a_amount_raw,
             amount AS token_b_amount_raw,
             NULL::numeric AS usd_amount,
-            CASE WHEN dst = '\x0000000000000000000000000000000000000000' THEN 
-                '\xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'::bytea ELSE dst
+            CASE WHEN "dstToken" = '\x0000000000000000000000000000000000000000' THEN 
+                '\xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'::bytea ELSE "dstToken"
             END AS token_a_address,
-            CASE WHEN src = '\x0000000000000000000000000000000000000000' THEN 
-                '\xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'::bytea ELSE src
+            CASE WHEN "srcToken" = '\x0000000000000000000000000000000000000000' THEN 
+                '\xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'::bytea ELSE "srcToken"
             END AS token_b_address,
             contract_address AS exchange_contract_address,
             evt_tx_hash AS tx_hash,
             NULL::integer[] AS trace_address,
             evt_index
-        FROM mooniswap."MooniSwap_evt_Swapped"
+        FROM onelp."Mooniswap_evt_Swapped"
     ) dexs
     INNER JOIN ethereum.transactions tx
         ON dexs.tx_hash = tx.hash
@@ -104,41 +104,26 @@ RETURN r;
 END
 $function$;
 
--- fill 2020H1
-SELECT dex.insert_mooniswap(
+-- fill 2020
+SELECT dex.insert_1inch_lp(
     '2020-01-01',
-    '2020-06-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-06-01')
-)
-WHERE NOT EXISTS (
-    SELECT *
-    FROM dex.trades
-    WHERE block_time > '2020-01-01'
-    AND block_time <= '2020-06-01'
-    AND project = 'Mooniswap'
-);
-
--- fill 2020H2
-SELECT dex.insert_mooniswap(
-    '2020-06-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-06-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
     SELECT *
     FROM dex.trades
-    WHERE block_time > '2020-06-01'
+    WHERE block_time > '2020-01-01'
     AND block_time <= '2021-01-01'
-    AND project = 'Mooniswap'
+    AND project = '1inch LP'
 );
 
 -- fill 2021
-SELECT dex.insert_mooniswap(
+SELECT dex.insert_1inch_lp(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
@@ -146,15 +131,15 @@ WHERE NOT EXISTS (
     FROM dex.trades
     WHERE block_time > '2021-01-01'
     AND block_time <= now()
-    AND project = 'Mooniswap'
+    AND project = '1inch LP'
 );
 
 INSERT INTO cron.job (schedule, command)
 VALUES ('*/12 * * * *', $$
-    SELECT dex.insert_mooniswap(
-        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Mooniswap'),
+    SELECT dex.insert_1inch_lp(
+        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='1inch LP'),
         (SELECT now()),
-        (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Mooniswap')),
+        (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='1inch LP')),
         (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_1inch_lp.sql
+++ b/ethereum/dex/trades/insert_1inch_lp.sql
@@ -57,7 +57,7 @@ WITH rows AS (
     FROM (
         -- 1inch LP
         SELECT
-            evt_block_time,
+            evt_block_time AS block_time,
             '1inch LP' AS project,
             '1' AS version,
             'DEX' AS category,


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
