### PR TITLE
synthetix: add recent Synthetix contracts

### DIFF
--- a/ethereum/synthetix/rates.sql
+++ b/ethereum/synthetix/rates.sql
@@ -100,6 +100,18 @@ WITH rows AS (
     INNER JOIN synthetix."ExchangeRates_v2_31_1_evt_AggregatorAdded" agg ON agg.aggregator = clam.proxy_address
     WHERE cl.evt_block_time >= start_ts
     AND cl.evt_block_time < end_ts
+
+    UNION
+
+    SELECT
+        agg."currencyKey" AS currency_key,
+        cl.current * 1e10 AS currency_rate,
+        cl.evt_block_time AS block_time
+    FROM chainlink."Aggregator_evt_AnswerUpdated" cl
+    INNER JOIN chainlink."view_aggregator_mappings" clam ON clam.aggregator_address = cl.contract_address
+    INNER JOIN synthetix."ExchangeRates_v2_35_2_evt_AggregatorAdded" agg ON agg.aggregator = clam.proxy_address
+    WHERE cl.evt_block_time >= start_ts
+    AND cl.evt_block_time < end_ts
     ON CONFLICT DO NOTHING
     RETURNING 1
 )

--- a/ethereum/synthetix/symbols.sql
+++ b/ethereum/synthetix/symbols.sql
@@ -220,6 +220,20 @@ WITH rows AS (
     FROM synthetix."Issuer_v2_31_1_evt_SynthAdded"
     WHERE evt_block_time >= start_ts
     AND evt_block_time < end_ts
+
+    UNION
+
+    SELECT trim('\000' from encode("currencyKey", 'escape')) AS symbol, synth AS address, evt_block_time AS block_time
+    FROM synthetix."Issuer_v2_35_2_evt_SynthAdded"
+    WHERE evt_block_time >= start_ts
+    AND evt_block_time < end_ts
+
+    UNION
+
+    SELECT trim('\000' from encode("currencyKey", 'escape')) AS symbol, synth AS address, evt_block_time AS block_time
+    FROM synthetix."Issuer_v2_36_0_evt_SynthAdded"
+    WHERE evt_block_time >= start_ts
+    AND evt_block_time < end_ts
     ON CONFLICT DO NOTHING
     RETURNING 1
 )

--- a/ethereum/synthetix/synths.sql
+++ b/ethereum/synthetix/synths.sql
@@ -219,6 +219,20 @@ WITH rows AS (
     FROM synthetix."Issuer_v2_31_1_evt_SynthAdded"
     WHERE evt_block_time >= start_ts
     AND evt_block_time < end_ts
+
+    UNION
+
+    SELECT synth AS address, "currencyKey" AS currency_key, evt_block_time AS block_time
+    FROM synthetix."Issuer_v2_35_2_evt_SynthAdded"
+    WHERE evt_block_time >= start_ts
+    AND evt_block_time < end_ts
+
+    UNION
+
+    SELECT synth AS address, "currencyKey" AS currency_key, evt_block_time AS block_time
+    FROM synthetix."Issuer_v2_36_0_evt_SynthAdded"
+    WHERE evt_block_time >= start_ts
+    AND evt_block_time < end_ts
     ON CONFLICT DO NOTHING
     RETURNING 1
 )


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
