### PR TITLE
0x: update the view.fills table to include v4 native fills

### DIFF
--- a/ethereum/zeroex/view_fills.sql
+++ b/ethereum/zeroex/view_fills.sql
@@ -104,11 +104,123 @@ WITH
         LEFT JOIN erc20.tokens mt ON mt.contract_address = SUBSTRING(fills."makerAssetData",17,20)
         LEFT JOIN erc20.tokens tt ON tt.contract_address = SUBSTRING(fills."takerAssetData",17,20)
     )
+    , v4_limit_fills AS (
+
+        SELECT
+            fills.evt_block_time AS timestamp
+            , 'v4' AS protocol_version
+            , fills.evt_tx_hash AS transaction_hash
+            , fills.evt_index
+            , fills."maker" AS maker_address
+            , fills."taker" AS taker_address
+            , fills."makerToken" AS maker_token
+            , mt.symbol AS maker_symbol
+            , fills."makerTokenFilledAmount" / (10^mt.decimals) AS maker_asset_filled_amount
+            , fills."takerToken" AS taker_token
+            , tt.symbol AS taker_symbol
+            , fills."takerTokenFilledAmount" / (10^tt.decimals) AS taker_asset_filled_amount
+            , fills."feeRecipient" AS fee_recipient_address
+            , CASE
+                    WHEN tp.symbol = 'USDC' THEN (fills."takerTokenFilledAmount" / 1e6) ----don't multiply by anything as these assets are USD
+                    WHEN mp.symbol = 'USDC' THEN (fills."makerTokenFilledAmount" / 1e6) ----don't multiply by anything as these assets are USD
+                    WHEN tp.symbol = 'TUSD' THEN (fills."takerTokenFilledAmount" / 1e18) --don't multiply by anything as these assets are USD
+                    WHEN mp.symbol = 'TUSD' THEN (fills."makerTokenFilledAmount" / 1e18) --don't multiply by anything as these assets are USD
+                    WHEN tp.symbol = 'USDT' THEN (fills."takerTokenFilledAmount" / 1e6) * tp.price
+                    WHEN mp.symbol = 'USDT' THEN (fills."makerTokenFilledAmount" / 1e6) * mp.price
+                    WHEN tp.symbol = 'DAI' THEN (fills."takerTokenFilledAmount" / 1e18) * tp.price
+                    WHEN mp.symbol = 'DAI' THEN (fills."makerTokenFilledAmount" / 1e18) * mp.price
+                    WHEN tp.symbol = 'WETH' THEN (fills."takerTokenFilledAmount" / 1e18) * tp.price
+                    WHEN mp.symbol = 'WETH' THEN (fills."makerTokenFilledAmount" / 1e18) * mp.price
+                    ELSE COALESCE((fills."makerTokenFilledAmount" / (10^mt.decimals))*mp.price,(fills."takerTokenFilledAmount" / (10^tt.decimals))*tp.price)
+                END AS volume_usd
+            , fills."protocolFeePaid"/ 1e18 AS protocol_fee_paid_eth
+        FROM zeroex."ExchangeProxy_evt_LimitOrderFilled" fills
+        LEFT JOIN prices.usd tp ON
+            date_trunc('minute', evt_block_time) = tp.minute
+            AND CASE
+                    -- Set Deversifi ETHWrapper to WETH
+                    WHEN fills."takerToken" IN ('\x50cb61afa3f023d17276dcfb35abf85c710d1cff'::BYTEA,'\xaa7427d8f17d87a28f5e1ba3adbb270badbe1011'::BYTEA) THEN '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'::BYTEA
+                    -- Set Deversifi USDCWrapper to USDC
+                    WHEN fills."takerToken" IN ('\x69391cca2e38b845720c7deb694ec837877a8e53'::BYTEA) THEN '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::BYTEA
+                    ELSE fills."takerToken"
+                END = tp.contract_address
+        LEFT JOIN prices.usd mp ON
+            DATE_TRUNC('minute', evt_block_time) = mp.minute
+            AND CASE
+                    -- Set Deversifi ETHWrapper to WETH
+                    WHEN fills."makerToken" IN ('\x50cb61afa3f023d17276dcfb35abf85c710d1cff'::BYTEA,'\xaa7427d8f17d87a28f5e1ba3adbb270badbe1011'::BYTEA) THEN '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'::BYTEA
+                    -- Set Deversifi USDCWrapper to USDC
+                    WHEN fills."makerToken" IN ('\x69391cca2e38b845720c7deb694ec837877a8e53'::BYTEA) THEN '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::BYTEA
+                    ELSE fills."makerToken"
+                END = mp.contract_address
+        LEFT JOIN erc20.tokens mt ON mt.contract_address = fills."makerToken"
+        LEFT JOIN erc20.tokens tt ON tt.contract_address = fills."takerToken"
+    )
+
+    , v4_rfq_fills AS (
+      SELECT
+          fills.evt_block_time AS timestamp
+          , 'v4' AS protocol_version
+          , fills.evt_tx_hash AS transaction_hash
+          , fills.evt_index
+          , fills."maker" AS maker_address
+          , fills."taker" AS taker_address
+          , fills."makerToken" AS maker_token
+          , mt.symbol AS maker_symbol
+          , fills."makerTokenFilledAmount" / (10^mt.decimals) AS maker_asset_filled_amount
+          , fills."takerToken" AS taker_token
+          , tt.symbol AS taker_symbol
+          , fills."takerTokenFilledAmount" / (10^tt.decimals) AS taker_asset_filled_amount
+          , NULL::BYTEA AS fee_recipient_address
+          , CASE
+                  WHEN tp.symbol = 'USDC' THEN (fills."takerTokenFilledAmount" / 1e6) ----don't multiply by anything as these assets are USD
+                  WHEN mp.symbol = 'USDC' THEN (fills."makerTokenFilledAmount" / 1e6) ----don't multiply by anything as these assets are USD
+                  WHEN tp.symbol = 'TUSD' THEN (fills."takerTokenFilledAmount" / 1e18) --don't multiply by anything as these assets are USD
+                  WHEN mp.symbol = 'TUSD' THEN (fills."makerTokenFilledAmount" / 1e18) --don't multiply by anything as these assets are USD
+                  WHEN tp.symbol = 'USDT' THEN (fills."takerTokenFilledAmount" / 1e6) * tp.price
+                  WHEN mp.symbol = 'USDT' THEN (fills."makerTokenFilledAmount" / 1e6) * mp.price
+                  WHEN tp.symbol = 'DAI' THEN (fills."takerTokenFilledAmount" / 1e18) * tp.price
+                  WHEN mp.symbol = 'DAI' THEN (fills."makerTokenFilledAmount" / 1e18) * mp.price
+                  WHEN tp.symbol = 'WETH' THEN (fills."takerTokenFilledAmount" / 1e18) * tp.price
+                  WHEN mp.symbol = 'WETH' THEN (fills."makerTokenFilledAmount" / 1e18) * mp.price
+                  ELSE COALESCE((fills."makerTokenFilledAmount" / (10^mt.decimals))*mp.price,(fills."takerTokenFilledAmount" / (10^tt.decimals))*tp.price)
+              END AS volume_usd
+          , NULL::NUMERIC AS protocol_fee_paid_eth
+      FROM zeroex."ExchangeProxy_evt_RfqOrderFilled" fills
+      LEFT JOIN prices.usd tp ON
+          date_trunc('minute', evt_block_time) = tp.minute
+          AND CASE
+                  -- Set Deversifi ETHWrapper to WETH
+                  WHEN fills."takerToken" IN ('\x50cb61afa3f023d17276dcfb35abf85c710d1cff'::BYTEA,'\xaa7427d8f17d87a28f5e1ba3adbb270badbe1011'::BYTEA) THEN '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'::BYTEA
+                  -- Set Deversifi USDCWrapper to USDC
+                  WHEN fills."takerToken" IN ('\x69391cca2e38b845720c7deb694ec837877a8e53'::BYTEA) THEN '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::BYTEA
+                  ELSE fills."takerToken"
+              END = tp.contract_address
+      LEFT JOIN prices.usd mp ON
+          DATE_TRUNC('minute', evt_block_time) = mp.minute
+          AND CASE
+                  -- Set Deversifi ETHWrapper to WETH
+                  WHEN fills."makerToken" IN ('\x50cb61afa3f023d17276dcfb35abf85c710d1cff'::BYTEA,'\xaa7427d8f17d87a28f5e1ba3adbb270badbe1011'::BYTEA) THEN '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'::BYTEA
+                  -- Set Deversifi USDCWrapper to USDC
+                  WHEN fills."makerToken" IN ('\x69391cca2e38b845720c7deb694ec837877a8e53'::BYTEA) THEN '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::BYTEA
+                  ELSE fills."makerToken"
+              END = mp.contract_address
+      LEFT JOIN erc20.tokens mt ON mt.contract_address = fills."makerToken"
+      LEFT JOIN erc20.tokens tt ON tt.contract_address = fills."takerToken"
+    )
     SELECT * FROM v3_fills
 
     UNION ALL
 
     SELECT * FROM v2_1_fills
+
+    UNION ALL
+
+    SELECT * FROM v4_limit_fills
+
+    UNION ALL
+
+    SELECT * FROM v4_rfq_fills
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS zeroex_fills_unique ON zeroex.view_fills (transaction_hash, evt_index);


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
