### PR TITLE
fix contracts label query

### DIFF
--- a/labels/ethereum/contracts.sql
+++ b/labels/ethereum/contracts.sql
@@ -16,4 +16,6 @@ SELECT
 FROM
     ethereum.contracts
 WHERE
-    address IS NOT NULL;
+    address IS NOT NULL
+AND
+    updated_at >= '{{ timestamp }}';


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
