### PR TITLE
add order by symbol to increase determinism

### DIFF
--- a/labels/ethereum/balancer_pools.sql
+++ b/labels/ethereum/balancer_pools.sql
@@ -47,6 +47,6 @@ FROM   (
     select s1.pool, symbol, cast(100*denorm/total_denorm as integer) as norm_weight from settings s1
     inner join (select pool, sum(denorm) as total_denorm from settings group by pool) s2
     on s1.pool = s2.pool
-    order by 1 asc , 3 desc
+    order by 1 asc , 3 desc, 2 asc
 ) s
 GROUP  BY 1


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
