### PR TITLE
add a contract label from contract creations

### DIFF
--- a/labels/ethereum/account_type.sql
+++ b/labels/ethereum/account_type.sql
@@ -1,7 +1,7 @@
 SELECT DISTINCT
     address,
-    'Contract' AS label,
-    'Account Type' AS type,
+    'contract' AS label,
+    'account type' AS type,
     'sui414' AS author
 FROM ethereum."traces"
 WHERE type = 'create' and success is true

--- a/labels/ethereum/account_type.sql
+++ b/labels/ethereum/account_type.sql
@@ -1,0 +1,7 @@
+SELECT DISTINCT
+    address,
+    'Contract' AS label,
+    'Account Type' AS type,
+    'sui414' AS author
+FROM ethereum."traces"
+WHERE type = 'create' and success is true


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
