### PR TITLE
fix WNXM to wNXM symbol

### DIFF
--- a/prices/prices.ini
+++ b/prices/prices.ini
@@ -1233,7 +1233,7 @@ decimals = 18
 
 [assets.wnxm_wrapped_nxm]
 id = wnxm-wrapped-nxm
-symbol = WNXM
+symbol = wNXM
 address = 0x0d438f3b5175bebc262bf23753c1e53d03432bde
 decimals = 18
 


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
