### PR TITLE
dex.trades: fix dates

### DIFF
--- a/ethereum/dex/trades/insert_1inch.sql
+++ b/ethereum/dex/trades/insert_1inch.sql
@@ -181,7 +181,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_1inch(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -196,7 +196,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_1inch(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (

--- a/ethereum/dex/trades/insert_balancer.sql
+++ b/ethereum/dex/trades/insert_balancer.sql
@@ -105,7 +105,7 @@ $function$;
 SELECT dex.insert_balancer(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -120,7 +120,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_balancer(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (

--- a/ethereum/dex/trades/insert_bancor.sql
+++ b/ethereum/dex/trades/insert_bancor.sql
@@ -141,7 +141,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_bancor(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -156,7 +156,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_bancor(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (

--- a/ethereum/dex/trades/insert_curve.sql
+++ b/ethereum/dex/trades/insert_curve.sql
@@ -104,7 +104,7 @@ $function$;
 SELECT dex.insert_curve(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -119,7 +119,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_curve(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (

--- a/ethereum/dex/trades/insert_ddex.sql
+++ b/ethereum/dex/trades/insert_ddex.sql
@@ -113,7 +113,7 @@ $function$;
 SELECT dex.insert_ddex(
     '2019-01-01',
     '2020-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2019-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01')
 )
 WHERE NOT EXISTS (
@@ -128,7 +128,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_ddex(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -143,7 +143,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_ddex(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (

--- a/ethereum/dex/trades/insert_dydx.sql
+++ b/ethereum/dex/trades/insert_dydx.sql
@@ -151,7 +151,7 @@ $function$;
 SELECT dex.insert_dydx(
     '2019-01-01',
     '2020-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2019-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01')
 )
 WHERE NOT EXISTS (
@@ -166,7 +166,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_dydx(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -181,7 +181,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_dydx(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (

--- a/ethereum/dex/trades/insert_gnosis_protocol.sql
+++ b/ethereum/dex/trades/insert_gnosis_protocol.sql
@@ -103,7 +103,7 @@ $function$;
 SELECT dex.insert_gnosis_protocol(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -118,7 +118,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_gnosis_protocol(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (

--- a/ethereum/dex/trades/insert_idex.sql
+++ b/ethereum/dex/trades/insert_idex.sql
@@ -111,7 +111,7 @@ $function$;
 SELECT dex.insert_idex(
     '2019-01-01',
     '2020-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2019-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01')
 )
 WHERE NOT EXISTS (
@@ -126,7 +126,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_idex(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -141,7 +141,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_idex(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (

--- a/ethereum/dex/trades/insert_kyber.sql
+++ b/ethereum/dex/trades/insert_kyber.sql
@@ -201,7 +201,7 @@ $function$;
 SELECT dex.insert_kyber(
     '2019-01-01',
     '2020-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2019-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01')
 )
 WHERE NOT EXISTS (
@@ -216,7 +216,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_kyber(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -231,7 +231,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_kyber(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (

--- a/ethereum/dex/trades/insert_linkswap.sql
+++ b/ethereum/dex/trades/insert_linkswap.sql
@@ -107,7 +107,7 @@ $function$;
 SELECT dex.insert_linkswap(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -122,7 +122,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_linkswap(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (

--- a/ethereum/dex/trades/insert_loopring.sql
+++ b/ethereum/dex/trades/insert_loopring.sql
@@ -183,7 +183,7 @@ $function$;
 SELECT dex.insert_loopring(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -198,7 +198,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_loopring(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (

--- a/ethereum/dex/trades/insert_mooniswap.sql
+++ b/ethereum/dex/trades/insert_mooniswap.sql
@@ -104,7 +104,7 @@ $function$;
 SELECT dex.insert_mooniswap(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -119,7 +119,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_mooniswap(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (

--- a/ethereum/dex/trades/insert_oasis.sql
+++ b/ethereum/dex/trades/insert_oasis.sql
@@ -142,7 +142,7 @@ $function$;
 SELECT dex.insert_oasis(
     '2019-01-01',
     '2020-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2019-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01')
 )
 WHERE NOT EXISTS (
@@ -157,7 +157,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_oasis(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -172,7 +172,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_oasis(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (

--- a/ethereum/dex/trades/insert_sushi.sql
+++ b/ethereum/dex/trades/insert_sushi.sql
@@ -107,7 +107,7 @@ $function$;
 SELECT dex.insert_sushi(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -122,7 +122,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_sushi(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (

--- a/ethereum/dex/trades/insert_synthetix.sql
+++ b/ethereum/dex/trades/insert_synthetix.sql
@@ -74,7 +74,7 @@ $function$;
 SELECT dex.insert_synthetix(
     '2019-01-01',
     '2020-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2019-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01')
 )
 WHERE NOT EXISTS (
@@ -89,7 +89,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_synthetix(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -104,7 +104,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_synthetix(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (

--- a/ethereum/dex/trades/insert_uniswap.sql
+++ b/ethereum/dex/trades/insert_uniswap.sql
@@ -154,7 +154,7 @@ $function$;
 SELECT dex.insert_uniswap(
     '2019-01-01',
     '2020-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2019-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01')
 )
 WHERE NOT EXISTS (
@@ -169,7 +169,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_uniswap(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -184,7 +184,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_uniswap(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (

--- a/ethereum/dex/trades/insert_zeroex.sql
+++ b/ethereum/dex/trades/insert_zeroex.sql
@@ -211,7 +211,7 @@ $function$;
 SELECT dex.insert_zeroex(
     '2019-01-01',
     '2020-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2019-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01')
 )
 WHERE NOT EXISTS (
@@ -226,7 +226,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_zeroex(
     '2020-01-01',
     '2021-01-01',
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
 )
 WHERE NOT EXISTS (
@@ -241,7 +241,7 @@ WHERE NOT EXISTS (
 SELECT dex.insert_zeroex(
     '2021-01-01',
     now(),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
     (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
