### PR TITLE
index: add new DPI additions following march rebalance

### DIFF
--- a/ethereum/index/view_indices_assets.sql
+++ b/ethereum/index/view_indices_assets.sql
@@ -67,6 +67,8 @@ CREATE OR REPLACE VIEW index.view_indices_assets (Index, project, asset, asset_a
 ('DPI'      ::text, 'IndexCoop' ::text,    'UNI'	    ::text,   '\x1f9840a85d5af5bf1d1762f925bdaddc4201f984'::bytea),
 ('DPI'      ::text, 'IndexCoop' ::text,    'MKR'	    ::text,   '\x9f8f72aa9304c8b593d555f12ef6589cc3a579a2'::bytea),
 ('DPI'      ::text, 'IndexCoop' ::text,    'SUSHI'	    ::text,   '\x6b3595068778dd592e39a122f4f5a5cf09c90fe2'::bytea),
+('DPI'      ::text, 'IndexCoop' ::text,    'FARM'	    ::text,   '\xa0246c9032bC3A600820415aE600c6388619A14D'::bytea),
+('DPI'      ::text, 'IndexCoop' ::text,    'CREAM'	    ::text,   '\x2ba592F78dB6436527729929AAf6c908497cB200'::bytea),
 ('ORCL5'    ::text, 'Indexed'   ::text,    'DIA'	    ::text,   '\x84ca8bc7997272c7cfb4d0cd3d55cd942b3c9419'::bytea),
 ('ORCL5'    ::text, 'Indexed'   ::text,    'ORAI'	    ::text,   '\x4c11249814f11b9346808179cf06e71ac328c1b5'::bytea),
 ('ORCL5'    ::text, 'Indexed'   ::text,    'UMA'	    ::text,   '\x04fa0d235c4abf4bcf4787af4cf447de572ef828'::bytea),


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
