### PR TITLE
new bridge fill event - 0x

### DIFF
--- a/ethereum/zeroex/view_0x_api_fills.sql
+++ b/ethereum/zeroex/view_0x_api_fills.sql
@@ -139,14 +139,12 @@ WITH zeroex_tx_raw AS (
             INDEX AS evt_index,
             logs.contract_address,
             block_time AS block_time,
-           
             substring(DATA,13,20)::varchar AS maker,
             '\xdef1c0ded9bec7f1a1670819833240f027b25eff'::bytea AS taker,
             substring(DATA,45,20) AS taker_token,
             substring(DATA,77,20) AS maker_token,
             bytea2numericpy(substring(DATA,109,20)) AS taker_token_amount_raw,
             bytea2numericpy(substring(DATA,141,20)) AS maker_token_amount_raw,
-           
             'Bridge Fill' AS type,
             zeroex_tx.affiliate_address as affiliate_address,
             TRUE AS swap_flag,
@@ -250,6 +248,8 @@ WITH zeroex_tx_raw AS (
           SELECT * FROM ERC20BridgeTransfer
           UNION ALL
           SELECT * FROM BridgeFill
+          UNION ALL
+          SELECT * FROM NewBridgeFill
           UNION ALL
           SELECT * FROM v3_fills_no_bridge
           UNION ALL

--- a/ethereum/zeroex/view_0x_api_fills.sql
+++ b/ethereum/zeroex/view_0x_api_fills.sql
@@ -134,6 +134,28 @@ WITH zeroex_tx_raw AS (
     		WHERE topic1 = '\xff3bc5e46464411f331d1b093e1587d2d1aa667f5618f98a95afc4132709d3a9'::bytea
     	),
 
+      NewBridgeFill AS (
+        SELECT  logs.tx_hash,
+            INDEX AS evt_index,
+            logs.contract_address,
+            block_time AS block_time,
+           
+            substring(DATA,13,20)::varchar AS maker,
+            '\xdef1c0ded9bec7f1a1670819833240f027b25eff'::bytea AS taker,
+            substring(DATA,45,20) AS taker_token,
+            substring(DATA,77,20) AS maker_token,
+            bytea2numericpy(substring(DATA,109,20)) AS taker_token_amount_raw,
+            bytea2numericpy(substring(DATA,141,20)) AS maker_token_amount_raw,
+           
+            'Bridge Fill' AS type,
+            zeroex_tx.affiliate_address as affiliate_address,
+            TRUE AS swap_flag,
+            FALSE AS matcha_limit_order_flag
+        FROM ethereum."logs" logs
+        join zeroex_tx on zeroex_tx.tx_hash = logs.tx_hash
+        WHERE topic1 = '\xe59e71a14fe90157eedc866c4f8c767d3943d6b6b2e8cd64dddcc92ab4c55af8'::bytea
+                and contract_address = '\x22f9dcf4647084d6c31b2765f6910cd85c178c18'::bytea
+      ),
       direct_PLP AS (
         SELECT 	plp.evt_tx_hash,
     				plp.evt_index AS evt_index,


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`



--- 

event first seen block: 12231667

i believe the dex.trades will need a partial backfill for this events starting from that block @mewwts 