### PR TITLE
fixed dex.trades

### DIFF
--- a/ethereum/dex/trades/insert_ddex.sql
+++ b/ethereum/dex/trades/insert_ddex.sql
@@ -124,17 +124,32 @@ WHERE NOT EXISTS (
     AND project = 'DDEX'
 );
 
--- fill 2020
+-- fill 2020H1
 SELECT dex.insert_ddex(
     '2020-01-01',
-    '2021-01-01',
+    '2020-06-01',
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
+    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-06-01')
 )
 WHERE NOT EXISTS (
     SELECT *
     FROM dex.trades
     WHERE block_time > '2020-01-01'
+    AND block_time <= '2020-06-01'
+    AND project = 'DDEX'
+);
+
+-- fill 2020H2
+SELECT dex.insert_ddex(
+    '2020-06-01',
+    '2021-01-01',
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-06-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM dex.trades
+    WHERE block_time > '2020-06-01'
     AND block_time <= '2021-01-01'
     AND project = 'DDEX'
 );

--- a/ethereum/dex/trades/insert_mooniswap.sql
+++ b/ethereum/dex/trades/insert_mooniswap.sql
@@ -100,17 +100,32 @@ RETURN r;
 END
 $function$;
 
--- fill 2020
+-- fill 2020H1
 SELECT dex.insert_mooniswap(
     '2020-01-01',
-    '2021-01-01',
+    '2020-06-01',
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
-    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
+    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-06-01')
 )
 WHERE NOT EXISTS (
     SELECT *
     FROM dex.trades
     WHERE block_time > '2020-01-01'
+    AND block_time <= '2020-06-01'
+    AND project = 'Mooniswap'
+);
+
+-- fill 2020H2
+SELECT dex.insert_mooniswap(
+    '2020-06-01',
+    '2021-01-01',
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-06-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM dex.trades
+    WHERE block_time > '2020-06-01'
     AND block_time <= '2021-01-01'
     AND project = 'Mooniswap'
 );


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
