### PR TITLE
dex.trades: blacklist feg in uniswap

### DIFF
--- a/ethereum/dex/trades/insert_uniswap.sql
+++ b/ethereum/dex/trades/insert_uniswap.sql
@@ -122,6 +122,7 @@ WITH rows AS (
             uniswap_v2."Pair_evt_Swap" t
         INNER JOIN uniswap_v2."Factory_evt_PairCreated" f ON f.pair = t.contract_address
         WHERE t.contract_address != '\xed9c854cb02de75ce4c9bba992828d6cb7fd5c71' --Remove WETH-UBOMB wash trading pair
+        and t.contract_address != '\x854373387e41371ac6e307a1f29603c6fa10d872' --remove feg/eth token pair
     ) dexs
     INNER JOIN ethereum.transactions tx
         ON dexs.tx_hash = tx.hash

--- a/ethereum/dex/trades/insert_uniswap.sql
+++ b/ethereum/dex/trades/insert_uniswap.sql
@@ -121,8 +121,10 @@ WITH rows AS (
         FROM
             uniswap_v2."Pair_evt_Swap" t
         INNER JOIN uniswap_v2."Factory_evt_PairCreated" f ON f.pair = t.contract_address
-        WHERE t.contract_address != '\xed9c854cb02de75ce4c9bba992828d6cb7fd5c71' --Remove WETH-UBOMB wash trading pair
-        and t.contract_address != '\x854373387e41371ac6e307a1f29603c6fa10d872' --remove feg/eth token pair
+        WHERE t.contract_address NOT IN (
+            '\xed9c854cb02de75ce4c9bba992828d6cb7fd5c71', -- remove WETH-UBOMB wash trading pair
+            '\x854373387e41371ac6e307a1f29603c6fa10d872'  -- remove FEG/ETH token pair
+        )
     ) dexs
     INNER JOIN ethereum.transactions tx
         ON dexs.tx_hash = tx.hash


### PR DESCRIPTION
I've checked that:

* [X] the query produces the intended results
* [X] the folder name matches the schema name
* [X] the schema name exists in Dune
* [X] views are prefixed with `view_`, functions with `fn_`.
* [X] the filename matches the defined view, table or function and ends with .sql
* [X] each file has only one view, table or function defined  
* [X] column names are `lowercase_snake_cased`
