### PR TITLE
Bugfix ens names sql

### DIFF
--- a/labels/ethereum/ens_names.sql
+++ b/labels/ethereum/ens_names.sql
@@ -11,8 +11,9 @@ UNION
 SELECT
     owner AS address,
     lower(name) AS label,
-    'hagaetc' AS author,
-    'ens name' AS type
+    'ens name' AS type,
+    'hagaetc' AS author
+
 FROM
     ethereumnameservice."ETHRegistrarController_2_evt_NameRegistered"
 WHERE
@@ -21,8 +22,9 @@ UNION
 SELECT
     owner AS address,
     lower(name) AS label,
-    'hagaetc' AS author,
-    'ens name' AS type
+    'ens name' AS type,
+    'hagaetc' AS author
+
 FROM
     ethereumnameservice."ETHRegistrarController_3_evt_NameRegistered"
 WHERE


### PR DESCRIPTION
I did not add any new files.

I found a bug in labels/ens_names.sql and attempted to fix it.

I really like the project and what you guys are working on, hopefully this is helpful and correct! 

Tried to follow pull request protocol here

https://www.loom.com/share/866bcb47884c47aa87f6ca4cdca64918

the union means that subsequent queries do not pay attention to attribute naming, only order.

So ENS names from `ETHRegistrarController_2_evt_NameRegistered` and `ETHRegistrarController_3_evt_NameRegistered` are getting author and type written to improperly.