### PR TITLE
balancer: add v2 pools to token weights view

### DIFF
--- a/ethereum/balancer/view_pools_liquidity.sql
+++ b/ethereum/balancer/view_pools_liquidity.sql
@@ -41,7 +41,7 @@ CREATE MATERIALIZED VIEW balancer.view_pools_liquidity AS (
             b.amount_usd_from_dex / w.normalized_weight AS liquidity_from_dex
         FROM cumulative_usd_balance_by_token b 
         INNER JOIN balancer.view_pools_tokens_weights w
-        ON b.pool = w.pool_address
+        ON b.pool = w.pool_id
         AND b.token = w.token_address
         AND (b.amount_usd_from_api > 0 OR b.amount_usd_from_dex > 0)
         AND w.normalized_weight > 0

--- a/ethereum/balancer/view_pools_tokens_weights.sql
+++ b/ethereum/balancer/view_pools_tokens_weights.sql
@@ -51,4 +51,12 @@ norm_weights as (
     select settings.pool AS pool_address, token AS token_address, denorm/sum_denorm as normalized_weight
     from settings inner join sum_denorm on settings.pool = sum_denorm.pool
 )
-select * from norm_weights
+select pool_address as pool_id, token_address,  normalized_weight
+from norm_weights
+
+union all
+
+select c."poolId" as pool_id, unnest(cc.tokens) as token_address, unnest(cc.weights)/1e18 as normalized_weight
+from balancer_v2."Vault_evt_PoolRegistered" c
+inner join balancer_v2."WeightedPoolFactory_call_create" cc
+on c.evt_tx_hash = cc.call_tx_hash


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
