### PR TITLE
Token balances

### DIFF
--- a/ethereum/token_balances/load_balances.sql
+++ b/ethereum/token_balances/load_balances.sql
@@ -108,3 +108,22 @@ CREATE OR replace FUNCTION load_token_balances_batch_excluding_usdt(limit_ int) 
    order by symbol, contract_address 
    limit limit_;
 END $$;
+
+-- these are too big to do in one go, must be handled separately
+select load_token_balances('\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, date_trunc('hour', now() - interval '1 hour')); -- usdc
+select load_token_balances('\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'::bytea, date_trunc('hour', now() - interval '1 hour')); -- weth
+select load_token_balances('\xdac17f958d2ee523a2206206994597c13d831ec7'::bytea, date_trunc('hour', now() - interval '1 hour')); -- usdt
+
+-- For everything else do in batches of 100
+-- There are 800~ erc20.tokens 
+select load_token_balances_batch_excluding_usdt(100); -- 1
+select load_token_balances_batch_excluding_usdt(100); -- 2
+select load_token_balances_batch_excluding_usdt(100); -- 3
+select load_token_balances_batch_excluding_usdt(100); -- 4
+select load_token_balances_batch_excluding_usdt(100); -- 5
+select load_token_balances_batch_excluding_usdt(100); -- 6
+select load_token_balances_batch_excluding_usdt(100); -- 7
+select load_token_balances_batch_excluding_usdt(100); -- 8
+select load_token_balances_batch_excluding_usdt(100); -- 9
+
+

--- a/ethereum/token_balances/load_balances.sql
+++ b/ethereum/token_balances/load_balances.sql
@@ -12,3 +12,92 @@ CREATE INDEX IF NOT EXISTS token_balances_wallet_address_token_address_idx ON to
 CREATE INDEX IF NOT EXISTS token_balances_wallet_address_token_address_timestamp_idx ON token_balances USING btree (wallet_address, token_address, timestamp) include (amount);
 CREATE INDEX IF NOT EXISTS token_balances_token_timestamp_idx ON token_balances USING btree (timestamp, token_address);
 
+CREATE OR replace FUNCTION load_token_balances(contract_address_ bytea, to_time_ timestamptz) RETURNS void language plpgsql AS 
+$$ DECLARE 
+_row_count integer;
+_last_insert_time timestamptz;
+BEGIN
+_last_insert_time := coalesce((select timestamp from token_balances where token_address = contract_address_ order by timestamp desc limit 1), '2015-01-01 00:00:00');
+RAISE NOTICE 'LAST INSERT %', _last_insert_time;
+insert into
+   token_balances with transfers AS (
+      SELECT
+         date_trunc('hour', evt_block_time) block_hour,
+         wallet_address,
+         token_address,
+         sum(amount) as amount
+      FROM
+         (
+            SELECT
+               evt_block_time,
+               "to" AS wallet_address,
+               contract_address AS token_address,
+               value AS amount
+            FROM
+               erc20."ERC20_evt_Transfer"
+            WHERE
+               contract_address = contract_address_
+               AND evt_block_time >= _last_insert_time + interval '1 hour'
+               AND evt_block_time < to_time_
+            UNION
+            ALL
+            SELECT
+               evt_block_time,
+               "from" AS wallet_address,
+               contract_address AS token_address,
+               - VALUE AS amount
+            FROM
+               erc20."ERC20_evt_Transfer"
+            WHERE
+               contract_address = contract_address_
+               AND evt_block_time >= _last_insert_time + interval '1 hour'
+               AND evt_block_time < to_time_
+         ) transfers
+      GROUP BY 1, 2, 3
+      UNION ALL(
+      -- For every wallet address get its latest balance
+      SELECT DISTINCT ON (wallet_address, token_address)
+         timestamp,
+         wallet_address,
+         token_address,
+         amount_raw
+      FROM token_balances 
+      WHERE 
+         token_address = contract_address_ 
+         and timestamp < to_time_
+      ORDER BY wallet_address, token_address, timestamp desc
+      )
+    ),
+   wallet_balances AS (
+      SELECT
+         block_hour,
+         wallet_address,
+         token_address,
+         SUM(amount) OVER (
+            PARTITION BY wallet_address,
+            token_address
+            ORDER BY
+               block_hour
+         ) as amount
+      FROM
+         transfers
+   )
+SELECT
+   wb.block_hour as timestamp,
+   wb.wallet_address,
+   wb.token_address,
+   tokens.symbol AS token_symbol,
+   wb.amount AS amount_raw,
+   wb.amount / 10 ^ tokens.decimals AS amount
+FROM
+   wallet_balances wb
+   LEFT JOIN erc20.tokens tokens ON tokens.contract_address = wb.token_address
+WHERE 
+   -- don't insert rows for timeblocks that already exist
+   wb.block_hour > _last_insert_time
+ORDER BY
+   1 DESC;
+GET DIAGNOSTICS _row_count = ROW_COUNT;
+  RAISE NOTICE 'INSERTED %', _row_count;
+END $$;
+

--- a/ethereum/token_balances/load_balances.sql
+++ b/ethereum/token_balances/load_balances.sql
@@ -101,3 +101,10 @@ GET DIAGNOSTICS _row_count = ROW_COUNT;
   RAISE NOTICE 'INSERTED %', _row_count;
 END $$;
 
+CREATE OR replace FUNCTION load_token_balances_batch_excluding_usdt(limit_ int) RETURNS void language plpgsql AS $$ DECLARE BEGIN
+   perform load_token_balances(contract_address, date_trunc('hour', now() - interval '1 hour')) 
+   from erc20.tokens 
+   where symbol not in ('USDC', 'WETH', 'USDT') and contract_address not in (select distinct token_address from token_balances)
+   order by symbol, contract_address 
+   limit limit_;
+END $$;

--- a/ethereum/token_balances/load_balances.sql
+++ b/ethereum/token_balances/load_balances.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS token_balances(
+   timestamp timestamptz,
+   wallet_address bytea,
+   token_address bytea,
+   token_symbol text,
+   amount_raw NUMERIC,
+   amount NUMERIC,
+   PRIMARY KEY(timestamp, wallet_address, token_address)
+);
+
+CREATE INDEX IF NOT EXISTS token_balances_wallet_address_token_address_idx ON token_balances USING btree (wallet_address, token_address);
+CREATE INDEX IF NOT EXISTS token_balances_wallet_address_token_address_timestamp_idx ON token_balances USING btree (wallet_address, token_address, timestamp) include (amount);
+CREATE INDEX IF NOT EXISTS token_balances_token_timestamp_idx ON token_balances USING btree (timestamp, token_address);
+

--- a/ethereum/token_balances/load_balances2.sql
+++ b/ethereum/token_balances/load_balances2.sql
@@ -1,0 +1,82 @@
+CREATE TABLE IF NOT EXISTS token_balances_v3(
+   timestamp timestamptz,
+   wallet_address bytea,
+   token_address bytea,
+   token_symbol text,
+   amount_raw NUMERIC,
+   amount NUMERIC,
+   PRIMARY KEY(timestamp, wallet_address, token_address)
+);
+
+CREATE INDEX IF NOT EXISTS token_balances_v3_wallet_address_token_address_idx ON token_balances_v3 USING btree (wallet_address, token_address);
+CREATE INDEX IF NOT EXISTS token_balances_v3_wallet_address_token_address_timestamp_desc_idx ON token_balances_v3 USING btree (wallet_address, token_address, timestamp DESC) include (amount);
+CREATE INDEX IF NOT EXISTS token_balances_v3_timestamp_idx ON token_balances_v3 USING btree(timestamp);
+
+CREATE OR replace FUNCTION load_token_balances_v3(to_time_ timestamptz) RETURNS void language plpgsql AS 
+$$ DECLARE 
+_row_count integer;
+_last_insert_time timestamptz;
+BEGIN
+-- add check for last block time
+_last_insert_time := coalesce((select timestamp from token_balances_v3 order by timestamp desc limit 1), '2015-01-01 00:00:00');
+RAISE NOTICE 'LAST INSERT %', _last_insert_time;
+insert into
+   token_balances_v3 with transfers AS (
+    SELECT
+        date_trunc('hour', v.ts) block_hour,
+        v.wallet_address,
+        v.token_address,
+        sum(v.amount) as amount
+    FROM
+        erc20."ERC20_evt_Transfer" t
+    cross join lateral (VALUES
+        (evt_block_time, "from", contract_address, - value),
+        (evt_block_time, "to", contract_address, value)
+    ) v(ts, wallet_address, token_address, amount)
+    WHERE
+        evt_block_time >= _last_insert_time + interval '1 hour'
+        AND evt_block_time < to_time_
+    GROUP BY 1, 2, 3
+        UNION ALL(
+        -- For every wallet address get its latest balance
+        SELECT DISTINCT ON (wallet_address, token_address)
+            timestamp,
+            wallet_address,
+            token_address,
+            amount_raw
+        FROM token_balances_v3
+        ORDER BY wallet_address, token_address, timestamp desc
+        )
+    ),
+   wallet_balances AS (
+      SELECT
+         block_hour,
+         wallet_address,
+         token_address,
+         SUM(amount) OVER (
+            PARTITION BY wallet_address,
+            token_address
+            ORDER BY
+               block_hour
+         ) as amount
+      FROM
+         transfers
+   )
+SELECT
+   wb.block_hour as timestamp,
+   wb.wallet_address,
+   wb.token_address,
+   tokens.symbol AS token_symbol,
+   wb.amount AS amount_raw,
+   wb.amount / 10 ^ tokens.decimals AS amount
+FROM
+   wallet_balances wb
+   LEFT JOIN erc20.tokens tokens ON tokens.contract_address = wb.token_address
+WHERE 
+   -- don't insert rows for timeblocks that already exist
+   wb.block_hour > _last_insert_time
+ORDER BY
+   1 DESC;
+GET DIAGNOSTICS _row_count = ROW_COUNT;
+  RAISE NOTICE 'INSERTED %', _row_count;
+END $$;

--- a/ethereum/token_balances/token_balances4.sql
+++ b/ethereum/token_balances/token_balances4.sql
@@ -1,0 +1,69 @@
+CREATE TABLE IF NOT EXISTS token_balances_v4(
+   timestamp timestamptz,
+   wallet_address bytea,
+   token_address bytea,
+   token_symbol text,
+   amount_raw NUMERIC,
+   amount NUMERIC,
+   PRIMARY KEY(timestamp, wallet_address, token_address)
+);
+
+CREATE INDEX IF NOT EXISTS token_balances_v4_wallet_address_token_address_timestamp_desc_idx ON token_balances_v4 USING btree (wallet_address, token_address, timestamp DESC) include (amount);
+CREATE INDEX IF NOT EXISTS token_balances_v4_timestamp_idx ON token_balances_v4 USING brin(timestamp);
+CREATE INDEX IF NOT EXISTS token_balances_v4_timestampbtree_idx ON token_balances_v4 USING btree(timestamp);
+
+CREATE OR replace FUNCTION load_token_balances_v4(to_time_ timestamptz) RETURNS void language plpgsql AS 
+$$ DECLARE 
+_row_count integer;
+_last_insert_time timestamptz;
+BEGIN
+-- add check for last block time
+_last_insert_time := coalesce((select timestamp from token_balances_v4 order by timestamp desc limit 1), '2015-01-01 00:00:00');
+RAISE NOTICE 'LAST INSERT %', _last_insert_time;
+insert into
+   token_balances_v4 with transfers AS (
+    SELECT
+        date_trunc('hour', v.ts) block_hour,
+        v.wallet_address,
+        v.token_address,
+        sum(v.amount) as amount
+    FROM
+        erc20."ERC20_evt_Transfer" t
+    cross join lateral (VALUES
+        (evt_block_time, "from", contract_address, - value),
+        (evt_block_time, "to", contract_address, value)
+    ) v(ts, wallet_address, token_address, amount)
+    WHERE
+        evt_block_time < to_time_
+    GROUP BY 1, 2, 3
+    ),
+   wallet_balances AS (
+      SELECT
+         block_hour,
+         wallet_address,
+         token_address,
+         SUM(amount) OVER (
+            PARTITION BY wallet_address,
+            token_address
+            ORDER BY
+               block_hour
+         ) as amount
+      FROM
+         transfers
+   )
+SELECT
+   wb.block_hour as timestamp,
+   wb.wallet_address,
+   wb.token_address,
+   tokens.symbol AS token_symbol,
+   wb.amount AS amount_raw,
+   wb.amount / 10 ^ tokens.decimals AS amount
+FROM
+   wallet_balances wb
+   LEFT JOIN erc20.tokens tokens ON tokens.contract_address = wb.token_address
+WHERE 
+   -- don't insert rows for timeblocks that already exist
+   wb.block_hour > _last_insert_time;
+GET DIAGNOSTICS _row_count = ROW_COUNT;
+  RAISE NOTICE 'INSERTED %', _row_count;
+END $$;


### PR DESCRIPTION
This PR introduces a new abstraction for token balances. It's continuing on https://github.com/duneanalytics/abstractions/pull/327.

The balances are calculated based on `erc20."ERC20_evt_Transfer"` and put in a new table `token_balances`. I've created a function `load_token_balances` to load the balance for each token (`contract_address`). `load_token_balances` will insert everything up until a provided timestamp (truncated to an hour) with the assumption that everything is synced up until that hour in the `erc20."ERC20_evt_Transfer"` table.

`load_token_balances` is idempotent, meaning that if it's run for the same hourly timestamp more than once it will not insert new rows. For example: it makes sure that if there is a record for a balance at `2021-05-01 00:00:00`, no new records will be inserted for that hour and going back.

The actual query looks for transfers related to a erc20 token based on the `contract_address` and then sums with the current balance per wallet that exists (if any). So while the first update looks all the way back in time, incremental ones only look as far back as needed and are therefor faster.

The erc20 tokens with the most transfers are USDT, USDC, WETH, where USDT is much bigger than the latter two combined. Because of that I've separated these in the initial insert to be not be included in the batches. As a reference WETH took about 38 min hour when I was testing and USDT about 1.5 hours. Smaller tokens like AAVE and SUSHI take about 5-10 minutes from inception.

Questions:
* This in the `token_balances` folder, but not sure if we should use another one?
* What interval should the cron job update the balances on?
* What is the time lag on the `erc20."ERC20_evt_Transfer"` table?

Left todo:
* I still need to test a full insert of everything, I suspect there's some memory issue when doing larger batches of inserts.
* Cronjob interval and test it
* Create views that make it nicer to use this table, for another PR since this is already getting big

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
