### PR TITLE
dex.trades: add 1inch Unoswap

### DIFF
--- a/ethereum/dex/trades/insert_1inch.sql
+++ b/ethereum/dex/trades/insert_1inch.sql
@@ -103,6 +103,32 @@ WITH rows AS (
         FROM zeroex_v2."Exchange2.1_evt_Fill"
         WHERE "feeRecipientAddress" IN ('\x910bf2d50fa5e014fd06666f456182d4ab7c8bd2', '\x68a17b587caf4f9329f0e372e3a78d23a46de6b5')
 
+        UNION ALL
+
+        -- 1inch Unoswap
+        SELECT
+            call_block_time as block_time,
+            '1inch' AS project,
+            '1' AS version,
+            'Aggregator' AS category,
+            COALESCE(tr.address, tx."from") AS trader_a,
+            NULL::bytea AS trader_b,
+            "output_returnAmount" AS token_a_amount_raw,
+            "amount" AS token_b_amount_raw,
+            NULL::numeric AS usd_amount,
+            (CASE WHEN ll.contract_address = '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' AND substring("_3"[ARRAY_LENGTH("_3", 1)] from 1 for 1) IN ('\xc0', '\x40') THEN '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' ELSE ll.contract_address END) AS token_a_address,
+            (CASE WHEN "srcToken" = '\x0000000000000000000000000000000000000000' THEN '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' ELSE "srcToken" END) AS token_b_address,
+            us.contract_address AS exchange_contract_address,
+            call_tx_hash,
+            call_trace_address AS trace_address,
+            NULL::integer AS evt_index
+        FROM oneinch_v3."AggregationRouterV3_call_unoswap" us
+        LEFT JOIN ethereum.transactions tx ON tx.hash = us.call_tx_hash
+        LEFT JOIN ethereum.traces tr ON tr.tx_hash = us.call_tx_hash AND tr.trace_address = us.call_trace_address[:ARRAY_LENGTH(us.call_trace_address, 1)-1]
+        LEFT JOIN ethereum.logs ll ON ll.tx_hash = us.call_tx_hash
+            AND topic1 = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef' -- Transfer(addresss,addresss,uint256)
+            AND substring(topic2 from 13 for 20) = substring("_3"[ARRAY_LENGTH("_3", 1)] from 13 for 20)
+        WHERE tx.success
 
     ) dexs
     INNER JOIN ethereum.transactions tx


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
