### PR TITLE
dex.trades: rename project name from dodo to DODO

### DIFF
--- a/ethereum/dex/trades/insert_dodo.sql
+++ b/ethereum/dex/trades/insert_dodo.sql
@@ -59,7 +59,7 @@ WITH rows AS (
         -- dodo v1 sell
         SELECT
             s.evt_block_time AS block_time,
-            'dodo' AS project,
+            'DODO' AS project,
             '1' AS version,
             'DEX' AS category,
             s.seller AS trader_a,
@@ -83,7 +83,7 @@ WITH rows AS (
         -- dodo v1 buy
         SELECT
             b.evt_block_time AS block_time,
-            'dodo' AS project,
+            'DODO' AS project,
             '1' AS version,
             'DEX' AS category,
             b.buyer AS trader_a,
@@ -107,7 +107,7 @@ WITH rows AS (
         -- dodov1 proxy01
         SELECT
             evt_block_time AS block_time,
-            'dodo' AS project,
+            'DODO' AS project,
             '1' AS version,
             'DEX' AS category,
             sender AS trader_a,
@@ -129,7 +129,7 @@ WITH rows AS (
         -- dodov1 proxy04
         SELECT
             evt_block_time AS block_time,
-            'dodo' AS project,
+            'DODO' AS project,
             '1' AS version,
             'DEX' AS category,
             sender AS trader_a,
@@ -151,7 +151,7 @@ WITH rows AS (
         -- dodov2 proxy02
         SELECT
             evt_block_time AS block_time,
-            'dodo' AS project,
+            'DODO' AS project,
             '2' AS version,
             'DEX' AS category,
             sender AS trader_a,
@@ -173,7 +173,7 @@ WITH rows AS (
         -- dodov2 dvm
         SELECT
             evt_block_time AS block_time,
-            'dodo' AS project,
+            'DODO' AS project,
             '2' AS version,
             'DEX' AS category,
             trader AS trader_a,
@@ -196,7 +196,7 @@ WITH rows AS (
         -- dodov2 dpp
         SELECT
             evt_block_time AS block_time,
-            'dodo' AS project,
+            'DODO' AS project,
             '2' AS version,
             'DEX' AS category,
             trader AS trader_a,
@@ -253,7 +253,7 @@ WHERE NOT EXISTS (
     FROM dex.trades
     WHERE block_time > '2020-01-01'
     AND block_time <= '2021-01-01'
-    AND project = 'dodo'
+    AND project = 'DODO'
 );
 
 -- fill 2021
@@ -268,15 +268,15 @@ WHERE NOT EXISTS (
     FROM dex.trades
     WHERE block_time > '2021-01-01'
     AND block_time <= now()
-    AND project = 'dodo'
+    AND project = 'DODO'
 );
 
 INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_dodo(
-        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='dodo'),
+        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='DODO'),
         (SELECT now()),
-        (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='dodo')),
+        (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='DODO')),
         (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
