### PR TITLE
Update insert_zeroex.sql

### DIFF
--- a/ethereum/dex/trades/insert_zeroex.sql
+++ b/ethereum/dex/trades/insert_zeroex.sql
@@ -199,6 +199,7 @@ WITH rows AS (
         AND pb.minute < end_ts
     WHERE dexs.block_time >= start_ts
     AND dexs.block_time < end_ts
+    ORDER BY project
     ON CONFLICT DO NOTHING
     RETURNING 1
 )


### PR DESCRIPTION
This query returns duplicate entries for the records pertaining to Matcha and 0x

```
SELECT * FROM dex.trades
WHERE tx_hash = '\x62a80b28321ea05f7c40180d4f7168598c3728983a81e54ad0078845069fe867'
```

![image](https://user-images.githubusercontent.com/34865315/119748425-48609780-be6b-11eb-86e1-2e5c928e0287.png)

As can be seen on [Etherscan](https://etherscan.io/tx/0x62a80b28321ea05f7c40180d4f7168598c3728983a81e54ad0078845069fe867), this was a trade that went through Matcha and the 0x API to ultimately perform a swap on Sushiswap and a swap on Uniswap.

So `dex.trades` should return 2 records for Matcha and 2 for 0x API. Instead it returns 4 + 4.

When I run the query that populates `dex.trades` filtering for that transaction only, I get the expect result: 2 records for Matcha and 2 for 0x API


```
SELECT
    dexs.block_time,
    erc20a.symbol AS token_a_symbol,
    erc20b.symbol AS token_b_symbol,
    token_a_amount_raw / 10 ^ erc20a.decimals AS token_a_amount,
    token_b_amount_raw / 10 ^ erc20b.decimals AS token_b_amount,
    project,
    version,
    category,
    coalesce(trader_a, tx."from") as trader_a, -- subqueries rely on this COALESCE to avoid redundant joins with the transactions table
    trader_b,
    token_a_amount_raw,
    token_b_amount_raw,
    coalesce(
        usd_amount,
        token_a_amount_raw / 10 ^ erc20a.decimals * pa.price,
        token_b_amount_raw / 10 ^ erc20b.decimals * pb.price
    ) as usd_amount,
    token_a_address,
    token_b_address,
    exchange_contract_address,
    tx_hash,
    tx."from" as tx_from,
    tx."to" as tx_to,
    trace_address,
    evt_index,
    row_number() OVER (PARTITION BY tx_hash, evt_index, trace_address) AS trade_id
FROM (
    -- 0x v2.1
    SELECT
        evt_block_time AS block_time,
        '0x Native' AS project,
        '2.1' AS version,
        'DEX' AS category,
        "takerAddress" AS trader_a,
        "makerAddress" AS trader_b,
        "takerAssetFilledAmount" AS token_a_amount_raw,
        "makerAssetFilledAmount" AS token_b_amount_raw,
        NULL::numeric AS usd_amount,
        substring("takerAssetData" for 20 from 17) AS token_a_address,
        substring("makerAssetData" for 20 from 17) AS token_b_address,
        contract_address AS exchange_contract_address,
        evt_tx_hash AS tx_hash,
        NULL::integer[] AS trace_address,
        evt_index
    FROM zeroex_v2."Exchange2.1_evt_Fill"

    UNION ALL

    -- 0x v3
    SELECT
        evt_block_time AS block_time,
        '0x Native' AS project,
        '3' AS version,
        'DEX' AS category,
        "takerAddress" AS trader_a,
        "makerAddress" AS trader_b,
        "takerAssetFilledAmount" AS token_a_amount_raw,
        "makerAssetFilledAmount" AS token_b_amount_raw,
        NULL::numeric AS usd_amount,
        substring("takerAssetData" for 20 from 17) AS token_a_address,
        substring("makerAssetData" for 20 from 17) AS token_b_address,
        contract_address AS exchange_contract_address,
        evt_tx_hash AS tx_hash,
        NULL::integer[] AS trace_address,
        evt_index
    FROM zeroex_v3."Exchange_evt_Fill"

    UNION ALL

    -- 0x v4 limit orders
    SELECT
        evt_block_time AS block_time,
        '0x Native' AS project,
        '4' AS version,
        'DEX' AS category,
        taker AS trader_a,
        maker AS trader_b,
        "takerTokenFilledAmount" AS token_a_amount_raw,
        "makerTokenFilledAmount" AS token_b_amount_raw,
        NULL::numeric AS usd_amount,
        "takerToken" AS token_a_address,
        "makerToken" AS token_b_address,
        contract_address AS exchange_contract_address,
        evt_tx_hash AS tx_hash,
        NULL::integer[] AS trace_address,
        evt_index
    FROM zeroex."ExchangeProxy_evt_LimitOrderFilled"

    UNION ALL

    -- 0x v4 rfq orders
    SELECT
        evt_block_time AS block_time,
        '0x Native' AS project,
        '4' AS version,
        'DEX' AS category,
        taker AS trader_a,
        maker AS trader_b,
        "takerTokenFilledAmount" AS token_a_amount_raw,
        "makerTokenFilledAmount" AS token_b_amount_raw,
        NULL::numeric AS usd_amount,
        "takerToken" AS token_a_address,
        "makerToken" AS token_b_address,
        contract_address AS exchange_contract_address,
        evt_tx_hash AS tx_hash,
        NULL::integer[] AS trace_address,
        evt_index
    FROM zeroex."ExchangeProxy_evt_RfqOrderFilled"

    UNION ALL

    -- 0x api
    SELECT
        block_time,
        '0x API' AS project,
        NULL AS version,
        'Aggregator' AS category,
        "taker" AS trader_a,
        "maker" AS trader_b,
        "taker_token_amount_raw" AS token_a_amount_raw,
        "maker_token_amount_raw" AS token_b_amount_raw,
        NULL::numeric AS usd_amount,
        taker_token AS token_a_address,
        maker_token AS token_b_address,
        contract_address AS exchange_contract_address,
        tx_hash,
        NULL::integer[] AS trace_address,
        evt_index
    FROM zeroex."view_0x_api_fills"
    where swap_flag is TRUE

    UNION ALL

    -- Matcha
    SELECT
        block_time,
        'Matcha' AS project,
        NULL AS version,
        'Aggregator' AS category,
        "taker" AS trader_a,
        "maker" AS trader_b,
        "taker_token_amount_raw" AS token_a_amount_raw,
        "maker_token_amount_raw" AS token_b_amount_raw,
        NULL::numeric AS usd_amount,
        taker_token AS token_a_address,
        maker_token AS token_b_address,
        contract_address AS exchange_contract_address,
        tx_hash,
        NULL::integer[] AS trace_address,
        evt_index
    FROM zeroex."view_0x_api_fills"
    where affiliate_address ='\x86003b044f70dac0abc80ac8957305b6370893ed'
) dexs
INNER JOIN ethereum.transactions tx
    ON dexs.tx_hash = tx.hash
    AND tx.block_time >= '2021-05-19'
    AND tx.block_time < '2021-05-20'
LEFT JOIN erc20.tokens erc20a ON erc20a.contract_address = dexs.token_a_address
LEFT JOIN erc20.tokens erc20b ON erc20b.contract_address = dexs.token_b_address
LEFT JOIN prices.usd pa ON pa.minute = date_trunc('minute', dexs.block_time)
    AND pa.contract_address = dexs.token_a_address
    AND pa.minute >= '2021-05-19'
    AND pa.minute < '2021-05-20'
LEFT JOIN prices.usd pb ON pb.minute = date_trunc('minute', dexs.block_time)
    AND pb.contract_address = dexs.token_b_address
    AND pb.minute >= '2021-05-19'
    AND pb.minute < '2021-05-20'
WHERE dexs.block_time >= '2021-05-19'
AND dexs.block_time < '2021-05-20'
AND dexs.tx_hash = '\x62a80b28321ea05f7c40180d4f7168598c3728983a81e54ad0078845069fe867'
```

I noticed the duplicity in `dex.trades` is due to `trade_id` field. For the same txn, trace_address and evt_index, there are two different `trade_id`s
![image](https://user-images.githubusercontent.com/34865315/119749720-1866c380-be6e-11eb-9eca-bd3e80b7529e.png)

I believe this happens because the `select` statement that populates `dex.trades` does not sort by project name. Therefore, sometimes it will return Matcha before 1inch, and sometimes the opposite. If I'm right, this will be an issue for any `insert_*.sql` file that produces records for multiple `projects`, which is why we see this issue for Matcha and 0x but not for Uniswap or Sushiswap.

In that case, I see two options:
1. Add an `ORDER BY project` as per this PR - not sure what the performance impact may be
2. Adopt the convention of a single project per `insert_*.sql` file