### PR TITLE
Address null usd values in dex.trades

### DIFF
--- a/ethereum/dex/trades/insert_1inch.sql
+++ b/ethereum/dex/trades/insert_1inch.sql
@@ -223,7 +223,7 @@ SELECT dex.insert_1inch(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -237,8 +237,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_1inch(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='1inch'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='1inch')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_1inch.sql
+++ b/ethereum/dex/trades/insert_1inch.sql
@@ -223,7 +223,7 @@ SELECT dex.insert_1inch(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -237,8 +237,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_1inch(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='1inch'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='1inch')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_1inch_lp.sql
+++ b/ethereum/dex/trades/insert_1inch_lp.sql
@@ -124,7 +124,7 @@ SELECT dex.insert_1inch_lp(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -138,8 +138,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/12 * * * *', $$
     SELECT dex.insert_1inch_lp(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='1inch LP'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='1inch LP')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_1inch_lp.sql
+++ b/ethereum/dex/trades/insert_1inch_lp.sql
@@ -124,7 +124,7 @@ SELECT dex.insert_1inch_lp(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-07-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -138,8 +138,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/12 * * * *', $$
     SELECT dex.insert_1inch_lp(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='1inch LP'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='1inch LP')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_airswap.sql
+++ b/ethereum/dex/trades/insert_airswap.sql
@@ -72,9 +72,9 @@ WITH rows AS (
             NULL::numeric as usd_amount,
             evt_index
         FROM airswap."Light_evt_Swap"
-        
+
         UNION ALL
-        
+
         SELECT
             evt_block_time as block_time,
             'airswap' as project,
@@ -170,7 +170,7 @@ SELECT dex.insert_airswap(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -184,8 +184,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_airswap(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='airswap'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='airswap')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_airswap.sql
+++ b/ethereum/dex/trades/insert_airswap.sql
@@ -72,9 +72,9 @@ WITH rows AS (
             NULL::numeric as usd_amount,
             evt_index
         FROM airswap."Light_evt_Swap"
-
+        
         UNION ALL
-
+        
         SELECT
             evt_block_time as block_time,
             'airswap' as project,
@@ -170,7 +170,7 @@ SELECT dex.insert_airswap(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -184,8 +184,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_airswap(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='airswap'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='airswap')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_balancer.sql
+++ b/ethereum/dex/trades/insert_balancer.sql
@@ -144,7 +144,7 @@ SELECT dex.insert_balancer(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -158,8 +158,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_balancer(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Balancer'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Balancer')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_balancer.sql
+++ b/ethereum/dex/trades/insert_balancer.sql
@@ -144,7 +144,7 @@ SELECT dex.insert_balancer(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -158,8 +158,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_balancer(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Balancer'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Balancer')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_bancor.sql
+++ b/ethereum/dex/trades/insert_bancor.sql
@@ -157,7 +157,7 @@ SELECT dex.insert_bancor(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -171,8 +171,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_bancor(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Bancor Network'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Bancor Network')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_bancor.sql
+++ b/ethereum/dex/trades/insert_bancor.sql
@@ -157,7 +157,7 @@ SELECT dex.insert_bancor(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -171,8 +171,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_bancor(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Bancor Network'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Bancor Network')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_curve.sql
+++ b/ethereum/dex/trades/insert_curve.sql
@@ -120,7 +120,7 @@ SELECT dex.insert_curve(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -134,8 +134,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_curve(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Curve'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Curve')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_curve.sql
+++ b/ethereum/dex/trades/insert_curve.sql
@@ -120,7 +120,7 @@ SELECT dex.insert_curve(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -134,8 +134,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_curve(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Curve'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Curve')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_ddex.sql
+++ b/ethereum/dex/trades/insert_ddex.sql
@@ -159,7 +159,7 @@ SELECT dex.insert_ddex(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -173,8 +173,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_ddex(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='DDEX'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='DDEX')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_ddex.sql
+++ b/ethereum/dex/trades/insert_ddex.sql
@@ -159,7 +159,7 @@ SELECT dex.insert_ddex(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -173,8 +173,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_ddex(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='DDEX'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='DDEX')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_dodo.sql
+++ b/ethereum/dex/trades/insert_dodo.sql
@@ -261,7 +261,7 @@ SELECT dex.insert_dodo(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -275,8 +275,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_dodo(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='dodo'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='dodo')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_dodo.sql
+++ b/ethereum/dex/trades/insert_dodo.sql
@@ -261,7 +261,7 @@ SELECT dex.insert_dodo(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -275,8 +275,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_dodo(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='dodo'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='dodo')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_dydx.sql
+++ b/ethereum/dex/trades/insert_dydx.sql
@@ -182,7 +182,7 @@ SELECT dex.insert_dydx(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -196,8 +196,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_dydx(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='dYdX'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='dYdX')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_dydx.sql
+++ b/ethereum/dex/trades/insert_dydx.sql
@@ -182,7 +182,7 @@ SELECT dex.insert_dydx(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -196,8 +196,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_dydx(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='dYdX'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='dYdX')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_futureswap.sql
+++ b/ethereum/dex/trades/insert_futureswap.sql
@@ -130,7 +130,7 @@ SELECT dex.insert_futureswap(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -144,8 +144,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/12 * * * *', $$
     SELECT dex.insert_futureswap(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Futureswap'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Futureswap')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_futureswap.sql
+++ b/ethereum/dex/trades/insert_futureswap.sql
@@ -130,7 +130,7 @@ SELECT dex.insert_futureswap(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -144,8 +144,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/12 * * * *', $$
     SELECT dex.insert_futureswap(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Futureswap'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Futureswap')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_gnosis_protocol.sql
+++ b/ethereum/dex/trades/insert_gnosis_protocol.sql
@@ -119,7 +119,7 @@ SELECT dex.insert_gnosis_protocol(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -133,8 +133,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_gnosis_protocol(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Gnosis Protocol'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Gnosis Protocol')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_gnosis_protocol.sql
+++ b/ethereum/dex/trades/insert_gnosis_protocol.sql
@@ -119,7 +119,7 @@ SELECT dex.insert_gnosis_protocol(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -133,8 +133,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_gnosis_protocol(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Gnosis Protocol'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Gnosis Protocol')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_idex.sql
+++ b/ethereum/dex/trades/insert_idex.sql
@@ -172,7 +172,7 @@ SELECT dex.insert_idex(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -186,8 +186,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_idex(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='IDEX'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='IDEX')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_idex.sql
+++ b/ethereum/dex/trades/insert_idex.sql
@@ -172,7 +172,7 @@ SELECT dex.insert_idex(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -186,8 +186,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_idex(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='IDEX'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='IDEX')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_kyber.sql
+++ b/ethereum/dex/trades/insert_kyber.sql
@@ -232,7 +232,7 @@ SELECT dex.insert_kyber(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -246,8 +246,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_kyber(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Kyber'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Kyber')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_kyber.sql
+++ b/ethereum/dex/trades/insert_kyber.sql
@@ -232,7 +232,7 @@ SELECT dex.insert_kyber(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -246,8 +246,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_kyber(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Kyber'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Kyber')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_linkswap.sql
+++ b/ethereum/dex/trades/insert_linkswap.sql
@@ -123,7 +123,7 @@ SELECT dex.insert_linkswap(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -137,8 +137,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_linkswap(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='LINKSWAP'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='LINKSWAP')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_linkswap.sql
+++ b/ethereum/dex/trades/insert_linkswap.sql
@@ -123,7 +123,7 @@ SELECT dex.insert_linkswap(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -137,8 +137,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_linkswap(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='LINKSWAP'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='LINKSWAP')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_loopring.sql
+++ b/ethereum/dex/trades/insert_loopring.sql
@@ -199,7 +199,7 @@ SELECT dex.insert_loopring(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -213,8 +213,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/12 * * * *', $$
     SELECT dex.insert_loopring(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Loopring'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Loopring')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_loopring.sql
+++ b/ethereum/dex/trades/insert_loopring.sql
@@ -199,7 +199,7 @@ SELECT dex.insert_loopring(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -213,8 +213,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/12 * * * *', $$
     SELECT dex.insert_loopring(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Loopring'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Loopring')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_mooniswap.sql
+++ b/ethereum/dex/trades/insert_mooniswap.sql
@@ -139,7 +139,7 @@ SELECT dex.insert_mooniswap(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -153,8 +153,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/12 * * * *', $$
     SELECT dex.insert_mooniswap(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Mooniswap'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Mooniswap')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_mooniswap.sql
+++ b/ethereum/dex/trades/insert_mooniswap.sql
@@ -139,7 +139,7 @@ SELECT dex.insert_mooniswap(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -153,8 +153,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/12 * * * *', $$
     SELECT dex.insert_mooniswap(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Mooniswap'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Mooniswap')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_oasis.sql
+++ b/ethereum/dex/trades/insert_oasis.sql
@@ -173,7 +173,7 @@ SELECT dex.insert_oasis(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -187,8 +187,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_oasis(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Oasis'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Oasis')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_oasis.sql
+++ b/ethereum/dex/trades/insert_oasis.sql
@@ -173,7 +173,7 @@ SELECT dex.insert_oasis(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -187,8 +187,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_oasis(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Oasis'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Oasis')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_sushi.sql
+++ b/ethereum/dex/trades/insert_sushi.sql
@@ -123,7 +123,7 @@ SELECT dex.insert_sushi(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -137,8 +137,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_sushi(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Sushiswap'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Sushiswap')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_sushi.sql
+++ b/ethereum/dex/trades/insert_sushi.sql
@@ -123,7 +123,7 @@ SELECT dex.insert_sushi(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -137,8 +137,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_sushi(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Sushiswap'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Sushiswap')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_synthetix.sql
+++ b/ethereum/dex/trades/insert_synthetix.sql
@@ -105,7 +105,7 @@ SELECT dex.insert_synthetix(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -119,8 +119,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_synthetix(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Synthetix'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Synthetix')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_synthetix.sql
+++ b/ethereum/dex/trades/insert_synthetix.sql
@@ -105,7 +105,7 @@ SELECT dex.insert_synthetix(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -119,8 +119,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_synthetix(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Synthetix'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Synthetix')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_tokenlon.sql
+++ b/ethereum/dex/trades/insert_tokenlon.sql
@@ -72,7 +72,7 @@ WITH rows AS (
             evt_tx_hash AS tx_hash,
             NULL::integer[] AS trace_address,
             evt_index
-        FROM zeroex_v2."Exchange2.1_evt_Fill"
+        FROM zeroex_v2."Exchange2.1_evt_Fill" 
         WHERE "feeRecipientAddress" IN ('\x6f7ae872e995f98fcd2a7d3ba17b7ddfb884305f'::BYTEA,'\xb9e29984fe50602e7a619662ebed4f90d93824c7'::BYTEA)
 
         UNION ALL
@@ -94,7 +94,7 @@ WITH rows AS (
             evt_tx_hash AS tx_hash,
             NULL::integer[] AS trace_address,
             evt_index
-        FROM zeroex_v2."Exchange2.1_evt_Fill"
+        FROM zeroex_v2."Exchange2.1_evt_Fill" 
         WHERE "takerAddress" IN ('\x8d90113a1e286a5ab3e496fbd1853f265e5913c6'::BYTEA)
 
         UNION ALL
@@ -179,7 +179,7 @@ SELECT dex.insert_tokenlon_dex(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -193,8 +193,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_tokenlon_dex(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project = 'Tokenlon'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project = 'Tokenlon')),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_tokenlon.sql
+++ b/ethereum/dex/trades/insert_tokenlon.sql
@@ -72,7 +72,7 @@ WITH rows AS (
             evt_tx_hash AS tx_hash,
             NULL::integer[] AS trace_address,
             evt_index
-        FROM zeroex_v2."Exchange2.1_evt_Fill" 
+        FROM zeroex_v2."Exchange2.1_evt_Fill"
         WHERE "feeRecipientAddress" IN ('\x6f7ae872e995f98fcd2a7d3ba17b7ddfb884305f'::BYTEA,'\xb9e29984fe50602e7a619662ebed4f90d93824c7'::BYTEA)
 
         UNION ALL
@@ -94,7 +94,7 @@ WITH rows AS (
             evt_tx_hash AS tx_hash,
             NULL::integer[] AS trace_address,
             evt_index
-        FROM zeroex_v2."Exchange2.1_evt_Fill" 
+        FROM zeroex_v2."Exchange2.1_evt_Fill"
         WHERE "takerAddress" IN ('\x8d90113a1e286a5ab3e496fbd1853f265e5913c6'::BYTEA)
 
         UNION ALL
@@ -179,7 +179,7 @@ SELECT dex.insert_tokenlon_dex(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -193,8 +193,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_tokenlon_dex(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project = 'Tokenlon'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project = 'Tokenlon')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_uniswap.sql
+++ b/ethereum/dex/trades/insert_uniswap.sql
@@ -210,7 +210,7 @@ SELECT dex.insert_uniswap(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -224,8 +224,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_uniswap(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap'),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap')),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        (SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_uniswap.sql
+++ b/ethereum/dex/trades/insert_uniswap.sql
@@ -210,7 +210,7 @@ SELECT dex.insert_uniswap(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -224,8 +224,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_uniswap(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap'),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap')),
-        (SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'));
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_zeroex.sql
+++ b/ethereum/dex/trades/insert_zeroex.sql
@@ -242,7 +242,7 @@ SELECT dex.insert_zeroex(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    (SELECT max(number) FROM ethereum.blocks)
+    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -256,8 +256,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_zeroex(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project IN ('0x Native', '0x API', 'Matcha')),
-        (SELECT now()),
+        (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project IN ('0x Native', '0x API', 'Matcha'))),
-        (SELECT MAX(number) FROM ethereum.blocks));
+        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_zeroex.sql
+++ b/ethereum/dex/trades/insert_zeroex.sql
@@ -242,7 +242,7 @@ SELECT dex.insert_zeroex(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
-    SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'
+    (SELECT max(number) FROM ethereum.blocks)
 )
 WHERE NOT EXISTS (
     SELECT *
@@ -256,8 +256,8 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_zeroex(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project IN ('0x Native', '0x API', 'Matcha')),
-        (SELECT now() - interval '20 minutes'),
+        (SELECT now()),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project IN ('0x Native', '0x API', 'Matcha'))),
-        SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');
+        (SELECT MAX(number) FROM ethereum.blocks));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/lending/borrow.sql
+++ b/ethereum/lending/borrow.sql
@@ -205,7 +205,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS lending_borrow_tr_addr_uniq_idx ON lending.bor
 CREATE UNIQUE INDEX IF NOT EXISTS lending_borrow_evt_index_uniq_idx ON lending.borrow (tx_hash, evt_index);
 CREATE INDEX IF NOT EXISTS lending_borrow_block_time_idx ON lending.borrow USING BRIN (block_time);
 
-SELECT lending.insert_borrow('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), (SELECT MAX(number) FROM ethereum.blocks)) WHERE NOT EXISTS (SELECT * FROM lending.borrow LIMIT 1);
+SELECT lending.insert_borrow('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes') WHERE NOT EXISTS (SELECT * FROM lending.borrow LIMIT 1);
 INSERT INTO cron.job (schedule, command)
-VALUES ('14 1 * * *', $$SELECT lending.insert_borrow((SELECT max(block_time) - interval '2 days' FROM lending.borrow), (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM lending.borrow)), (SELECT MAX(number) FROM ethereum.blocks));$$)
+VALUES ('14 1 * * *', $$SELECT lending.insert_borrow((SELECT max(block_time) - interval '2 days' FROM lending.borrow), (SELECT now() - interval '20 minutes'), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM lending.borrow)), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/lending/borrow.sql
+++ b/ethereum/lending/borrow.sql
@@ -205,7 +205,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS lending_borrow_tr_addr_uniq_idx ON lending.bor
 CREATE UNIQUE INDEX IF NOT EXISTS lending_borrow_evt_index_uniq_idx ON lending.borrow (tx_hash, evt_index);
 CREATE INDEX IF NOT EXISTS lending_borrow_block_time_idx ON lending.borrow USING BRIN (block_time);
 
-SELECT lending.insert_borrow('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes') WHERE NOT EXISTS (SELECT * FROM lending.borrow LIMIT 1);
+SELECT lending.insert_borrow('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), (SELECT MAX(number) FROM ethereum.blocks)) WHERE NOT EXISTS (SELECT * FROM lending.borrow LIMIT 1);
 INSERT INTO cron.job (schedule, command)
-VALUES ('14 1 * * *', $$SELECT lending.insert_borrow((SELECT max(block_time) - interval '2 days' FROM lending.borrow), (SELECT now() - interval '20 minutes'), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM lending.borrow)), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');$$)
+VALUES ('14 1 * * *', $$SELECT lending.insert_borrow((SELECT max(block_time) - interval '2 days' FROM lending.borrow), (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM lending.borrow)), (SELECT MAX(number) FROM ethereum.blocks));$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/lending/collateral_change.sql
+++ b/ethereum/lending/collateral_change.sql
@@ -263,7 +263,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS lending_collateral_change_tr_addr_uniq_idx ON 
 CREATE UNIQUE INDEX IF NOT EXISTS lending_collateral_change_evt_index_uniq_idx ON lending.collateral_change (tx_hash, evt_index);
 CREATE INDEX IF NOT EXISTS lending_collateral_change_block_time_idx ON lending.collateral_change USING BRIN (block_time);
 
-SELECT lending.insert_collateral_changes('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), (SELECT MAX(number) FROM ethereum.blocks)) WHERE NOT EXISTS (SELECT * FROM lending.collateral_change LIMIT 1);
+SELECT lending.insert_collateral_changes('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes') WHERE NOT EXISTS (SELECT * FROM lending.collateral_change LIMIT 1);
 INSERT INTO cron.job (schedule, command)
-VALUES ('14 0 * * *', $$SELECT lending.insert_collateral_changes((SELECT max(block_time) - interval '2 days' FROM lending.collateral_change), (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM lending.collateral_change)), (SELECT MAX(number) FROM ethereum.blocks));$$)
+VALUES ('14 0 * * *', $$SELECT lending.insert_collateral_changes((SELECT max(block_time) - interval '2 days' FROM lending.collateral_change), (SELECT now() - interval '20 minutes'), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM lending.collateral_change)), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/lending/collateral_change.sql
+++ b/ethereum/lending/collateral_change.sql
@@ -263,7 +263,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS lending_collateral_change_tr_addr_uniq_idx ON 
 CREATE UNIQUE INDEX IF NOT EXISTS lending_collateral_change_evt_index_uniq_idx ON lending.collateral_change (tx_hash, evt_index);
 CREATE INDEX IF NOT EXISTS lending_collateral_change_block_time_idx ON lending.collateral_change USING BRIN (block_time);
 
-SELECT lending.insert_collateral_changes('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes') WHERE NOT EXISTS (SELECT * FROM lending.collateral_change LIMIT 1);
+SELECT lending.insert_collateral_changes('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), (SELECT MAX(number) FROM ethereum.blocks)) WHERE NOT EXISTS (SELECT * FROM lending.collateral_change LIMIT 1);
 INSERT INTO cron.job (schedule, command)
-VALUES ('14 0 * * *', $$SELECT lending.insert_collateral_changes((SELECT max(block_time) - interval '2 days' FROM lending.collateral_change), (SELECT now() - interval '20 minutes'), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM lending.collateral_change)), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');$$)
+VALUES ('14 0 * * *', $$SELECT lending.insert_collateral_changes((SELECT max(block_time) - interval '2 days' FROM lending.collateral_change), (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM lending.collateral_change)), (SELECT MAX(number) FROM ethereum.blocks));$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/lending/repay.sql
+++ b/ethereum/lending/repay.sql
@@ -203,7 +203,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS lending_repays_tr_addr_uniq_idx ON lending.rep
 CREATE UNIQUE INDEX IF NOT EXISTS lending_repays_evt_index_uniq_idx ON lending.repay (tx_hash, evt_index);
 CREATE INDEX IF NOT EXISTS lending_repays_block_time_idx ON lending.repay USING BRIN (block_time);
 
-SELECT lending.insert_repays('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes') WHERE NOT EXISTS (SELECT * FROM lending.repay LIMIT 1);
+SELECT lending.insert_repays('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), (SELECT MAX(number) FROM ethereum.blocks)) WHERE NOT EXISTS (SELECT * FROM lending.repay LIMIT 1);
 INSERT INTO cron.job (schedule, command)
-VALUES ('14 2 * * *', $$SELECT lending.insert_repays((SELECT max(block_time) - interval '2 days' FROM lending.repay), (SELECT now() - interval '20 minutes'), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM lending.repay)), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');$$)
+VALUES ('14 2 * * *', $$SELECT lending.insert_repays((SELECT max(block_time) - interval '2 days' FROM lending.repay), (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM lending.repay)), (SELECT MAX(number) FROM ethereum.blocks));$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/lending/repay.sql
+++ b/ethereum/lending/repay.sql
@@ -203,7 +203,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS lending_repays_tr_addr_uniq_idx ON lending.rep
 CREATE UNIQUE INDEX IF NOT EXISTS lending_repays_evt_index_uniq_idx ON lending.repay (tx_hash, evt_index);
 CREATE INDEX IF NOT EXISTS lending_repays_block_time_idx ON lending.repay USING BRIN (block_time);
 
-SELECT lending.insert_repays('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), (SELECT MAX(number) FROM ethereum.blocks)) WHERE NOT EXISTS (SELECT * FROM lending.repay LIMIT 1);
+SELECT lending.insert_repays('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes') WHERE NOT EXISTS (SELECT * FROM lending.repay LIMIT 1);
 INSERT INTO cron.job (schedule, command)
-VALUES ('14 2 * * *', $$SELECT lending.insert_repays((SELECT max(block_time) - interval '2 days' FROM lending.repay), (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM lending.repay)), (SELECT MAX(number) FROM ethereum.blocks));$$)
+VALUES ('14 2 * * *', $$SELECT lending.insert_repays((SELECT max(block_time) - interval '2 days' FROM lending.repay), (SELECT now() - interval '20 minutes'), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM lending.repay)), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/oneinch/swaps.sql
+++ b/ethereum/oneinch/swaps.sql
@@ -205,8 +205,8 @@ CREATE INDEX IF NOT EXISTS oneinch_swaps_idx ON oneinch.swaps USING BRIN (block_
 CREATE INDEX IF NOT EXISTS oneinch_swaps_idx_tx_from ON oneinch.swaps (tx_from);
 
 -- backfill
-SELECT oneinch.insert_swap('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes') WHERE NOT EXISTS (SELECT * FROM oneinch.swaps LIMIT 1);
+SELECT oneinch.insert_swap('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), (SELECT MAX(number) FROM ethereum.blocks)) WHERE NOT EXISTS (SELECT * FROM oneinch.swaps LIMIT 1);
 
 INSERT INTO cron.job (schedule, command)
-VALUES ('*/15 * * * *', $$SELECT oneinch.insert_swap((SELECT max(block_time) - interval '2 days' FROM oneinch.swaps), (SELECT now() - interval '20 minutes'), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM oneinch.swaps)), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');$$)
+VALUES ('*/15 * * * *', $$SELECT oneinch.insert_swap((SELECT max(block_time) - interval '2 days' FROM oneinch.swaps), (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM oneinch.swaps)), (SELECT MAX(number) FROM ethereum.blocks));$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/oneinch/swaps.sql
+++ b/ethereum/oneinch/swaps.sql
@@ -205,8 +205,8 @@ CREATE INDEX IF NOT EXISTS oneinch_swaps_idx ON oneinch.swaps USING BRIN (block_
 CREATE INDEX IF NOT EXISTS oneinch_swaps_idx_tx_from ON oneinch.swaps (tx_from);
 
 -- backfill
-SELECT oneinch.insert_swap('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), (SELECT MAX(number) FROM ethereum.blocks)) WHERE NOT EXISTS (SELECT * FROM oneinch.swaps LIMIT 1);
+SELECT oneinch.insert_swap('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes') WHERE NOT EXISTS (SELECT * FROM oneinch.swaps LIMIT 1);
 
 INSERT INTO cron.job (schedule, command)
-VALUES ('*/15 * * * *', $$SELECT oneinch.insert_swap((SELECT max(block_time) - interval '2 days' FROM oneinch.swaps), (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM oneinch.swaps)), (SELECT MAX(number) FROM ethereum.blocks));$$)
+VALUES ('*/15 * * * *', $$SELECT oneinch.insert_swap((SELECT max(block_time) - interval '2 days' FROM oneinch.swaps), (SELECT now() - interval '20 minutes'), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM oneinch.swaps)), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/oneproto/swaps.sql
+++ b/ethereum/oneproto/swaps.sql
@@ -199,8 +199,8 @@ CREATE INDEX IF NOT EXISTS oneproto_swaps_idx_1 ON oneproto.swaps USING BRIN (bl
 CREATE INDEX IF NOT EXISTS oneproto_swaps_idx_tx_from ON oneproto.swaps (tx_from);
 
 -- backfill
-SELECT oneproto.insert_swap('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes') WHERE NOT EXISTS (SELECT * FROM oneproto.swaps LIMIT 1);
+SELECT oneproto.insert_swap('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), (SELECT MAX(number) FROM ethereum.blocks)) WHERE NOT EXISTS (SELECT * FROM oneproto.swaps LIMIT 1);
 
 INSERT INTO cron.job (schedule, command)
-VALUES ('*/17 * * * *', $$SELECT oneproto.insert_swap((SELECT max(block_time) - interval '2 days' FROM oneproto.swaps), (SELECT now() - interval '20 minutes'), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM oneproto.swaps)), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');$$)
+VALUES ('*/17 * * * *', $$SELECT oneproto.insert_swap((SELECT max(block_time) - interval '2 days' FROM oneproto.swaps), (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM oneproto.swaps)), (SELECT MAX(number) FROM ethereum.blocks));$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/oneproto/swaps.sql
+++ b/ethereum/oneproto/swaps.sql
@@ -199,8 +199,8 @@ CREATE INDEX IF NOT EXISTS oneproto_swaps_idx_1 ON oneproto.swaps USING BRIN (bl
 CREATE INDEX IF NOT EXISTS oneproto_swaps_idx_tx_from ON oneproto.swaps (tx_from);
 
 -- backfill
-SELECT oneproto.insert_swap('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), (SELECT MAX(number) FROM ethereum.blocks)) WHERE NOT EXISTS (SELECT * FROM oneproto.swaps LIMIT 1);
+SELECT oneproto.insert_swap('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes') WHERE NOT EXISTS (SELECT * FROM oneproto.swaps LIMIT 1);
 
 INSERT INTO cron.job (schedule, command)
-VALUES ('*/17 * * * *', $$SELECT oneproto.insert_swap((SELECT max(block_time) - interval '2 days' FROM oneproto.swaps), (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM oneproto.swaps)), (SELECT MAX(number) FROM ethereum.blocks));$$)
+VALUES ('*/17 * * * *', $$SELECT oneproto.insert_swap((SELECT max(block_time) - interval '2 days' FROM oneproto.swaps), (SELECT now() - interval '20 minutes'), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM oneproto.swaps)), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/onesplit/swaps.sql
+++ b/ethereum/onesplit/swaps.sql
@@ -211,8 +211,8 @@ CREATE INDEX IF NOT EXISTS onesplit_swaps_idx ON onesplit.swaps USING BRIN (bloc
 CREATE INDEX IF NOT EXISTS onesplit_swaps_idx_tx_from ON onesplit.swaps (tx_from);
 
 --backfill
-SELECT onesplit.insert_swap('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes') WHERE NOT EXISTS (SELECT * FROM onesplit.swaps LIMIT 1);
+SELECT onesplit.insert_swap('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), (SELECT MAX(number) FROM ethereum.blocks)) WHERE NOT EXISTS (SELECT * FROM onesplit.swaps LIMIT 1);
 
 INSERT INTO cron.job (schedule, command)
-VALUES ('*/14 * * * *', $$SELECT onesplit.insert_swap((SELECT max(block_time) - interval '2 days' FROM onesplit.swaps), (SELECT now() - interval '20 minutes'), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM onesplit.swaps)), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');$$)
+VALUES ('*/14 * * * *', $$SELECT onesplit.insert_swap((SELECT max(block_time) - interval '2 days' FROM onesplit.swaps), (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM onesplit.swaps)), (SELECT MAX(number) FROM ethereum.blocks));$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/onesplit/swaps.sql
+++ b/ethereum/onesplit/swaps.sql
@@ -211,8 +211,8 @@ CREATE INDEX IF NOT EXISTS onesplit_swaps_idx ON onesplit.swaps USING BRIN (bloc
 CREATE INDEX IF NOT EXISTS onesplit_swaps_idx_tx_from ON onesplit.swaps (tx_from);
 
 --backfill
-SELECT onesplit.insert_swap('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), (SELECT MAX(number) FROM ethereum.blocks)) WHERE NOT EXISTS (SELECT * FROM onesplit.swaps LIMIT 1);
+SELECT onesplit.insert_swap('2019-01-01', (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes') WHERE NOT EXISTS (SELECT * FROM onesplit.swaps LIMIT 1);
 
 INSERT INTO cron.job (schedule, command)
-VALUES ('*/14 * * * *', $$SELECT onesplit.insert_swap((SELECT max(block_time) - interval '2 days' FROM onesplit.swaps), (SELECT now()), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM onesplit.swaps)), (SELECT MAX(number) FROM ethereum.blocks));$$)
+VALUES ('*/14 * * * *', $$SELECT onesplit.insert_swap((SELECT max(block_time) - interval '2 days' FROM onesplit.swaps), (SELECT now() - interval '20 minutes'), (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '2 days' FROM onesplit.swaps)), SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes');$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;


### PR DESCRIPTION
## Context
Many trades in dex.trades have missing usd_amounts despite the values being in the prices.usd table (see https://duneanalytics.com/queries/56952). This seems to be caused by the prices.usd table lagging behind by 5 mins (due to implementation details of the prices stream). So if a insert job runs at time `t0` then it is likely to miss any prices for `t0` - approx 5 mins.

## How was this fixed
- This is addressed by updating the insert job to insert for transactions up until 20 minutes ago. The prices should defininately have been streamed by then and thus will be reported in dex.trades as null.

## Notes
- [ ] Wipe all the insert.jobs `delete from cron.job where command like %dex.insert%`
- [ ] The whole of dex.trades will need to be refilled to remove the existing null usd_values that are not valid.
