### PR TITLE
Remove addresses that have been manually labeled

### DIFF
--- a/labels/ethereum/balancer_arbitrage.sql
+++ b/labels/ethereum/balancer_arbitrage.sql
@@ -12,6 +12,12 @@ AND ((t1.project = 'Balancer' AND t2.project = 'Uniswap') or (t1.project = 'Unis
 INNER JOIN ethereum.transactions t ON t.hash = t1.tx_hash
 WHERE t1.block_time >= '{{timestamp}}'
 AND t2.block_time >= '{{timestamp}}'
+AND t.to NOT IN (
+    select address 
+    from labels.labels 
+    where author = 'balancerlabs'
+    and type = 'balancer_source'
+)
 UNION ALL
 SELECT
     DISTINCT(t.to) AS address,
@@ -27,3 +33,9 @@ AND ((t1.project = 'Balancer' AND t2.project = 'Sushiswap') or (t1.project = 'Su
 INNER JOIN ethereum.transactions t ON t.hash = t1.tx_hash
 WHERE t1.block_time >= '{{timestamp}}'
 AND t2.block_time >= '{{timestamp}}'
+AND t.to NOT IN (
+    select address 
+    from labels.labels 
+    where author = 'balancerlabs'
+    and type = 'balancer_source'
+)


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
