### PR TITLE
include HOPR in price

### DIFF
--- a/prices/prices.ini
+++ b/prices/prices.ini
@@ -1684,3 +1684,9 @@ id = farm-harvest-finance
 symbol = FARM
 address = 0xa0246c9032bC3A600820415aE600c6388619A14D
 decimals = 18
+
+[assets.hopr_hopr_network]
+id = hopr_hopr_network
+symbol = HOPR
+address = 0xa0246c9032bC3A600820415aE600c6388619A14D
+decimals = 18


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
