### PR TITLE
Set call trace address on paraswap to avoid duplicates

### DIFF
--- a/ethereum/dex/trades/insert_paraswap.sql
+++ b/ethereum/dex/trades/insert_paraswap.sql
@@ -155,7 +155,7 @@ WITH rows AS (
             LEFT(RIGHT(swaps.path::text, 44), 42)::bytea AS token_b_address,
             swaps."contract_address" AS exchange_contract_address,
             swaps."call_tx_hash" AS tx_hash,
-            NULL::integer[] AS trace_address,
+            swaps.call_trace_address AS trace_address,
             NULL::int8 AS evt_index
         FROM paraswap."AugustusSwapper5.0_call_swapOnUniswap" swaps
 
@@ -173,7 +173,7 @@ WITH rows AS (
             LEFT(RIGHT(swaps.path::text, 44), 42)::bytea AS token_b_address,
             swaps."contract_address" AS exchange_contract_address,
             swaps."call_tx_hash" AS tx_hash,
-            NULL::integer[] AS trace_address,
+            swaps.call_trace_address AS trace_address,
             NULL::int8 AS evt_index
         FROM paraswap."AugustusSwapper5.0_call_swapOnUniswapFork" swaps
 


### PR DESCRIPTION
## Context
Currently there are two unique indexes on the dex.trades table.
- `CREATE UNIQUE INDEX IF NOT EXISTS dex_trades_tr_addr_uniq_idx ON dex.trades (tx_hash, trace_address, trade_id);`
- `CREATE UNIQUE INDEX IF NOT EXISTS dex_trades_evt_index_uniq_idx ON dex.trades (tx_hash, evt_index, trade_id);`

This means in order to avoid duplicates at least one of these tuples need to contain non-null values.

## The problem
In the paraswap query the call tables are not setting the `trace_address` which results in the unique index not catching duplicates.

## The solution
Set the `trace_address` to `call_trace_address`.
