### PR TITLE
Fix issue410

### DIFF
--- a/ethereum/dex/view_token_prices.sql
+++ b/ethereum/dex/view_token_prices.sql
@@ -10,9 +10,10 @@ CREATE MATERIALIZED VIEW dex.view_token_prices AS (
     ), dex_trades AS (
         SELECT
             token_a_address as contract_address,
-            usd_amount/token_a_amount as price,
+            coalesce(usd_amount/token_a_amount, usd_amount/(token_a_amount_raw/10^decimals)) AS price,
             block_time
         FROM dex.trades
+        LEFT JOIN erc20.tokens ON contract_address = token_a_address
         WHERE 1=1
         AND usd_amount  > 0
         AND category = 'DEX'
@@ -23,9 +24,10 @@ CREATE MATERIALIZED VIEW dex.view_token_prices AS (
 
         SELECT
             token_b_address as contract_address,
-            usd_amount/token_b_amount as price,
+            coalesce(usd_amount/token_b_amount, usd_amount/(token_b_amount_raw/10^decimals)) AS price,
             block_time
         FROM dex.trades
+        LEFT JOIN erc20.tokens ON contract_address = token_b_address
         WHERE 1=1
         AND usd_amount  > 0
         AND category = 'DEX'

--- a/ethereum/dex/view_token_prices.sql
+++ b/ethereum/dex/view_token_prices.sql
@@ -17,7 +17,7 @@ CREATE MATERIALIZED VIEW dex.view_token_prices AS (
         WHERE 1=1
         AND usd_amount  > 0
         AND category = 'DEX'
-        AND token_a_amount > 0
+        AND token_a_amount_raw > 0
         AND token_a_address NOT IN (SELECT contract_address FROM tokens_in_prices_usd)
 
         UNION ALL
@@ -31,7 +31,7 @@ CREATE MATERIALIZED VIEW dex.view_token_prices AS (
         WHERE 1=1
         AND usd_amount  > 0
         AND category = 'DEX'
-        AND token_b_amount > 0
+        AND token_b_amount_raw > 0
         AND token_b_address NOT IN (SELECT contract_address FROM tokens_in_prices_usd)
     )
 


### PR DESCRIPTION
Please double check. I used `coalesce` to prioritise the original calculation of `usd_amount/token_a_amount`. `LEFT JOIN` ensures the view is still functional even in cases where token is not yet present in `erc20.tokens`.