### PR TITLE
clipper: add Clipper view_trades table

### DIFF
--- a/ethereum/clipper/view_trades.sql
+++ b/ethereum/clipper/view_trades.sql
@@ -1,0 +1,29 @@
+CREATE OR REPLACE VIEW clipper.view_trades (
+    block_time,
+    project,
+    version,
+    trader_a,
+    trader_b,
+    token_a_amount_raw,
+    token_b_amount_raw,
+    token_a_address,
+    token_b_address,
+    exchange_contract_address,
+    tx_hash,
+    trace_address,
+    evt_index
+) AS SELECT
+    evt_block_time AS block_time,
+    'Clipper' AS project,
+    NULL::text AS version,
+    recipient AS trader_a,
+    NULL::bytea AS trader_b,
+    "inAmount" AS token_a_amount_raw,
+    "outAmount" AS token_b_amount_raw,
+    "inAsset" as token_a_address,
+    "outAsset" as token_b_address,
+    contract_address AS exchange_contract_address,
+    evt_tx_hash AS tx_hash,
+    NULL::integer[] AS trace_address,
+    evt_index
+FROM clipper."ClipperExchangeInterface_evt_Swapped"


### PR DESCRIPTION
I've checked that:

* [ x ] the query produces the intended results
* [ x ] the folder name matches the schema name
* [ x ] the schema name exists in Dune
* [ x ] views are prefixed with `view_`, functions with `fn_`.
* [ x ] the filename matches the defined view, table or function and ends with .sql
* [ x ] each file has only one view, table or function defined  
* [ x ] column names are `lowercase_snake_cased`
