### PR TITLE
Add Coti price

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode

--- a/prices/prices.ini
+++ b/prices/prices.ini
@@ -1732,3 +1732,9 @@ id = mm-mmtoken
 symbol = MM
 address = 0xa283aA7CfBB27EF0cfBcb2493dD9F4330E0fd304
 decimals = 18
+
+[assets.govi_govi]
+id = govi-govi
+symbol = GOVI
+address = 0xeeaa40b28a2d1b0b08f6f97bb1dd4b75316c6107
+decimals = 18


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

* [x] All of the above N/A. 
* [x] Adding asset to prices list. Asset taken from CoinPaprika, and properties added to `.ini` file, per `README` instructions.