### PR TITLE
Fill missing nft prices helper query

### DIFF
--- a/ethereum/nft/trades/helper_queries.sql
+++ b/ethereum/nft/trades/helper_queries.sql
@@ -1,0 +1,31 @@
+-- Sometimes the prices table is updated with a new token and tables like nft.trades
+-- is not backfilled.
+-- This query will find those missing prices and fill them
+UPDATE
+	nft.trades
+SET
+	usd_amount = new_prices.new_price
+FROM
+	(
+		SELECT
+			n.platform,
+			n.tx_hash,
+			n.trace_address,
+			n.evt_index,
+			n.trade_id,
+			p.price as new_price
+		FROM
+			nft.trades n
+			LEFT JOIN prices.usd p ON p.contract_address = n.currency_contract
+			AND date_trunc('minute', n.block_time) = p."minute"
+		WHERE
+			usd_amount IS NULL
+			AND p.symbol IS NOT NULL
+	) as new_prices
+where
+	trades.platform = new_prices.platform
+	AND trades.tx_hash = new_prices.tx_hash
+	AND COALESCE(trades.trace_address, '{-1}') = COALESCE(new_prices.trace_address, '{-1}')
+	AND COALESCE(trades.evt_index, -1) = COALESCE(new_prices.evt_index, -1)
+	AND trades.trade_id = new_prices.trade_id;
+

--- a/ethereum/nft/trades/helper_queries.sql
+++ b/ethereum/nft/trades/helper_queries.sql
@@ -25,6 +25,8 @@ FROM
 where
 	trades.platform = new_prices.platform
 	AND trades.tx_hash = new_prices.tx_hash
+	-- These coalesces are to handle the times these values are null
+	-- because in postgres NULL = NULL equals NULL :face_palm:
 	AND COALESCE(trades.trace_address, '{-1}') = COALESCE(new_prices.trace_address, '{-1}')
 	AND COALESCE(trades.evt_index, -1) = COALESCE(new_prices.evt_index, -1)
 	AND trades.trade_id = new_prices.trade_id;


### PR DESCRIPTION
## Context
There are cases where the nft.trades table can have a null `usd_amount` even though a relevant price for the row exists in the prices.usd table. One reason for this is that a given token was added after a given row had already been inserted into the table. The new price does not fill historically relevant rows in other tables.

It can be cumbersome to refill the table when all you want is to update the price.

## What was done
This PR just adds a query that can be run to find the rows that have null prices even though a price exists and then updates it with that price.
