### PR TITLE
Add index to usd amount on dex.trades

### DIFF
--- a/ethereum/dex/trades/trades.sql
+++ b/ethereum/dex/trades/trades.sql
@@ -32,3 +32,4 @@ CREATE INDEX IF NOT EXISTS dex_trades_block_time_idx ON dex.trades USING BRIN (b
 CREATE INDEX IF NOT EXISTS dex_trades_token_a_idx ON dex.trades (token_a_address);
 CREATE INDEX IF NOT EXISTS dex_trades_token_b_idx ON dex.trades (token_b_address);
 CREATE INDEX IF NOT EXISTS dex_trades_block_time_project_idx ON dex.trades (block_time, project);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS dex_trades_usd_amount_idx ON dex.trades (usd_amount);


### PR DESCRIPTION
## Context
The primary purpose for this pr is to make my query that upserts missing null prices run much faster. However when looking at the query db I can see there are  approx 800 queries that would benefit from this index.
