### PR TITLE
Remove NFT Trades duplicate lines

### DIFF
--- a/ethereum/nft/trades/insert_cryptopunks.sql
+++ b/ethereum/nft/trades/insert_cryptopunks.sql
@@ -128,7 +128,6 @@ rows AS (
         trades.evt_tx_hash AS tx_hash,
         trades.evt_block_number AS block_number,
         -- Sometimes multiple NFT transfers occur in a given trade; the 'array' fields below provide info for these use cases 
-        erc.token_id_array AS nft_token_ids_array,
         trades.token_id_array AS nft_token_ids_array,
         trades.from_array AS senders_array,
         trades.to_array AS recipients_array,

--- a/ethereum/nft/trades/insert_foundation.sql
+++ b/ethereum/nft/trades/insert_foundation.sql
@@ -111,7 +111,6 @@ rows AS (
         trades.evt_block_number AS block_number,
         -- Sometimes multiple NFT transfers occur in a given trade; the 'array' fields below provide info for these use cases 
         erc.token_id_array AS nft_token_ids_array,
-        erc.token_id_array AS nft_token_ids_array,
         erc.from_array AS senders_array,
         erc.to_array AS recipients_array,
         erc.erc_type_array AS erc_types_array,

--- a/ethereum/nft/trades/insert_opensea.sql
+++ b/ethereum/nft/trades/insert_opensea.sql
@@ -141,7 +141,6 @@ rows AS (
         trades.evt_block_number,
         -- Sometimes multiple NFT transfers occur in a given trade; the 'array' fields below provide info for these use cases 
         erc.token_id_array AS nft_token_ids_array,
-        erc.token_id_array AS nft_token_ids_array,
         erc.from_array AS senders_array,
         erc.to_array AS recipients_array,
         erc.erc_type_array AS erc_types_array,

--- a/ethereum/nft/trades/insert_rarible.sql
+++ b/ethereum/nft/trades/insert_rarible.sql
@@ -340,7 +340,6 @@ rows AS (
         trades.evt_block_number AS block_number,
         -- Sometimes multiple NFT transfers occur in a given trade; the 'array' fields below provide info for these use cases 
         erc.token_id_array AS nft_token_ids_array,
-        erc.token_id_array AS nft_token_ids_array,
         erc.from_array AS senders_array,
         erc.to_array AS recipients_array,
         erc.erc_type_array AS erc_types_array,


### PR DESCRIPTION
The files in this PR have already been written into Postgres. While merging and writing PR #430 to the database, we needed to remove some duplicate lines in the process. These changes are reflected in this PR.