### PR TITLE
Add renBTC to Curve's `view_trades`

### DIFF
--- a/ethereum/curvefi/view_trades.sql
+++ b/ethereum/curvefi/view_trades.sql
@@ -465,13 +465,11 @@ SELECT
     tokens_bought AS token_a_amount_raw,
     tokens_sold AS token_b_amount_raw,
     CASE
-        --change address back to renBTC's, right now Dune only tracks WBTC price
-        WHEN bought_id = 0 THEN '\x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'::bytea
+        WHEN bought_id = 0 THEN '\xEB4C2781e4ebA804CE9a9803C67d0893436bB27D'::bytea
         WHEN bought_id = 1 THEN '\x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'::bytea
     END as token_a_address,
     CASE
-        --change address back to renBTC's, right now Dune only tracks WBTC price
-        WHEN sold_id = 0 THEN '\x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'::bytea
+        WHEN sold_id = 0 THEN '\xEB4C2781e4ebA804CE9a9803C67d0893436bB27D'::bytea
         WHEN sold_id = 1 THEN '\x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'::bytea
     END as token_b_address,
     contract_address AS exchange_contract_address,
@@ -491,14 +489,12 @@ SELECT
     tokens_bought AS token_a_amount_raw,
     tokens_sold AS token_b_amount_raw,
     CASE
-        --change address back to renBTC's, right now Dune only tracks WBTC price
-        WHEN bought_id = 0 THEN '\x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'::bytea
+        WHEN bought_id = 0 THEN '\xEB4C2781e4ebA804CE9a9803C67d0893436bB27D'::bytea
         WHEN bought_id = 1 THEN '\x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'::bytea
         WHEN bought_id = 2 THEN '\xfE18be6b3Bd88A2D2A7f928d00292E7a9963CfC6'::bytea
     END as token_a_address,
     CASE
-        --change address back to renBTC's, right now Dune only tracks WBTC price
-        WHEN sold_id = 0 THEN '\x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'::bytea
+        WHEN sold_id = 0 THEN '\xEB4C2781e4ebA804CE9a9803C67d0893436bB27D'::bytea
         WHEN sold_id = 1 THEN '\x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'::bytea
         WHEN sold_id = 2 THEN '\xfE18be6b3Bd88A2D2A7f928d00292E7a9963CfC6'::bytea
     END as token_b_address,


### PR DESCRIPTION
It appears for some reason related to the price feed, when this view was created id_0 was attributed to WBTC instead of renBTC. This causes all swaps between renBTC and WBTC on Curve in `dex.trades` to be classified as swaps between WBTC and WBTC (see https://dune.xyz/queries/103798)

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
