### PR TITLE
Remove stETH from prices.ini

### DIFF
--- a/prices/prices.ini
+++ b/prices/prices.ini
@@ -1762,9 +1762,3 @@ id = mona-monavale
 symbol = mona
 address = 0x275f5Ad03be0Fa221B4C6649B8AeE09a42D9412A
 decimals = 18
-
-[assets.steth_lido_staked_ether]
-id = steth-lido-staked-ether
-symbol = stETH
-address = 0xae7ab96520de3a18e5e111b5eaab095312d7fe84
-decimals = 18


### PR DESCRIPTION
Removing stETH from the prices table. Lack of historical data from coinpaprika was causing existing dashboards to be out of date. By removing this, we can revert to pulling it's price from `dex.view_token_prices`.

I've checked that:

* [ x] the query produces the intended results
* [ x] the folder name matches the schema name
* [ x] the schema name exists in Dune
* [ x] views are prefixed with `view_`, functions with `fn_`.
* [ x] the filename matches the defined view, table or function and ends with .sql
* [ x] each file has only one view, table or function defined  
* [ x] column names are `lowercase_snake_cased`
