### PR TITLE
Adding LQTY to prices.ini

### DIFF
--- a/prices/prices.ini
+++ b/prices/prices.ini
@@ -1768,3 +1768,9 @@ id = steth-lido-staked-ether
 symbol = stETH
 address = 0xae7ab96520de3a18e5e111b5eaab095312d7fe84
 decimals = 18
+
+[assets.lqty_liquity]
+id = lqty-liquity
+symbol = LQTY
+address = 0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D
+decimals = 18


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
