### PR TITLE
curve.fi: add tricrypto2 to Curve view_trades

### DIFF
--- a/ethereum/curvefi/view_trades.sql
+++ b/ethereum/curvefi/view_trades.sql
@@ -609,3 +609,29 @@ SELECT
     NULL::integer[] AS trace_address,
     evt_index
 FROM curvefi."tricrypto_swap_evt_TokenExchange"
+
+UNION
+
+SELECT
+    evt_block_time AS block_time,
+    'Curve' AS project,
+    '2' AS version,
+    buyer AS trader_a,
+    NULL::bytea AS trader_b,
+    tokens_bought AS token_a_amount_raw,
+    tokens_sold AS token_b_amount_raw,
+    CASE
+        WHEN bought_id = 0 THEN '\xdac17f958d2ee523a2206206994597c13d831ec7'::bytea
+        WHEN bought_id = 1 THEN '\x2260fac5e5542a773aa44fbcfedf7c193bc2c599'::bytea
+        WHEN bought_id = 2 THEN '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'::bytea
+    END as token_a_address,
+    CASE
+        WHEN sold_id = 0 THEN '\xdac17f958d2ee523a2206206994597c13d831ec7'::bytea
+        WHEN sold_id = 1 THEN '\x2260fac5e5542a773aa44fbcfedf7c193bc2c599'::bytea
+        WHEN sold_id = 2 THEN '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'::bytea
+    END as token_b_address,
+    contract_address AS exchange_contract_address,
+    evt_tx_hash AS tx_hash,
+    NULL::integer[] AS trace_address,
+    evt_index
+FROM curvefi."tricrypto2_swap_evt_TokenExchange"


### PR DESCRIPTION
## Data source:

https://curve.fi/tricrypto2
https://etherscan.io/address/0xD51a44d3FaE010294C616388b506AcdA1bfAAE46

## Test query

https://dune.xyz/queries/111430

## Checks 

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
