### PR TITLE
Improve OpenSea insert for NFT trades and small fixes

### DIFF
--- a/ethereum/nft/trades/insert_cryptopunks.sql
+++ b/ethereum/nft/trades/insert_cryptopunks.sql
@@ -128,7 +128,6 @@ rows AS (
         trades.evt_tx_hash AS tx_hash,
         trades.evt_block_number AS block_number,
         -- Sometimes multiple NFT transfers occur in a given trade; the 'array' fields below provide info for these use cases
-        erc.token_id_array AS nft_token_ids_array,
         trades.token_id_array AS nft_token_ids_array,
         trades.from_array AS senders_array,
         trades.to_array AS recipients_array,

--- a/ethereum/nft/trades/insert_foundation.sql
+++ b/ethereum/nft/trades/insert_foundation.sql
@@ -111,7 +111,6 @@ rows AS (
         trades.evt_block_number AS block_number,
         -- Sometimes multiple NFT transfers occur in a given trade; the 'array' fields below provide info for these use cases 
         erc.token_id_array AS nft_token_ids_array,
-        erc.token_id_array AS nft_token_ids_array,
         erc.from_array AS senders_array,
         erc.to_array AS recipients_array,
         erc.erc_type_array AS erc_types_array,

--- a/ethereum/nft/trades/insert_rarible.sql
+++ b/ethereum/nft/trades/insert_rarible.sql
@@ -340,7 +340,6 @@ rows AS (
         trades.evt_block_number AS block_number,
         -- Sometimes multiple NFT transfers occur in a given trade; the 'array' fields below provide info for these use cases 
         erc.token_id_array AS nft_token_ids_array,
-        erc.token_id_array AS nft_token_ids_array,
         erc.from_array AS senders_array,
         erc.to_array AS recipients_array,
         erc.erc_type_array AS erc_types_array,


### PR DESCRIPTION
## Problem solved

- This query updates the OpenSea insert function in that it handles (rare) occasions where trades are missing from `opensea."WyvernExchange_call_atomicMatch_"`.
- The OpenSea query is expensive and the hourly cron job is modified to pull data going back 6 hours instead of 1 day. [Already merged]
- Removed duplicate lines [Already merged]

## Test query

https://dune.xyz/queries/121091

## Checks 

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`