### PR TITLE
Fix weth id for coinpaprika

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -794,7 +794,7 @@
   address: 0xC011A72400E58ecD99Ee497CF89E3775d4bd732F
   decimals: 18
 - name: weth_ethereum
-  id: eth-ethereum
+  id: weth-weth
   symbol: WETH
   address: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
   decimals: 18


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
