### PR TITLE
Add arb bots labels on Polygon

### DIFF
--- a/labels/polygon/balancer_arbitrage.sql
+++ b/labels/polygon/balancer_arbitrage.sql
@@ -1,0 +1,41 @@
+SELECT
+    DISTINCT(t.to) AS address,
+    'arbitrage bot' AS label,
+    'dapp usage' AS type,
+    'balancerlabs' AS author
+FROM dex.trades t1
+INNER JOIN dex.trades t2
+ON t1.tx_hash = t2.tx_hash
+AND t1.token_a_address = t2.token_b_address
+AND t1.token_b_address = t2.token_a_address
+AND ((t1.project = 'Balancer' AND t2.project = 'Quickswap') or (t1.project = 'Quickswap' AND t2.project = 'Balancer'))
+INNER JOIN polygon.transactions t ON t.hash = t1.tx_hash
+WHERE t1.block_time >= '{{timestamp}}'
+AND t2.block_time >= '{{timestamp}}'
+AND t.to NOT IN (
+    select address 
+    from labels.labels 
+    where author = 'balancerlabs'
+    and type = 'balancer_source'
+)
+UNION ALL
+SELECT
+    DISTINCT(t.to) AS address,
+    'arbitrage bot' AS label,
+    'dapp usage' AS type,
+    'balancerlabs' AS author
+FROM dex.trades t1
+INNER JOIN dex.trades t2
+ON t1.tx_hash = t2.tx_hash
+AND t1.token_a_address = t2.token_b_address
+AND t1.token_b_address = t2.token_a_address
+AND ((t1.project = 'Balancer' AND t2.project = 'Sushiswap') or (t1.project = 'Sushiswap' AND t2.project = 'Balancer'))
+INNER JOIN polygon.transactions t ON t.hash = t1.tx_hash
+WHERE t1.block_time >= '{{timestamp}}'
+AND t2.block_time >= '{{timestamp}}'
+AND t.to NOT IN (
+    select address 
+    from labels.labels 
+    where author = 'balancerlabs'
+    and type = 'balancer_source'
+)


### PR DESCRIPTION
These labels rely on `dex.trades` to be created so #465 needs to be merged first.

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
