### PR TITLE
prices/ethereum/coinpaprika.yaml

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1466,3 +1466,8 @@
   symbol: ERSDL
   address: 0x5218e472cfcfe0b64a064f055b43b4cdc9efd3a6
   decimals: 18
+- name: dpx-dopex
+  id: dpx-dopex
+  symbol: DPX
+  address: 0xeec2be5c91ae7f8a338e1e5f3b5de49d07afdc81
+  decimals: 18


### PR DESCRIPTION
Could you please add DPX to the price.usd table?

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
