### PR TITLE
prices/ethereum/coinpaprika.yaml

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1471,3 +1471,8 @@
   symbol: DPX
   address: 0xeec2be5c91ae7f8a338e1e5f3b5de49d07afdc81
   decimals: 18
+- name: rdpx-dopex-rebate-token
+  id: rdpx-dopex-rebate-token
+  symbol: rDPX
+  address: 0x0ff5a8451a839f5f0bb3562689d9a44089738d11
+  decimals: 18


### PR DESCRIPTION
Please add rdpx to prices.usd table

https://coinpaprika.com/coin/rdpx-dopex-rebate-token/
https://etherscan.io/token/0x0ff5a8451a839f5f0bb3562689d9a44089738d11

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
