### PR TITLE
Update labels table based on nft trades

### DIFF
--- a/labels/ethereum/nft_activity_type.sql
+++ b/labels/ethereum/nft_activity_type.sql
@@ -1,0 +1,17 @@
+SELECT
+    buyer AS address,
+    'nft trader' AS label,
+    'activity' AS type,
+    'masquot' AS author
+FROM nft.trades
+WHERE
+    block_time >= '{{timestamp}}'
+UNION
+SELECT
+    seller AS address,
+    'nft trader' AS label,
+    'activity' AS type,
+    'masquot' AS author
+FROM nft.trades
+WHERE
+    block_time >= '{{timestamp}}';

--- a/labels/ethereum/nft_users.sql
+++ b/labels/ethereum/nft_users.sql
@@ -1,0 +1,17 @@
+SELECT
+    buyer AS address,
+    LOWER(platform) || ' user' AS label,
+    'dapp usage' AS type,
+    'masquot' AS author
+FROM nft.trades
+WHERE
+    block_time >= '{{timestamp}}'
+UNION
+SELECT
+    seller AS address,
+    LOWER(platform) || ' user' AS label,
+    'dapp usage' AS type,
+    'masquot' AS author
+FROM nft.trades
+WHERE
+    block_time >= '{{timestamp}}';

--- a/labels/ethereum/nft_users_collections_traded.sql
+++ b/labels/ethereum/nft_users_collections_traded.sql
@@ -1,0 +1,17 @@
+SELECT
+    buyer AS address,
+    LOWER(nft_project_name) AS label,
+    'nft collection buyer' AS type,
+    'masquot' AS author
+FROM nft.trades
+WHERE
+    block_time >= '{{timestamp}}' AND nft_project_name IS NOT NULL
+UNION
+SELECT
+    seller AS address,
+    LOWER(nft_project_name) AS label,
+    'nft collection seller' AS type,
+    'masquot' AS author
+FROM nft.trades
+WHERE
+    block_time >= '{{timestamp}}' AND nft_project_name IS NOT NULL;


### PR DESCRIPTION
## What

Use the data from `nft.trades` to update Dune's `labels.labels` to make it easier for Dune users to identify:
- NFT traders
- NFT platform users
- NFT collectibles bought or sold by an address

## Test query

https://dune.xyz/queries/161328

## Checks 

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
