### PR TITLE
Fix column ordering in lending_users labels

### DIFF
--- a/labels/ethereum/lending_users.sql
+++ b/labels/ethereum/lending_users.sql
@@ -11,8 +11,8 @@ UNION
 SELECT
     borrower AS address,
     lower(project) || ' user' AS label,
-    'hagaetc' AS author,
-    'dapp usage' AS type
+    'dapp usage' AS type,
+    'hagaetc' AS author
 FROM
     lending.collateral_change
 WHERE


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
