### PR TITLE
Remove YELD token from Polygon prices

### DIFF
--- a/prices/polygon/coingecko.yaml
+++ b/prices/polygon/coingecko.yaml
@@ -253,7 +253,6 @@
 - id: polywhale
 - id: polywhirl
 - id: polywolf
-- id: polyyeld-token
 - id: polyyield-token
 - id: polyyork
 - id: polyzap


### PR DESCRIPTION
After looking into issues on `dex.trades` related to inflated USD volumes on Quickswap and Sushiswap for September we figured out the problem was related to this token. We'll remove it as it's no longer active and fix the table.

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
