### PR TITLE
Adding Eden Network to coinpaprika.yaml

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1476,7 +1476,7 @@
   symbol: rDPX
   address: 0x0ff5a8451a839f5f0bb3562689d9a44089738d11
   decimals: 18
-- name: eden-eden-network
+- name: eden_eden_network
   id: eden-eden-network
   symbol: EDEN
   address: 0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559

--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1476,3 +1476,8 @@
   symbol: rDPX
   address: 0x0ff5a8451a839f5f0bb3562689d9a44089738d11
   decimals: 18
+- name: eden-eden-network
+  id: eden-eden-network
+  symbol: EDEN
+  address: 0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559
+  decimals: 18


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
