### PR TITLE
Remove foundation users labels

### DIFF
--- a/labels/ethereum/foundation_users.sql
+++ b/labels/ethereum/foundation_users.sql
@@ -1,9 +1,0 @@
-SELECT
-    address,
-    name AS label,
-    'foundation user' as type,
-    'foundation' as author
-FROM
-    foundation.user_names
-WHERE
-    updated_at >= '{{timestamp}}'


### PR DESCRIPTION
Remove the script generating these labels as it's been generating errors we do not currently have the time to debug since this is a low prio issue.