### PR TITLE
add decimals and symbol to dex.view_prices

### DIFF
--- a/ethereum/dex/view_token_prices.sql
+++ b/ethereum/dex/view_token_prices.sql
@@ -45,6 +45,8 @@ CREATE MATERIALIZED VIEW dex.view_token_prices AS (
     SELECT
         date_trunc('hour', block_time) as hour,
         contract_address,
+        decimals,
+        symbol,
         (PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY price)) AS median_price,
         count(1) AS sample_size
     FROM dex_trades

--- a/ethereum/dex/view_token_prices.sql
+++ b/ethereum/dex/view_token_prices.sql
@@ -3,17 +3,22 @@ BEGIN;
 DROP MATERIALIZED VIEW IF EXISTS dex.view_token_prices;
 
 CREATE MATERIALIZED VIEW dex.view_token_prices AS (
-    WITH tokens_in_prices_usd AS (
+    WITH 
+    tokens_in_prices_usd AS (
         SELECT DISTINCT contract_address
         FROM prices.usd
         WHERE minute > now() - interval '10 minutes'
-    ), dex_trades AS (
+    ), 
+    dex_trades AS (
         SELECT
             token_a_address as contract_address,
+            decimals,
+            symbol,
             coalesce(usd_amount/token_a_amount, usd_amount/(token_a_amount_raw/10^decimals)) AS price,
             block_time
         FROM dex.trades
-        LEFT JOIN erc20.tokens ON contract_address = token_a_address
+        LEFT JOIN erc20.tokens 
+        ON contract_address = token_a_address
         WHERE 1=1
         AND usd_amount  > 0
         AND category = 'DEX'
@@ -24,6 +29,8 @@ CREATE MATERIALIZED VIEW dex.view_token_prices AS (
 
         SELECT
             token_b_address as contract_address,
+            decimals,
+            symbol,
             coalesce(usd_amount/token_b_amount, usd_amount/(token_b_amount_raw/10^decimals)) AS price,
             block_time
         FROM dex.trades


### PR DESCRIPTION
Considering the decimals are known at the time this view is generated, this will make some dashboard much more performant if they don't have to join on the erc20 table every time to get decimals.


I've checked that:

* [x] the query produces the intended results (cf https://dune.xyz/queries/230676)
* [x] the schema name exists in Dune

