### PR TITLE
Add USD prices from DEX swap data

### DIFF
--- a/ethereum/prices/insert_prices_from_dex_data.sql
+++ b/ethereum/prices/insert_prices_from_dex_data.sql
@@ -1,0 +1,192 @@
+CREATE OR REPLACE FUNCTION prices.insert_prices_from_dex_data(start_time timestamptz, end_time timestamptz=now()) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+
+WITH trades_with_usd_amount AS (
+    SELECT
+        token_a_address as contract_address,
+        token_a_symbol as symbol,
+        usd_amount/(token_a_amount_raw/10^decimals) AS price,
+        block_time
+    FROM dex.trades
+    INNER JOIN erc20.tokens ON contract_address = token_a_address
+    WHERE usd_amount  > 0
+    AND category = 'DEX'
+    AND token_a_amount_raw > 0
+    AND block_time >= start_time
+    AND block_time < end_time
+
+    UNION ALL
+
+    SELECT
+        token_b_address as contract_address,
+        token_b_symbol as symbol,
+        usd_amount/(token_b_amount_raw/10^decimals) AS price,
+        block_time
+    FROM dex.trades
+    INNER JOIN erc20.tokens ON contract_address = token_b_address
+    WHERE usd_amount  > 0
+    AND category = 'DEX'
+    AND token_b_amount_raw > 0
+    AND block_time >= start_time
+    AND block_time < end_time
+),
+grouped_by_hour AS (
+    SELECT
+        date_trunc('hour', block_time) as hour,
+        contract_address,
+        symbol,
+        (PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY price)) AS median_price,
+        count(1) AS sample_size
+    FROM trades_with_usd_amount
+    GROUP BY 1, 2, 3
+    -- Get previous entries from the table
+    -- This is necessary to provide price continuity for tokens with low swap volume
+    -- when performing historic backfill.
+    UNION ALL
+    SELECT
+        hour,
+        contract_address,
+        symbol,
+        median_price,
+        sample_size
+    FROM prices.prices_from_dex_data
+    WHERE hour = (select start_ts - INTERVAL '1 hour')
+),
+-- The SQL code in `leaddata`, `generate_hours` and `add_data_for_all_hours`
+-- sets the median_price to the price of the previous hour in case that there
+-- are no swaps in an hour for a token.
+leaddata as 
+(
+    SELECT
+        hour,
+        contract_address,
+        symbol,
+        median_price,
+        sample_size,
+        lead(hour, 1, now() ) OVER (PARTITION BY contract_address ORDER BY hour asc) AS next_hour
+    FROM grouped_by_hour
+    WHERE sample_size > 0
+),
+generate_hours AS
+(
+    SELECT hour from generate_series(start_time, (select end_time - INTERVAL '1 hour'), '1 hour') g(hour)
+),
+add_data_for_all_hours as 
+(
+    SELECT
+    gen.hour as hour,
+    contract_address,
+    symbol,
+    median_price,
+    CASE WHEN gen.hour = data.hour THEN sample_size ELSE 0 END AS sample_size
+    FROM leaddata data
+    INNER JOIN generate_hours gen ON data.hour <= gen.hour
+    AND gen.hour < data.next_hour -- Yields an observation for every hour after the first transfer until the next hour with transfer
+),
+
+rows AS (
+    INSERT INTO prices.prices_from_dex_data (
+        contract_address,
+        hour,
+        median_price,
+        sample_size,
+        symbol
+    )
+
+    SELECT 
+        contract_address,
+        hour,
+        median_price,
+        sample_size,
+        symbol
+    FROM add_data_for_all_hours
+
+    ON CONFLICT (contract_address, hour) DO UPDATE SET median_price = EXCLUDED.median_price 
+    RETURNING 1
+)
+SELECT count(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+-- Monthly backfill starting 1 Jan 2020
+SELECT prices.insert_prices_from_dex_data('2020-01-01', '2020-02-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2020-01-01' and hour < '2020-02-01');
+
+SELECT prices.insert_prices_from_dex_data('2020-02-01', '2020-03-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2020-02-01' and hour < '2020-03-01');
+
+SELECT prices.insert_prices_from_dex_data('2020-03-01', '2020-04-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2020-03-01' and hour < '2020-04-01');
+
+SELECT prices.insert_prices_from_dex_data('2020-04-01', '2020-05-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2020-04-01' and hour < '2020-05-01');
+
+SELECT prices.insert_prices_from_dex_data('2020-05-01', '2020-06-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2020-05-01' and hour < '2020-06-01');
+
+SELECT prices.insert_prices_from_dex_data('2020-06-01', '2020-07-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2020-06-01' and hour < '2020-07-01');
+
+SELECT prices.insert_prices_from_dex_data('2020-07-01', '2020-08-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2020-07-01' and hour < '2020-08-01');
+
+SELECT prices.insert_prices_from_dex_data('2020-08-01', '2020-09-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2020-08-01' and hour < '2020-09-01');
+
+SELECT prices.insert_prices_from_dex_data('2020-09-01', '2020-10-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2020-09-01' and hour < '2020-10-01');
+
+SELECT prices.insert_prices_from_dex_data('2020-10-01', '2020-11-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2020-10-01' and hour < '2020-11-01');
+
+SELECT prices.insert_prices_from_dex_data('2020-11-01', '2020-12-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2020-11-01' and hour < '2020-12-01');
+
+SELECT prices.insert_prices_from_dex_data('2020-12-01', '2021-01-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2020-12-01' and hour < '2021-01-01');
+
+SELECT prices.insert_prices_from_dex_data('2021-01-01', '2021-02-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2021-01-01' and hour < '2021-02-01');
+
+SELECT prices.insert_prices_from_dex_data('2021-02-01', '2021-03-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2021-02-01' and hour < '2021-03-01');
+
+SELECT prices.insert_prices_from_dex_data('2021-03-01', '2021-04-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2021-03-01' and hour < '2021-04-01');
+
+SELECT prices.insert_prices_from_dex_data('2021-04-01', '2021-05-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2021-04-01' and hour < '2021-05-01');
+
+SELECT prices.insert_prices_from_dex_data('2021-05-01', '2021-06-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2021-05-01' and hour < '2021-06-01');
+
+SELECT prices.insert_prices_from_dex_data('2021-06-01', '2021-07-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2021-06-01' and hour < '2021-07-01');
+
+SELECT prices.insert_prices_from_dex_data('2021-07-01', '2021-08-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2021-07-01' and hour < '2021-08-01');
+
+SELECT prices.insert_prices_from_dex_data('2021-08-01', '2021-09-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2021-08-01' and hour < '2021-09-01');
+
+SELECT prices.insert_prices_from_dex_data('2021-09-01', '2021-10-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2021-09-01' and hour < '2021-10-01');
+
+SELECT prices.insert_prices_from_dex_data('2021-10-01', '2021-11-01')
+WHERE NOT EXISTS (SELECT * FROM prices.prices_from_dex_data WHERE hour >= '2021-10-01' and hour < '2021-11-01');
+
+SELECT prices.insert_prices_from_dex_data('2021-11-01', now());
+
+-- Have the insert script run twice every hour at minute 16 and 46
+-- `start-time` is set to go back three days in time so that entries can be retroactively updated 
+-- in case `dex.trades` or price data falls behind.
+INSERT INTO cron.job (schedule, command)
+VALUES ('16,46 * * * *', $$
+    SELECT prices.insert_prices_from_dex_data(
+        (SELECT date_trunc('hour', now()) - interval '3 days'),
+        (SELECT date_trunc('hour', now())));
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/prices/insert_prices_from_dex_data.sql
+++ b/ethereum/prices/insert_prices_from_dex_data.sql
@@ -56,7 +56,7 @@ grouped_by_hour AS (
         median_price,
         sample_size
     FROM prices.prices_from_dex_data
-    WHERE hour = (select start_ts - INTERVAL '1 hour')
+    WHERE hour = (select start_time - INTERVAL '1 hour')
 ),
 -- The SQL code in `leaddata`, `generate_hours` and `add_data_for_all_hours`
 -- sets the median_price to the price of the previous hour in case that there

--- a/ethereum/prices/prices_from_dex_data.sql
+++ b/ethereum/prices/prices_from_dex_data.sql
@@ -1,0 +1,13 @@
+CREATE TABLE prices.prices_from_dex_data(
+    contract_address bytea NOT NULL,
+    hour timestamptz NOT NULL,
+    median_price numeric,
+    sample_size integer,
+    symbol text
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS prices_prices_from_dex_data_contract_addr_hour_uniq_idx ON prices.prices_from_dex_data (contract_address, hour);
+CREATE INDEX IF NOT EXISTS prices_prices_from_dex_data_hour_idx ON prices.prices_from_dex_data USING BRIN (hour);
+CREATE INDEX IF NOT EXISTS prices_prices_from_dex_data_contract_address_idx ON prices.prices_from_dex_data (contract_address);
+CREATE INDEX IF NOT EXISTS prices_prices_from_dex_data_symbol_idx ON prices.prices_from_dex_data (symbol);
+CREATE INDEX IF NOT EXISTS prices_prices_from_dex_data_median_price_idx ON prices.prices_from_dex_data (median_price);

--- a/ethereum/prices/prices_from_dex_data.sql
+++ b/ethereum/prices/prices_from_dex_data.sql
@@ -1,9 +1,10 @@
-CREATE TABLE prices.prices_from_dex_data(
+CREATE TABLE IF NOT EXISTS prices.prices_from_dex_data(
     contract_address bytea NOT NULL,
     hour timestamptz NOT NULL,
     median_price numeric,
     sample_size integer,
-    symbol text
+    symbol text,
+    decimals int4
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS prices_prices_from_dex_data_contract_addr_hour_uniq_idx ON prices.prices_from_dex_data (contract_address, hour);


### PR DESCRIPTION
## Problem solved

Create a table with hourly price data based on DEX swap data that replaces the currently existing view `dex.view_token_prices.sql` and makes it more performant.

This approach to creating USD price tables has the advantage that a token just needs to be included in `erc20.tokens` for it to have hourly price data.

To make this table easy to use, the query fills those hours where there was no trades with the price of the previous hour.

## Credits

- First saw this approach used by Balancer @markusbkoch and @mendesfabio 
- Improvements and feedback by:
  - @jorijnsmit #446 
  - @bh2smith #521 
  - @0xBoxer

## Test queries

- https://dune.xyz/queries/235418 (3 days of data)
- https://dune.xyz/queries/235657 (showcases for one token how the query fills those hours where there was no trades with the price of the previous hour) 

## Checks 

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`

