### PR TITLE
Get symbol from erc20.tokens

### DIFF
--- a/ethereum/prices/insert_prices_from_dex_data.sql
+++ b/ethereum/prices/insert_prices_from_dex_data.sql
@@ -6,7 +6,7 @@ BEGIN
 WITH trades_with_usd_amount AS (
     SELECT
         token_a_address as contract_address,
-        token_a_symbol as symbol,
+        symbol,
         decimals,
         usd_amount/(token_a_amount_raw/10^decimals) AS price,
         block_time
@@ -22,7 +22,7 @@ WITH trades_with_usd_amount AS (
 
     SELECT
         token_b_address as contract_address,
-        token_b_symbol as symbol,
+        symbol,
         decimals,
         usd_amount/(token_b_amount_raw/10^decimals) AS price,
         block_time


### PR DESCRIPTION
This PR #527 introduced some excellent changes, although it turns out that using on dex.trades for token symbol is unreliable in comparison with erc20.tokens

This query shows that there are 3265 distinct missing token symbols in dex.trades that are all contained in erc20.token

https://dune.xyz/queries/237271