### PR TITLE
Split up Uniswap DEX insert job

### DIFF
--- a/ethereum/dex/trades/insert_uniswap_v1.sql
+++ b/ethereum/dex/trades/insert_uniswap_v1.sql
@@ -1,0 +1,182 @@
+CREATE OR REPLACE FUNCTION dex.insert_uniswap_v1(start_ts timestamptz, end_ts timestamptz=now(), start_block numeric=0, end_block numeric=9e18) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH rows AS (
+    INSERT INTO dex.trades (
+        block_time,
+        token_a_symbol,
+        token_b_symbol,
+        token_a_amount,
+        token_b_amount,
+        project,
+        version,
+        category,
+        trader_a,
+        trader_b,
+        token_a_amount_raw,
+        token_b_amount_raw,
+        usd_amount,
+        token_a_address,
+        token_b_address,
+        exchange_contract_address,
+        tx_hash,
+        tx_from,
+        tx_to,
+        trace_address,
+        evt_index,
+        trade_id
+    )
+    SELECT
+        dexs.block_time,
+        erc20a.symbol AS token_a_symbol,
+        erc20b.symbol AS token_b_symbol,
+        token_a_amount_raw / 10 ^ erc20a.decimals AS token_a_amount,
+        token_b_amount_raw / 10 ^ erc20b.decimals AS token_b_amount,
+        project,
+        version,
+        category,
+        coalesce(trader_a, tx."from") as trader_a, -- subqueries rely on this COALESCE to avoid redundant joins with the transactions table
+        trader_b,
+        token_a_amount_raw,
+        token_b_amount_raw,
+        coalesce(
+            usd_amount,
+            token_a_amount_raw / 10 ^ pa.decimals * pa.price,
+            token_b_amount_raw / 10 ^ pb.decimals * pb.price
+        ) as usd_amount,
+        token_a_address,
+        token_b_address,
+        exchange_contract_address,
+        tx_hash,
+        tx."from" as tx_from,
+        tx."to" as tx_to,
+        trace_address,
+        evt_index,
+        row_number() OVER (PARTITION BY project, tx_hash, evt_index, trace_address ORDER BY version, category) AS trade_id
+    FROM (
+        -- Uniswap v1 TokenPurchase
+        SELECT
+            t.evt_block_time AS block_time,
+            'Uniswap' AS project,
+            '1' AS version,
+            'DEX' AS category,
+            buyer AS trader_a,
+            NULL::bytea AS trader_b,
+            tokens_bought token_a_amount_raw,
+            eth_sold token_b_amount_raw,
+            NULL::numeric AS usd_amount,
+            f.token AS token_a_address,
+            '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'::bytea AS token_b_address, --Using WETH for easier joining with USD price table
+            t.contract_address exchange_contract_address,
+            t.evt_tx_hash AS tx_hash,
+            NULL::integer[] AS trace_address,
+            t.evt_index
+        FROM
+            uniswap. "Exchange_evt_TokenPurchase" t
+        INNER JOIN uniswap. "Factory_evt_NewExchange" f ON f.exchange = t.contract_address
+        WHERE t.evt_block_time >= start_ts AND t.evt_block_time < end_ts
+
+        UNION ALL
+
+        -- Uniswap v1 EthPurchase
+        SELECT
+            t.evt_block_time AS block_time,
+            'Uniswap' AS project,
+            '1' AS version,
+            'DEX' AS category,
+            buyer AS trader_a,
+            NULL::bytea AS trader_b,
+            eth_bought token_a_amount_raw,
+            tokens_sold token_b_amount_raw,
+            NULL::numeric AS usd_amount,
+            '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'::bytea token_a_address, --Using WETH for easier joining with USD price table
+            f.token AS token_b_address,
+            t.contract_address exchange_contract_address,
+            t.evt_tx_hash AS tx_hash,
+            NULL::integer[] AS trace_address,
+            t.evt_index
+        FROM
+            uniswap. "Exchange_evt_EthPurchase" t
+        INNER JOIN uniswap. "Factory_evt_NewExchange" f ON f.exchange = t.contract_address
+        WHERE t.evt_block_time >= start_ts AND t.evt_block_time < end_ts
+    ) dexs
+    INNER JOIN ethereum.transactions tx
+        ON dexs.tx_hash = tx.hash
+        AND tx.block_time >= start_ts
+        AND tx.block_time < end_ts
+        AND tx.block_number >= start_block
+        AND tx.block_number < end_block
+    LEFT JOIN erc20.tokens erc20a ON erc20a.contract_address = dexs.token_a_address
+    LEFT JOIN erc20.tokens erc20b ON erc20b.contract_address = dexs.token_b_address
+    LEFT JOIN prices.usd pa ON pa.minute = date_trunc('minute', dexs.block_time)
+        AND pa.contract_address = dexs.token_a_address
+        AND pa.minute >= start_ts
+        AND pa.minute < end_ts
+    LEFT JOIN prices.usd pb ON pb.minute = date_trunc('minute', dexs.block_time)
+        AND pb.contract_address = dexs.token_b_address
+        AND pb.minute >= start_ts
+        AND pb.minute < end_ts
+
+    ON CONFLICT DO NOTHING
+    RETURNING 1
+)
+SELECT count(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+-- fill 2019
+SELECT dex.insert_uniswap_v1(
+    '2019-01-01',
+    '2020-01-01',
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM dex.trades
+    WHERE block_time > '2019-01-01'
+    AND block_time <= '2020-01-01'
+    AND project = 'Uniswap'
+);
+
+-- fill 2020
+SELECT dex.insert_uniswap_v1(
+    '2020-01-01',
+    '2021-01-01',
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM dex.trades
+    WHERE block_time > '2020-01-01'
+    AND block_time <= '2021-01-01'
+    AND project = 'Uniswap'
+);
+
+-- fill 2021
+SELECT dex.insert_uniswap_v1(
+    '2021-01-01',
+    now(),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
+    (SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM dex.trades
+    WHERE block_time > '2021-01-01'
+    AND block_time <= now() - interval '20 minutes'
+    AND project = 'Uniswap'
+);
+
+INSERT INTO cron.job (schedule, command)
+VALUES ('7,37 * * * *', $$
+    SELECT dex.insert_uniswap_v1(
+        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap'),
+        (SELECT now() - interval '20 minutes'),
+        (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap')),
+        (SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'));
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_uniswap_v1.sql
+++ b/ethereum/dex/trades/insert_uniswap_v1.sql
@@ -138,7 +138,7 @@ WHERE NOT EXISTS (
     FROM dex.trades
     WHERE block_time > '2019-01-01'
     AND block_time <= '2020-01-01'
-    AND project = 'Uniswap'
+    AND project = 'Uniswap' AND version = '1'
 );
 
 -- fill 2020
@@ -153,7 +153,7 @@ WHERE NOT EXISTS (
     FROM dex.trades
     WHERE block_time > '2020-01-01'
     AND block_time <= '2021-01-01'
-    AND project = 'Uniswap'
+    AND project = 'Uniswap' AND version = '1'
 );
 
 -- fill 2021
@@ -168,15 +168,15 @@ WHERE NOT EXISTS (
     FROM dex.trades
     WHERE block_time > '2021-01-01'
     AND block_time <= now() - interval '20 minutes'
-    AND project = 'Uniswap'
+    AND project = 'Uniswap' AND version = '1'
 );
 
 INSERT INTO cron.job (schedule, command)
 VALUES ('7,37 * * * *', $$
     SELECT dex.insert_uniswap_v1(
-        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap'),
+        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap' AND version = '1'),
         (SELECT now() - interval '20 minutes'),
-        (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap')),
+        (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap' AND version = '1')),
         (SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_uniswap_v2.sql
+++ b/ethereum/dex/trades/insert_uniswap_v2.sql
@@ -118,7 +118,7 @@ WHERE NOT EXISTS (
     FROM dex.trades
     WHERE block_time > '2019-01-01'
     AND block_time <= '2020-01-01'
-    AND project = 'Uniswap'
+    AND project = 'Uniswap' AND version = '2'
 );
 
 -- fill 2020
@@ -133,7 +133,7 @@ WHERE NOT EXISTS (
     FROM dex.trades
     WHERE block_time > '2020-01-01'
     AND block_time <= '2021-01-01'
-    AND project = 'Uniswap'
+    AND project = 'Uniswap' AND version = '2'
 );
 
 -- fill 2021
@@ -148,15 +148,15 @@ WHERE NOT EXISTS (
     FROM dex.trades
     WHERE block_time > '2021-01-01'
     AND block_time <= now() - interval '20 minutes'
-    AND project = 'Uniswap'
+    AND project = 'Uniswap' AND version = '2'
 );
 
 INSERT INTO cron.job (schedule, command)
 VALUES ('17,47 * * * *', $$
     SELECT dex.insert_uniswap_v2(
-        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap'),
+        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap' AND version = '2'),
         (SELECT now() - interval '20 minutes'),
-        (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap')),
+        (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap' AND version = '2')),
         (SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_uniswap_v2.sql
+++ b/ethereum/dex/trades/insert_uniswap_v2.sql
@@ -1,0 +1,162 @@
+CREATE OR REPLACE FUNCTION dex.insert_uniswap_v2(start_ts timestamptz, end_ts timestamptz=now(), start_block numeric=0, end_block numeric=9e18) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH rows AS (
+    INSERT INTO dex.trades (
+        block_time,
+        token_a_symbol,
+        token_b_symbol,
+        token_a_amount,
+        token_b_amount,
+        project,
+        version,
+        category,
+        trader_a,
+        trader_b,
+        token_a_amount_raw,
+        token_b_amount_raw,
+        usd_amount,
+        token_a_address,
+        token_b_address,
+        exchange_contract_address,
+        tx_hash,
+        tx_from,
+        tx_to,
+        trace_address,
+        evt_index,
+        trade_id
+    )
+    SELECT
+        dexs.block_time,
+        erc20a.symbol AS token_a_symbol,
+        erc20b.symbol AS token_b_symbol,
+        token_a_amount_raw / 10 ^ erc20a.decimals AS token_a_amount,
+        token_b_amount_raw / 10 ^ erc20b.decimals AS token_b_amount,
+        project,
+        version,
+        category,
+        coalesce(trader_a, tx."from") as trader_a, -- subqueries rely on this COALESCE to avoid redundant joins with the transactions table
+        trader_b,
+        token_a_amount_raw,
+        token_b_amount_raw,
+        coalesce(
+            usd_amount,
+            token_a_amount_raw / 10 ^ pa.decimals * pa.price,
+            token_b_amount_raw / 10 ^ pb.decimals * pb.price
+        ) as usd_amount,
+        token_a_address,
+        token_b_address,
+        exchange_contract_address,
+        tx_hash,
+        tx."from" as tx_from,
+        tx."to" as tx_to,
+        trace_address,
+        evt_index,
+        row_number() OVER (PARTITION BY project, tx_hash, evt_index, trace_address ORDER BY version, category) AS trade_id
+    FROM (
+        -- Uniswap v2
+        SELECT
+            t.evt_block_time AS block_time,
+            'Uniswap' AS project,
+            '2' AS version,
+            'DEX' AS category,
+            t."to" AS trader_a,
+            NULL::bytea AS trader_b,
+            CASE WHEN "amount0Out" = 0 THEN "amount1Out" ELSE "amount0Out" END AS token_a_amount_raw,
+            CASE WHEN "amount0In" = 0 THEN "amount1In" ELSE "amount0In" END AS token_b_amount_raw,
+            NULL::numeric AS usd_amount,
+            CASE WHEN "amount0Out" = 0 THEN f.token1 ELSE f.token0 END AS token_a_address,
+            CASE WHEN "amount0In" = 0 THEN f.token1 ELSE f.token0 END AS token_b_address,
+            t.contract_address AS exchange_contract_address,
+            t.evt_tx_hash AS tx_hash,
+            NULL::integer[] AS trace_address,
+            t.evt_index
+        FROM
+            uniswap_v2."Pair_evt_Swap" t
+        INNER JOIN uniswap_v2."Factory_evt_PairCreated" f ON f.pair = t.contract_address
+        WHERE t.contract_address NOT IN (
+            '\xed9c854cb02de75ce4c9bba992828d6cb7fd5c71', -- remove WETH-UBOMB wash trading pair
+            '\x854373387e41371ac6e307a1f29603c6fa10d872' ) -- remove FEG/ETH token pair
+        AND t.evt_block_time >= start_ts AND t.evt_block_time < end_ts
+
+    ) dexs
+    INNER JOIN ethereum.transactions tx
+        ON dexs.tx_hash = tx.hash
+        AND tx.block_time >= start_ts
+        AND tx.block_time < end_ts
+        AND tx.block_number >= start_block
+        AND tx.block_number < end_block
+    LEFT JOIN erc20.tokens erc20a ON erc20a.contract_address = dexs.token_a_address
+    LEFT JOIN erc20.tokens erc20b ON erc20b.contract_address = dexs.token_b_address
+    LEFT JOIN prices.usd pa ON pa.minute = date_trunc('minute', dexs.block_time)
+        AND pa.contract_address = dexs.token_a_address
+        AND pa.minute >= start_ts
+        AND pa.minute < end_ts
+    LEFT JOIN prices.usd pb ON pb.minute = date_trunc('minute', dexs.block_time)
+        AND pb.contract_address = dexs.token_b_address
+        AND pb.minute >= start_ts
+        AND pb.minute < end_ts
+
+    ON CONFLICT DO NOTHING
+    RETURNING 1
+)
+SELECT count(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+-- fill 2019
+SELECT dex.insert_uniswap_v2(
+    '2019-01-01',
+    '2020-01-01',
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2020-01-01')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM dex.trades
+    WHERE block_time > '2019-01-01'
+    AND block_time <= '2020-01-01'
+    AND project = 'Uniswap'
+);
+
+-- fill 2020
+SELECT dex.insert_uniswap_v2(
+    '2020-01-01',
+    '2021-01-01',
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
+    (SELECT max(number) FROM ethereum.blocks WHERE time <= '2021-01-01')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM dex.trades
+    WHERE block_time > '2020-01-01'
+    AND block_time <= '2021-01-01'
+    AND project = 'Uniswap'
+);
+
+-- fill 2021
+SELECT dex.insert_uniswap_v2(
+    '2021-01-01',
+    now(),
+    (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
+    (SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM dex.trades
+    WHERE block_time > '2021-01-01'
+    AND block_time <= now() - interval '20 minutes'
+    AND project = 'Uniswap'
+);
+
+INSERT INTO cron.job (schedule, command)
+VALUES ('17,47 * * * *', $$
+    SELECT dex.insert_uniswap_v2(
+        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap'),
+        (SELECT now() - interval '20 minutes'),
+        (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap')),
+        (SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'));
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_uniswap_v3.sql
+++ b/ethereum/dex/trades/insert_uniswap_v3.sql
@@ -115,7 +115,7 @@ WHERE NOT EXISTS (
     FROM dex.trades
     WHERE block_time > '2019-01-01'
     AND block_time <= '2020-01-01'
-    AND project = 'Uniswap'
+    AND project = 'Uniswap' AND version = '3'
 );
 
 -- fill 2020
@@ -130,7 +130,7 @@ WHERE NOT EXISTS (
     FROM dex.trades
     WHERE block_time > '2020-01-01'
     AND block_time <= '2021-01-01'
-    AND project = 'Uniswap'
+    AND project = 'Uniswap' AND version = '3'
 );
 
 -- fill 2021
@@ -145,15 +145,15 @@ WHERE NOT EXISTS (
     FROM dex.trades
     WHERE block_time > '2021-01-01'
     AND block_time <= now() - interval '20 minutes'
-    AND project = 'Uniswap'
+    AND project = 'Uniswap' AND version = '3'
 );
 
 INSERT INTO cron.job (schedule, command)
 VALUES ('27,57 * * * *', $$
     SELECT dex.insert_uniswap_v3(
-        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap'),
+        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap' AND version = '3'),
         (SELECT now() - interval '20 minutes'),
-        (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap')),
+        (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap' AND version = '3')),
         (SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/dex/trades/insert_uniswap_v3.sql
+++ b/ethereum/dex/trades/insert_uniswap_v3.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION dex.insert_uniswap(start_ts timestamptz, end_ts timestamptz=now(), start_block numeric=0, end_block numeric=9e18) RETURNS integer
+CREATE OR REPLACE FUNCTION dex.insert_uniswap_v3(start_ts timestamptz, end_ts timestamptz=now(), start_block numeric=0, end_block numeric=9e18) RETURNS integer
 LANGUAGE plpgsql AS $function$
 DECLARE r integer;
 BEGIN
@@ -55,77 +55,6 @@ WITH rows AS (
         evt_index,
         row_number() OVER (PARTITION BY project, tx_hash, evt_index, trace_address ORDER BY version, category) AS trade_id
     FROM (
-        -- Uniswap v1 TokenPurchase
-        SELECT
-            t.evt_block_time AS block_time,
-            'Uniswap' AS project,
-            '1' AS version,
-            'DEX' AS category,
-            buyer AS trader_a,
-            NULL::bytea AS trader_b,
-            tokens_bought token_a_amount_raw,
-            eth_sold token_b_amount_raw,
-            NULL::numeric AS usd_amount,
-            f.token AS token_a_address,
-            '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'::bytea AS token_b_address, --Using WETH for easier joining with USD price table
-            t.contract_address exchange_contract_address,
-            t.evt_tx_hash AS tx_hash,
-            NULL::integer[] AS trace_address,
-            t.evt_index
-        FROM
-            uniswap. "Exchange_evt_TokenPurchase" t
-        INNER JOIN uniswap. "Factory_evt_NewExchange" f ON f.exchange = t.contract_address
-
-        UNION ALL
-
-        -- Uniswap v1 EthPurchase
-        SELECT
-            t.evt_block_time AS block_time,
-            'Uniswap' AS project,
-            '1' AS version,
-            'DEX' AS category,
-            buyer AS trader_a,
-            NULL::bytea AS trader_b,
-            eth_bought token_a_amount_raw,
-            tokens_sold token_b_amount_raw,
-            NULL::numeric AS usd_amount,
-            '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'::bytea token_a_address, --Using WETH for easier joining with USD price table
-            f.token AS token_b_address,
-            t.contract_address exchange_contract_address,
-            t.evt_tx_hash AS tx_hash,
-            NULL::integer[] AS trace_address,
-            t.evt_index
-        FROM
-            uniswap. "Exchange_evt_EthPurchase" t
-        INNER JOIN uniswap. "Factory_evt_NewExchange" f ON f.exchange = t.contract_address
-
-        UNION ALL
-        -- Uniswap v2
-        SELECT
-            t.evt_block_time AS block_time,
-            'Uniswap' AS project,
-            '2' AS version,
-            'DEX' AS category,
-            t."to" AS trader_a,
-            NULL::bytea AS trader_b,
-            CASE WHEN "amount0Out" = 0 THEN "amount1Out" ELSE "amount0Out" END AS token_a_amount_raw,
-            CASE WHEN "amount0In" = 0 THEN "amount1In" ELSE "amount0In" END AS token_b_amount_raw,
-            NULL::numeric AS usd_amount,
-            CASE WHEN "amount0Out" = 0 THEN f.token1 ELSE f.token0 END AS token_a_address,
-            CASE WHEN "amount0In" = 0 THEN f.token1 ELSE f.token0 END AS token_b_address,
-            t.contract_address AS exchange_contract_address,
-            t.evt_tx_hash AS tx_hash,
-            NULL::integer[] AS trace_address,
-            t.evt_index
-        FROM
-            uniswap_v2."Pair_evt_Swap" t
-        INNER JOIN uniswap_v2."Factory_evt_PairCreated" f ON f.pair = t.contract_address
-        WHERE t.contract_address NOT IN (
-            '\xed9c854cb02de75ce4c9bba992828d6cb7fd5c71', -- remove WETH-UBOMB wash trading pair
-            '\x854373387e41371ac6e307a1f29603c6fa10d872' ) -- remove FEG/ETH token pair
-
-
-        UNION ALL
         --Uniswap v3
         SELECT
             t.evt_block_time AS block_time,
@@ -146,6 +75,7 @@ WITH rows AS (
         FROM
             uniswap_v3."Pair_evt_Swap" t
         INNER JOIN uniswap_v3."Factory_evt_PoolCreated" f ON f.pool = t.contract_address
+        WHERE t.evt_block_time >= start_ts AND t.evt_block_time < end_ts
 
     ) dexs
     INNER JOIN ethereum.transactions tx
@@ -164,8 +94,6 @@ WITH rows AS (
         AND pb.contract_address = dexs.token_b_address
         AND pb.minute >= start_ts
         AND pb.minute < end_ts
-    WHERE dexs.block_time >= start_ts
-    AND dexs.block_time < end_ts
 
     ON CONFLICT DO NOTHING
     RETURNING 1
@@ -176,7 +104,7 @@ END
 $function$;
 
 -- fill 2019
-SELECT dex.insert_uniswap(
+SELECT dex.insert_uniswap_v3(
     '2019-01-01',
     '2020-01-01',
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2019-01-01'),
@@ -191,7 +119,7 @@ WHERE NOT EXISTS (
 );
 
 -- fill 2020
-SELECT dex.insert_uniswap(
+SELECT dex.insert_uniswap_v3(
     '2020-01-01',
     '2021-01-01',
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2020-01-01'),
@@ -206,7 +134,7 @@ WHERE NOT EXISTS (
 );
 
 -- fill 2021
-SELECT dex.insert_uniswap(
+SELECT dex.insert_uniswap_v3(
     '2021-01-01',
     now(),
     (SELECT max(number) FROM ethereum.blocks WHERE time < '2021-01-01'),
@@ -221,8 +149,8 @@ WHERE NOT EXISTS (
 );
 
 INSERT INTO cron.job (schedule, command)
-VALUES ('*/10 * * * *', $$
-    SELECT dex.insert_uniswap(
+VALUES ('27,57 * * * *', $$
+    SELECT dex.insert_uniswap_v3(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap'),
         (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap')),


### PR DESCRIPTION
## Problem solved

The Uniswap `insert` script for `dex.trades` puts heavy load on the DB and occasionally runs for many hours before completing.  Aim is to improve performance by splitting up the single Uniswap load job into three smaller jobs, one for each version of the protocol.

## Checks 

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
