### PR TITLE
Adding OVM_ETH

### DIFF
--- a/optimism2/erc20/tokens.sql
+++ b/optimism2/erc20/tokens.sql
@@ -52,6 +52,7 @@ COPY erc20.tokens (contract_address, symbol, decimals) FROM stdin;
 \\x588abc030b08819c4c284189ce269a8fb4efe439	quotMKRquot	18
 \\xe3c332a5dce0e1d9bc2cc72a68437790570c28a4	VEE	18
 \\xb27e3eab7526bf721ea8029bfcd3fdc94c4f8b5b	ODOGE	18
+\\xdeaddeaddeaddeaddeaddeaddeaddeaddead0000	ETH	18
 \.
 
 


### PR DESCRIPTION
OVM_ETH is used for bridging events '\xdeaddeaddeaddeaddeaddeaddeaddeaddead0000' but we should keep it's symbol as ETH since that's how it's labeled in the token contract (placeholder for ETH).

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
