### PR TITLE
Create Balancer lookup table on Polygon to replace label functionality

### DIFF
--- a/polygon/balancer/address_mappings.sql
+++ b/polygon/balancer/address_mappings.sql
@@ -1,0 +1,11 @@
+CREATE SCHEMA IF NOT EXISTS balancer;
+
+CREATE TABLE IF NOT EXISTS balancer.address_mappings (
+    address bytea NOT NULL,
+    label   text  NOT NULL,
+    type    text  NOT NULL,
+    author  text  NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS balancer_address_label_uniq_idx ON balancer.address_mappings (address, label);
+CREATE INDEX IF NOT EXISTS balancer_address_idx ON balancer.address_mappings (address);

--- a/polygon/balancer/arbitrage_mappings.sql
+++ b/polygon/balancer/arbitrage_mappings.sql
@@ -1,3 +1,5 @@
+BEGIN;
+
 CREATE OR REPLACE FUNCTION balancer.arbitrage_mappings(start_ts timestamptz, end_ts timestamptz=now()) RETURNS integer
 LANGUAGE plpgsql AS $function$
 DECLARE r integer;
@@ -21,8 +23,8 @@ WITH rows AS (
     AND t1.token_b_address = t2.token_a_address
     AND ((t1.project = 'Balancer' AND t2.project = 'Quickswap') or (t1.project = 'Quickswap' AND t2.project = 'Balancer'))
     INNER JOIN polygon.transactions t ON t.hash = t1.tx_hash
-    WHERE t1.block_time >= start_ts and t1.block_time >= end_ts
-    AND t2.block_time >= start_ts and t2.block_time >= end_ts
+    WHERE t1.block_time >= start_ts and t1.block_time < end_ts
+    AND t2.block_time >= start_ts and t2.block_time < end_ts
     AND t.to NOT IN (
         select address
         from balancer.address_mappings
@@ -42,8 +44,8 @@ WITH rows AS (
     AND t1.token_b_address = t2.token_a_address
     AND ((t1.project = 'Balancer' AND t2.project = 'Sushiswap') or (t1.project = 'Sushiswap' AND t2.project = 'Balancer'))
     INNER JOIN polygon.transactions t ON t.hash = t1.tx_hash
-    WHERE t1.block_time >= start_ts and t1.block_time >= end_ts
-    AND t2.block_time >= start_ts and t2.block_time >= end_ts
+    WHERE t1.block_time >= start_ts and t1.block_time < end_ts
+    AND t2.block_time >= start_ts and t2.block_time < end_ts
     AND t.to NOT IN (
         select address
         from balancer.address_mappings
@@ -59,9 +61,21 @@ END
 $function$;
 
 -- fill 2021
-SELECT balancer.arbitrage_mappings('2021-01-01', now());
+SELECT balancer.arbitrage_mappings('2021-01-01', '2021-02-01');
+SELECT balancer.arbitrage_mappings('2021-02-01', '2021-03-01');
+SELECT balancer.arbitrage_mappings('2021-03-01', '2021-04-01');
+SELECT balancer.arbitrage_mappings('2021-04-01', '2021-05-01');
+SELECT balancer.arbitrage_mappings('2021-05-01', '2021-06-01');
+SELECT balancer.arbitrage_mappings('2021-06-01', '2021-07-01');
+SELECT balancer.arbitrage_mappings('2021-07-01', '2021-08-01');
+SELECT balancer.arbitrage_mappings('2021-08-01', '2021-09-01');
+SELECT balancer.arbitrage_mappings('2021-09-01', '2021-10-01');
+SELECT balancer.arbitrage_mappings('2021-10-01', '2021-11-01');
+SELECT balancer.arbitrage_mappings('2021-11-01', now());
 
 -- daily update
 INSERT INTO cron.job (schedule, command)
 VALUES ('1 22 * * *', $$SELECT balancer.arbitrage_mappings((SELECT now() - interval '3 days'), now());$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+
+COMMIT;

--- a/polygon/balancer/arbitrage_mappings.sql
+++ b/polygon/balancer/arbitrage_mappings.sql
@@ -1,0 +1,67 @@
+CREATE OR REPLACE FUNCTION balancer.arbitrage_mappings(start_ts timestamptz, end_ts timestamptz=now()) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH rows AS (
+    INSERT into balancer.address_mappings (
+        address,
+        label,
+        type,
+        author
+    )
+    SELECT
+        DISTINCT(t.to) AS address,
+        'arbitrage bot' AS label,
+        'dapp usage' AS type,
+        'balancerlabs' AS author
+    FROM dex.trades t1
+    INNER JOIN dex.trades t2
+    ON t1.tx_hash = t2.tx_hash
+    AND t1.token_a_address = t2.token_b_address
+    AND t1.token_b_address = t2.token_a_address
+    AND ((t1.project = 'Balancer' AND t2.project = 'Quickswap') or (t1.project = 'Quickswap' AND t2.project = 'Balancer'))
+    INNER JOIN polygon.transactions t ON t.hash = t1.tx_hash
+    WHERE t1.block_time >= start_ts and t1.block_time >= end_ts
+    AND t2.block_time >= start_ts and t2.block_time >= end_ts
+    AND t.to NOT IN (
+        select address
+        from balancer.address_mappings
+        where author = 'balancerlabs'
+        and type = 'balancer_source'
+    )
+    UNION ALL
+    SELECT
+        DISTINCT(t.to) AS address,
+        'arbitrage bot' AS label,
+        'dapp usage' AS type,
+        'balancerlabs' AS author
+    FROM dex.trades t1
+    INNER JOIN dex.trades t2
+    ON t1.tx_hash = t2.tx_hash
+    AND t1.token_a_address = t2.token_b_address
+    AND t1.token_b_address = t2.token_a_address
+    AND ((t1.project = 'Balancer' AND t2.project = 'Sushiswap') or (t1.project = 'Sushiswap' AND t2.project = 'Balancer'))
+    INNER JOIN polygon.transactions t ON t.hash = t1.tx_hash
+    WHERE t1.block_time >= start_ts and t1.block_time >= end_ts
+    AND t2.block_time >= start_ts and t2.block_time >= end_ts
+    AND t.to NOT IN (
+        select address
+        from balancer.address_mappings
+        where author = 'balancerlabs'
+        and type = 'balancer_source'
+    )
+    ON CONFLICT DO NOTHING
+    RETURNING 1
+)
+SELECT count(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+-- fill 2021
+SELECT balancer.arbitrage_mappings('2021-01-01', now());
+
+-- daily update
+INSERT INTO cron.job (schedule, command)
+VALUES ('1 22 * * *', $$SELECT balancer.arbitrage_mappings((SELECT now() - interval '3 days'), now());$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/polygon/balancer/balancer_v2_pool_mappings.sql
+++ b/polygon/balancer/balancer_v2_pool_mappings.sql
@@ -1,0 +1,75 @@
+CREATE OR REPLACE FUNCTION balancer.balancer_v2_pool_mappings() RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH rows AS (
+    INSERT into balancer.address_mappings (
+        address,
+        label,
+        type,
+        author
+    )
+    with pools as (
+        select c."poolId" as pool_id, unnest(cc.tokens) as token_address, unnest(cc.weights)/1e18 as normalized_weight, cc.symbol, 'WP' as pool_type
+        from balancer_v2."Vault_evt_PoolRegistered" c
+        inner join balancer_v2."WeightedPoolFactory_call_create" cc
+        on c.evt_tx_hash = cc.call_tx_hash
+
+        union all
+
+        select c."poolId" as pool_id, unnest(cc.tokens) as token_address, unnest(cc.weights)/1e18 as normalized_weight, cc.symbol, 'WP2T' as pool_type
+        from balancer_v2."Vault_evt_PoolRegistered" c
+        inner join balancer_v2."WeightedPool2TokensFactory_call_create" cc
+        on c.evt_tx_hash = cc.call_tx_hash
+
+        union all
+
+        select c."poolId" as pool_id, unnest(cc.tokens) as token_address, 0 as normalized_weight, cc.symbol, 'SP' as pool_type
+        from balancer_v2."Vault_evt_PoolRegistered" c
+        inner join balancer_v2."StablePoolFactory_call_create" cc
+        on c.evt_tx_hash = cc.call_tx_hash
+
+        union all
+
+        select c."poolId" as pool_id, unnest(cc.tokens) as token_address, 0 as normalized_weight, cc.symbol, 'LBP' as pool_type
+        from balancer_v2."Vault_evt_PoolRegistered" c
+        inner join balancer_v2."LiquidityBootstrappingPoolFactory_call_create" cc
+        on c.evt_tx_hash = cc.call_tx_hash
+    ),
+    settings as (
+        select pool_id,
+        coalesce(t.symbol,'?') as token_symbol,
+        normalized_weight,
+        p.symbol as pool_symbol,
+        p.pool_type
+        from pools p
+        left join erc20.tokens t on p.token_address = t.contract_address
+    )
+    SELECT
+      SUBSTRING(pool_id FOR 20) as address,
+      case when pool_type in ('SP', 'LBP') then lower(pool_symbol)
+      else
+      lower(CONCAT(string_agg(token_symbol, '/'), ' ', string_agg(cast(norm_weight as text), '/')))
+      end AS label,
+      'balancer_v2_pool' AS type,
+      'balancerlabs' as author
+    FROM   (
+        select s1.pool_id, token_symbol, pool_symbol, cast(100*normalized_weight as integer) as norm_weight, pool_type from settings s1
+        order by 1 asc , 3 desc, 2 asc
+    ) s
+    GROUP  BY pool_id, pool_symbol, pool_type;
+    ON CONFLICT DO NOTHING
+    RETURNING 1
+)
+SELECT count(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+-- intial fill
+SELECT balancer.balancer_v2_pool_mappings();
+
+-- daily update
+INSERT INTO cron.job (schedule, command)
+VALUES ('2 22 * * *', $$SELECT balancer.balancer_v2_pool_mappings();$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/polygon/balancer/balancer_v2_pool_mappings.sql
+++ b/polygon/balancer/balancer_v2_pool_mappings.sql
@@ -1,3 +1,5 @@
+BEGIN;
+
 CREATE OR REPLACE FUNCTION balancer.balancer_v2_pool_mappings() RETURNS integer
 LANGUAGE plpgsql AS $function$
 DECLARE r integer;
@@ -57,7 +59,7 @@ WITH rows AS (
         select s1.pool_id, token_symbol, pool_symbol, cast(100*normalized_weight as integer) as norm_weight, pool_type from settings s1
         order by 1 asc , 3 desc, 2 asc
     ) s
-    GROUP  BY pool_id, pool_symbol, pool_type;
+    GROUP  BY pool_id, pool_symbol, pool_type
     ON CONFLICT DO NOTHING
     RETURNING 1
 )
@@ -73,3 +75,5 @@ SELECT balancer.balancer_v2_pool_mappings();
 INSERT INTO cron.job (schedule, command)
 VALUES ('2 22 * * *', $$SELECT balancer.balancer_v2_pool_mappings();$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+
+COMMIT;


### PR DESCRIPTION
## Problem solved

Refactored label entry scripts for Balancer on Polygon into normal entry scripts for regular DB table named `balancer.address_mappings`. The scripts run once every day

Original code:
- #434
- #466

## Checks 

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`

