### PR TITLE
Add WBNB

### DIFF
--- a/prices/bsc/coinpaprika.yaml
+++ b/prices/bsc/coinpaprika.yaml
@@ -8,6 +8,7 @@
   name: bnb-binance-coin
   id: bnb-binance-coin
   symbol: WBNB
+  decimals: 18
 - address: '0x2170ed0880ac9a755fd29b2688956bd959f933f8'
   decimals: 18
   id: eth-ethereum

--- a/prices/bsc/coinpaprika.yaml
+++ b/prices/bsc/coinpaprika.yaml
@@ -4,6 +4,10 @@
 - name: bnb_binance_coin
   id: bnb-binance-coin
   symbol: BNB
+- address: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c'
+  name: bnb-binance-coin
+  id: bnb-binance-coin
+  symbol: WBNB
 - address: '0x2170ed0880ac9a755fd29b2688956bd959f933f8'
   decimals: 18
   id: eth-ethereum


### PR DESCRIPTION
Adds WBNB that points to BNB (coinpaprika does not have WBNB) for making queries easier.
