### PR TITLE
Fix ens_names labels error

### DIFF
--- a/labels/ethereum/ens_names.sql
+++ b/labels/ethereum/ens_names.sql
@@ -28,5 +28,6 @@ SELECT
 FROM
     ethereumnameservice."ETHRegistrarController_3_evt_NameRegistered"
 WHERE
-    evt_block_time >= '{{timestamp}}';
-
+    evt_block_time >= '{{timestamp}}'
+    AND
+    LENGTH(name) < 10000;


### PR DESCRIPTION
This PR fixes an alert our labels manager was firing - https://dune.height.app/T-5002

The problem was basically that there were some `names` that were too long. This meant Postgres was failing on insert as this variable is used on one of the indexes and it was too big. To fix this I just limited the size of the `names`.

You can see it wasn't super common and so 99.9% of the data will be there:
```
 name_length | count 
-------------+-------
       38894 |     1
       10000 |     2
        4754 |     1
        1186 |     1
        1185 |     1
         670 |     1
         268 |     2
         256 |     1
         252 |     1
         224 |     1
         182 |     1
         171 |     1
         132 |     1
         127 |     1
         105 |     1
(15 rows)

Time: 111.169 ms
```