### PR TITLE
feat: add Poolsuite Executive Member to tokens.sql

### DIFF
--- a/ethereum/nft/tokens.sql
+++ b/ethereum/nft/tokens.sql
@@ -4817,6 +4817,7 @@ COPY nft.tokens (contract_address, name, symbol, standard) FROM stdin;
 \\xb32601bbc5136842b716a815d6cafe9a490f604d	make it beautIful		ERC721
 \\x7853f89f65344f9d6807d7080c4a02be1b12adb3	Cat Russell	CAAAT	ERC721
 \\xf36446105fF682999a442b003f2224BcB3D82067	Axolittles	AXOLITTLE	erc721
+\\xb228d7b6e099618ca71bd5522b3a8c3788a8f172 Poolsuite Executive Member POOLEXEC ERC721
 \.
 
 

--- a/ethereum/nft/tokens.sql
+++ b/ethereum/nft/tokens.sql
@@ -4817,7 +4817,7 @@ COPY nft.tokens (contract_address, name, symbol, standard) FROM stdin;
 \\xb32601bbc5136842b716a815d6cafe9a490f604d	make it beautIful		ERC721
 \\x7853f89f65344f9d6807d7080c4a02be1b12adb3	Cat Russell	CAAAT	ERC721
 \\xf36446105fF682999a442b003f2224BcB3D82067	Axolittles	AXOLITTLE	erc721
-\\xb228d7b6e099618ca71bd5522b3a8c3788a8f172 Poolsuite Executive Member POOLEXEC ERC721
+\\xb228d7b6e099618ca71bd5522b3a8c3788a8f172	Poolsuite Executive Member	POOLEXEC	ERC721
 \.
 
 


### PR DESCRIPTION
The purpose of this change is to add the Poolsuite token and NFT to `tokens.sql`

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`

First PR here, hopefully it looks okay!