### PR TITLE
GPv2 - View Trades

### DIFF
--- a/ethereum/gnosis_protocol_v2/view_trades.sql
+++ b/ethereum/gnosis_protocol_v2/view_trades.sql
@@ -35,20 +35,23 @@ WITH trades_with_prices AS (
                 tx_hash,
                 order_uid,
                 owner,
-                sell_token                             as sell_token_address,
+                sell_token                    as sell_token_address,
                 (CASE
                      WHEN s.symbol IS NULL THEN TEXT(sell_token)
                      ELSE s.symbol
-                    END)                               as sell_token,
-                buy_token                              as buy_token_address,
+                    END)                      as sell_token,
+                buy_token                     as buy_token_address,
                 (CASE
                      WHEN b.symbol IS NULL THEN TEXT(buy_token)
                      ELSE b.symbol
-                    END)                               as buy_token,
-                sell_amount / 10 ^ s.decimals          as units_sold,
-                buy_amount / 10 ^ b.decimals           as units_bought,
+                    END)                      as buy_token,
+                sell_amount / 10 ^ s.decimals as units_sold,
+                sell_amount                   as atoms_sold,
+                buy_amount / 10 ^ b.decimals  as units_bought,
+                buy_amount                    as atoms_bought,
                 -- We use sell value when possible and buy value when not
-                fee_amount / 10 ^ s.decimals           as fee,
+                fee_amount / 10 ^ s.decimals  as fee,
+                fee_amount                    as fee_atoms,
                 sell_price,
                 buy_price
          FROM trades_with_prices
@@ -62,13 +65,15 @@ WITH trades_with_prices AS (
          SELECT block_time,
                 tx_hash,
                 order_uid,
-                owner as trader,
+                owner    as trader,
                 sell_token_address,
                 sell_token,
                 buy_token_address,
                 buy_token,
                 units_sold,
+                atoms_sold,
                 units_bought,
+                atoms_bought,
                 -- We use sell value when possible and buy value when not
                 (CASE
                      WHEN sell_price IS NOT NULL THEN sell_price * units_sold
@@ -76,6 +81,7 @@ WITH trades_with_prices AS (
                      ELSE -0.01
                     END) as trade_value_usd,
                 fee,
+                fee_atoms,
                 (CASE
                      WHEN sell_price IS NOT NULL THEN sell_price * fee
                      WHEN sell_price IS NULL AND buy_price IS NOT NULL THEN buy_price * units_bought * fee / units_sold

--- a/ethereum/gnosis_protocol_v2/view_trades.sql
+++ b/ethereum/gnosis_protocol_v2/view_trades.sql
@@ -62,7 +62,7 @@ WITH trades_with_prices AS (
          SELECT block_time,
                 tx_hash,
                 order_uid,
-                owner,
+                owner as trader,
                 sell_token_address,
                 sell_token,
                 buy_token_address,

--- a/ethereum/gnosis_protocol_v2/view_trades.sql
+++ b/ethereum/gnosis_protocol_v2/view_trades.sql
@@ -52,9 +52,9 @@ WITH trades_with_prices AS (
                 sell_price,
                 buy_price
          FROM trades_with_prices
-                  LEFT OUTER JOIN dune_user_generated.erc20_extended s
+                  LEFT OUTER JOIN erc20.tokens s
                                   ON s.contract_address = sell_token
-                  LEFT OUTER JOIN dune_user_generated.erc20_extended b
+                  LEFT OUTER JOIN erc20.tokens b
                                   ON b.contract_address = buy_token
      ),
 

--- a/ethereum/gnosis_protocol_v2/view_trades.sql
+++ b/ethereum/gnosis_protocol_v2/view_trades.sql
@@ -88,24 +88,23 @@ WITH trades_with_prices AS (
                      ELSE -0.01
                     END) as fee_usd
          FROM trades_with_token_units
+         ORDER BY block_time DESC
      )
 -- This would be the kind of basic table we display when querying: It seems impractical to store the URL links
 -- created from the hashes (trader, transaction and order id) so they have not been included here.
---     results as (
---         SELECT
---             block_time,
---             CONCAT('<a href="https://etherscan.io/address/', CONCAT('0x', ENCODE(owner, 'hex')), '" target="_blank">', CONCAT('0x', ENCODE(owner, 'hex')),  '</a>') as trader,
---             sell_token,
---             buy_token,
---             units_sold,
---             units_bought,
---             trade_value_usd,
---             fee,
---             fee_usd,
---             CONCAT('<a href="https://etherscan.io/tx/', CONCAT('0x', ENCODE(tx_hash, 'hex')), '" target="_blank">', CONCAT('0x', ENCODE(tx_hash, 'hex')),  '</a>') as transaction,
---             CONCAT('<a href="https://gnosis-protocol.io/orders/', CONCAT('0x', ENCODE(order_uid, 'hex')), '" target="_blank">', CONCAT('0x', ENCODE(order_uid, 'hex')),  '</a>') as order_uid
---         FROM valued_trades
---     )
+-- SELECT
+--     block_time,
+--     CONCAT('<a href="https://etherscan.io/address/', CONCAT('0x', ENCODE(trader, 'hex')), '" target="_blank">', CONCAT('0x', ENCODE(trader, 'hex')),  '</a>') as trader,
+--     sell_token,
+--     buy_token,
+--     units_sold,
+--     units_bought,
+--     trade_value_usd,
+--     fee,
+--     fee_usd,
+--     CONCAT('<a href="https://etherscan.io/tx/', CONCAT('0x', ENCODE(tx_hash, 'hex')), '" target="_blank">', CONCAT('0x', ENCODE(tx_hash, 'hex')),  '</a>') as transaction,
+--     CONCAT('<a href="https://gnosis-protocol.io/orders/', CONCAT('0x', ENCODE(order_uid, 'hex')), '" target="_blank">', CONCAT('0x', ENCODE(order_uid, 'hex')),  '</a>') as order_uid
+-- FROM valued_trades
 
 SELECT *
 FROM valued_trades

--- a/ethereum/gnosis_protocol_v2/view_trades.sql
+++ b/ethereum/gnosis_protocol_v2/view_trades.sql
@@ -32,9 +32,9 @@ WITH trades_with_prices AS (
 
      trades_with_token_units as (
          SELECT block_time,
-                CONCAT('0x', ENCODE(tx_hash, 'hex'))   as tx_hash,
-                CONCAT('0x', ENCODE(order_uid, 'hex')) as order_uid,
-                CONCAT('0x', ENCODE(owner, 'hex'))     as trader,
+                tx_hash,
+                order_uid,
+                owner,
                 sell_token                             as sell_token_address,
                 (CASE
                      WHEN s.symbol IS NULL THEN TEXT(sell_token)
@@ -62,7 +62,7 @@ WITH trades_with_prices AS (
          SELECT block_time,
                 tx_hash,
                 order_uid,
-                trader,
+                owner,
                 sell_token_address,
                 sell_token,
                 buy_token_address,
@@ -88,7 +88,7 @@ WITH trades_with_prices AS (
 --     results as (
 --         SELECT
 --             block_time,
---             CONCAT('<a href="https://etherscan.io/address/', trader, '" target="_blank">', trader,  '</a>') as trader,
+--             CONCAT('<a href="https://etherscan.io/address/', CONCAT('0x', ENCODE(owner, 'hex')), '" target="_blank">', CONCAT('0x', ENCODE(owner, 'hex')),  '</a>') as trader,
 --             sell_token,
 --             buy_token,
 --             units_sold,
@@ -96,8 +96,8 @@ WITH trades_with_prices AS (
 --             trade_value_usd,
 --             fee,
 --             fee_usd,
---             CONCAT('<a href="https://etherscan.io/tx/', tx_hash, '" target="_blank">', tx_hash,  '</a>') as transaction,
---             CONCAT('<a href="https://gnosis-protocol.io/orders/', order_uid, '" target="_blank">', order_uid,  '</a>') as order_uid
+--             CONCAT('<a href="https://etherscan.io/tx/', CONCAT('0x', ENCODE(tx_hash, 'hex')), '" target="_blank">', CONCAT('0x', ENCODE(tx_hash, 'hex')),  '</a>') as transaction,
+--             CONCAT('<a href="https://gnosis-protocol.io/orders/', CONCAT('0x', ENCODE(order_uid, 'hex')), '" target="_blank">', CONCAT('0x', ENCODE(order_uid, 'hex')),  '</a>') as order_uid
 --         FROM valued_trades
 --     )
 
@@ -108,8 +108,9 @@ ORDER BY block_time DESC;
 
 CREATE UNIQUE INDEX IF NOT EXISTS view_trades_id ON gnosis_protocol_v2.view_trades (order_uid);
 CREATE INDEX view_trades_idx_1 ON gnosis_protocol_v2.view_trades (block_time);
-CREATE INDEX view_trades_idx_2 ON gnosis_protocol_v2.view_trades (sell_token);
-CREATE INDEX view_trades_idx_3 ON gnosis_protocol_v2.view_trades (buy_token);
+CREATE INDEX view_trades_idx_2 ON gnosis_protocol_v2.view_trades (sell_token_address);
+CREATE INDEX view_trades_idx_3 ON gnosis_protocol_v2.view_trades (buy_token_address);
+CREATE INDEX view_trades_idx_4 ON gnosis_protocol_v2.view_trades (trader);
 
 
 INSERT INTO cron.job (schedule, command)


### PR DESCRIPTION
Adding a view for all "valued" trades on Gnosis Protocol v2. This view is generated as an aggregation of 

- `gnosis_protocol_v2."GPv2Settlement_evt_Trade"`
- `prices.usd` and
- `erc20.tokens`

and an example of this results from this view can be found [here](https://dune.xyz/queries/37241/73825)

I've checked that:

* [x] the query produces the intended results - see above link.
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune 
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
