### PR TITLE
Add DYDX to price.usd

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1770,7 +1770,7 @@
   symbol: PPBLZ
   address: 0x4d2ee5dae46c86da2ff521f7657dad98834f97b8
   decimals: 18
-- name: dydx-dydx
+- name: dydx_dydx
   id: dydx-dydx
   symbol: DYDX
   address: 0x92d6c1e31e14520e676a687f0a93788b716beff5

--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1770,3 +1770,8 @@
   symbol: PPBLZ
   address: 0x4d2ee5dae46c86da2ff521f7657dad98834f97b8
   decimals: 18
+- name: dydx-dydx
+  id: dydx-dydx
+  symbol: DYDX
+  address: 0x92d6c1e31e14520e676a687f0a93788b716beff5
+  decimals: 18


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
