### PR TITLE
add nrge price feed

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1780,3 +1780,8 @@
   symbol: MOVE
   address: 0x3fa729b4548becbad4eab6ef18413470e6d5324c
   decimals: 18
+- name: nrge_energi
+  id: nrge-energi
+  symbol: NRGE
+  address: 0x1416946162b1c2c871a73b07e932d2fb6c932069
+  decimals: 18


### PR DESCRIPTION
Request to add NRGE price data

I've checked that:

* [x] the query produces the intended results
* [ ] the folder name matches the schema name
* [x] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
