### PR TITLE
adds numeric2bytea and bytea2numeric functions to polygon dataset

### DIFF
--- a/polygon/public/bytea2numeric.sql
+++ b/polygon/public/bytea2numeric.sql
@@ -1,0 +1,6 @@
+DROP FUNCTION bytea2numeric(bytea, boolean, text);
+CREATE FUNCTION bytea2numeric(a bytea, signed boolean = true, byteorder text = 'big')
+    RETURNS numeric
+AS $$
+    return int.from_bytes(a, byteorder=byteorder, signed=signed)
+$$ LANGUAGE plpython3u IMMUTABLE STRICT;

--- a/polygon/public/numeric2bytea.sql
+++ b/polygon/public/numeric2bytea.sql
@@ -1,0 +1,6 @@
+DROP FUNCTION numeric2bytea(numeric, integer, boolean, text);
+CREATE FUNCTION numeric2bytea (a numeric, _length integer = 32, signed boolean = true, byteorder text = 'big')
+  RETURNS bytea
+AS $$
+    return int(a).to_bytes(_length, byteorder=byteorder, signed=signed)
+$$ LANGUAGE plpython3u IMMUTABLE STRICT;


### PR DESCRIPTION
Hello, currently these functions [do not work on polygon datasets](https://dune.xyz/queries/296788), I am assuming this is because they do not exist within the `polygon/public` folder, like they do for both `ethereum/public` and `xdai/public`. This copies the `xdai` implementations into the `polygon` folder.

I've checked that:

* [X] the query produces the intended results **(same implementation works on xdai)**
* [X] the folder name matches the schema name
* [X] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`. **(is this applicable here?)**
* [X] the filename matches the defined view, table or function and ends with .sql
* [X] each file has only one view, table or function defined  
* [X] column names are `lowercase_snake_cased`
