### PR TITLE
GPv2: fix trade values in dex.trades

### DIFF
--- a/ethereum/dex/trades/insert_gnosis_protocol.sql
+++ b/ethereum/dex/trades/insert_gnosis_protocol.sql
@@ -86,7 +86,10 @@ WITH rows AS (
             NULL::bytea AS trader_b,
             t."buyAmount" AS token_a_amount_raw,
             t."sellAmount" AS token_b_amount_raw,
-            NULL::numeric AS usd_amount,
+            (CASE
+                 WHEN v.trade_value_usd >= 0 then v.trade_value_usd
+                 ELSE NULL::numeric
+            END) AS usd_amount,
             t."buyToken" token_a_address,
             t."sellToken" token_b_address,
             t.contract_address exchange_contract_address,
@@ -94,6 +97,8 @@ WITH rows AS (
             NULL::integer[] AS trace_address,
             t.evt_index
         FROM gnosis_protocol_v2."GPv2Settlement_evt_Trade" t
+        JOIN gnosis_protocol_v2."view_trades" v
+            ON "orderUid" = order_uid
     ) dexs
     INNER JOIN ethereum.transactions tx
         ON dexs.tx_hash = tx.hash

--- a/ethereum/gnosis_protocol_v2/view_trades.sql
+++ b/ethereum/gnosis_protocol_v2/view_trades.sql
@@ -101,7 +101,7 @@ WITH trades_with_prices AS (
                              ELSE sell_price * units_sold
                              END
                      WHEN sell_price IS NULL AND buy_price IS NOT NULL THEN buy_price * units_bought
-                     ELSE -0.01
+                     ELSE NULL::numeric
                     END)                                        as trade_value_usd,
                 buy_price * units_bought                        as buy_value_usd,
                 sell_price * units_sold                         as sell_value_usd,
@@ -115,7 +115,7 @@ WITH trades_with_prices AS (
                              ELSE sell_price * fee
                              END
                      WHEN sell_price IS NULL AND buy_price IS NOT NULL THEN buy_price * units_bought * fee / units_sold
-                     ELSE -0.01
+                     ELSE NULL::numeric
                     END)                                        as fee_usd,
                 app_data,
                 CONCAT('\x', substring(receiver from 3))::bytea as receiver


### PR DESCRIPTION
It has come to our attention that the trade usd amounts were in disagreement between our `trades_view` and `dex.trades`. This is due to recent developments in one place and not the other: 

[Here](https://dune.xyz/queries/299492) is a query showing the differences 

[Here](https://dune.xyz/queries/299557) is a query showing that the proposed change to dex.trades is working as "expected"

Essentially, we join the trade events with the trade view table so to fetch the usd valuation from there (instead of evaluating in both places). This would mean that continuous development of the trades view should result in changes being reflected in both places.

Note that I have also taken this opportunity to replace trade valuations of `-0.01` for `NULL` whenever trade value is "unknown"

I've checked that:

* [x] the query produces the intended results