### PR TITLE
Limit size of nft users collections label

### DIFF
--- a/labels/ethereum/nft_users_collections_traded.sql
+++ b/labels/ethereum/nft_users_collections_traded.sql
@@ -25,4 +25,5 @@ SELECT
     type,
     author
 FROM nft_users_collections_traded_clean 
-WHERE label = label_trim;
+WHERE label = label_trim
+    AND LENGTH(label) < 45;;


### PR DESCRIPTION
Still related to https://dune.height.app/T-5414 - limiting the size of name so this works with our current implementation of labels