### PR TITLE
Change id for polycrystal to crystl-finance

### DIFF
--- a/prices/polygon/coingecko.yaml
+++ b/prices/polygon/coingecko.yaml
@@ -231,7 +231,7 @@
 - id: polycat-finance
 - id: polychart
 - id: polycorn-finance
-- id: polycrystal
+- id: crystl-finance
 - id: polydoge
 - id: polyfi
 - id: polygold


### PR DESCRIPTION
PolyCrystal has rebranded to Crystl Finance. Read more at : https://crystlfinance.medium.com/polycrystal-rebranding-announcement-c2c72528ea5b

I've checked that:
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
