### PR TITLE
Temp HotFix: refresh baches only every hour

### DIFF
--- a/ethereum/gnosis_protocol_v2/view_batches.sql
+++ b/ethereum/gnosis_protocol_v2/view_batches.sql
@@ -64,13 +64,13 @@ FROM batch_info
 ORDER BY block_time DESC;
 
 
-CREATE UNIQUE INDEX IF NOT EXISTS view_batches_id ON gnosis_protocol_v2.view_batches (tx_hash);
+CREATE INDEX view_batches_id ON gnosis_protocol_v2.view_batches (tx_hash);
 CREATE INDEX view_batches_idx_1 ON gnosis_protocol_v2.view_batches (block_time);
 CREATE INDEX view_batches_idx_2 ON gnosis_protocol_v2.view_batches (solver_address);
 CREATE INDEX view_batches_idx_3 ON gnosis_protocol_v2.view_batches (num_trades);
 
 
 INSERT INTO cron.job (schedule, command)
-VALUES ('*/60 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol_v2.view_batches')
+VALUES ('*/30 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol_v2.view_batches')
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
 COMMIT;

--- a/ethereum/gnosis_protocol_v2/view_batches.sql
+++ b/ethereum/gnosis_protocol_v2/view_batches.sql
@@ -71,6 +71,6 @@ CREATE INDEX view_batches_idx_3 ON gnosis_protocol_v2.view_batches (num_trades);
 
 
 INSERT INTO cron.job (schedule, command)
-VALUES ('*/30 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol_v2.view_batches')
+VALUES ('*/60 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol_v2.view_batches')
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
 COMMIT;


### PR DESCRIPTION
We have discovered that [this view](https://dune.xyz/queries/38617/76300) has not been refreshed in over a day and I suspect it is because it takes more than 30 minutes to run the query but the query is being rerun every 30 minutes. This is only a temporary solution to a problem we have been discussing in more detail [here](https://github.com/duneanalytics/abstractions/pull/642#issuecomment-994505104)




