### PR TITLE
Revert "Temp HotFix: refresh baches only every hour"

### DIFF
--- a/ethereum/gnosis_protocol_v2/view_batches.sql
+++ b/ethereum/gnosis_protocol_v2/view_batches.sql
@@ -64,7 +64,7 @@ FROM batch_info
 ORDER BY block_time DESC;
 
 
-CREATE INDEX view_batches_id ON gnosis_protocol_v2.view_batches (tx_hash);
+CREATE UNIQUE INDEX IF NOT EXISTS view_batches_id ON gnosis_protocol_v2.view_batches (tx_hash);
 CREATE INDEX view_batches_idx_1 ON gnosis_protocol_v2.view_batches (block_time);
 CREATE INDEX view_batches_idx_2 ON gnosis_protocol_v2.view_batches (solver_address);
 CREATE INDEX view_batches_idx_3 ON gnosis_protocol_v2.view_batches (num_trades);


### PR DESCRIPTION
This change was only meant to temporarily mitigate a duplicate record (see [here](https://dune.xyz/queries/301879)) in the transactions table.

Along with this revert the following command should also be run on the database

```sql
DELETE FROM ethereum.transactions 
WHERE hash = '\x7184a4960605d477471f7fddf2dec18f95ed737ad6eec2f7c75568829aeaf1d9'
AND gas_used = 21000;
```

Reverts duneanalytics/abstractions#655