### PR TITLE
GPv2: Correct dex swaps for aggregator solvers

### DIFF
--- a/ethereum/gnosis_protocol_v2/view_trades.sql
+++ b/ethereum/gnosis_protocol_v2/view_trades.sql
@@ -144,8 +144,7 @@ SELECT *
 FROM valued_trades
 ORDER BY block_time DESC;
 
-
-CREATE UNIQUE INDEX IF NOT EXISTS view_trades_id ON gnosis_protocol_v2.view_trades (order_uid);
+CREATE INDEX view_trades_id ON gnosis_protocol_v2.view_trades (order_uid);
 CREATE INDEX view_trades_idx_1 ON gnosis_protocol_v2.view_trades (block_time);
 CREATE INDEX view_trades_idx_2 ON gnosis_protocol_v2.view_trades (sell_token_address);
 CREATE INDEX view_trades_idx_3 ON gnosis_protocol_v2.view_trades (buy_token_address);


### PR DESCRIPTION
This POC query demonstrates expected results: https://dune.xyz/queries/290498

The purpose is to correctly count the number of dex swaps when using aggregator solutions by counting the dex category entries in dex.trades for the corresponding transaction.

### Another independent change (HOT FIX)

Also, as a hot fix, we remove the unique index in the trade view because we now support partially fillable orders.
