### PR TITLE
GPv2 - Deduplicate Trade Records

### DIFF
--- a/ethereum/gnosis_protocol_v2/view_trades.sql
+++ b/ethereum/gnosis_protocol_v2/view_trades.sql
@@ -79,6 +79,10 @@ WITH trades_with_prices AS (
          FROM batches_with_nested_uids_and_appdata
      ),
 
+     deduplicated_app_uid_map as (
+         select distinct on (uid) uid, app_data, receiver from uid_to_app_id
+     ),
+
      valued_trades as (
          SELECT block_time,
                 tx_hash,
@@ -120,9 +124,8 @@ WITH trades_with_prices AS (
                 app_data,
                 CONCAT('\x', substring(receiver from 3))::bytea as receiver
          FROM trades_with_token_units
-                  JOIN uid_to_app_id
+                  JOIN deduplicated_app_uid_map
                        ON uid = order_uid
-         ORDER BY block_time DESC
      )
 -- This would be the kind of basic table we display when querying: It seems impractical to store the URL links
 -- created from the hashes (trader, transaction and order id) so they have not been included here.


### PR DESCRIPTION
We have recently encountered a "partially fillable" order which has caused one of our mapping tables to have duplicated records and (as a result) multiple duplicate records in the trades view. There were some especially large valued trades duplicated, causing a gross miscalculation in the dex.trades table (for yesterday's trading volume).

This change fixes the `gnosis_protocol_v2.view_trades` but I think additional update will need to be made to the dex.trades table (which updates according to the values here). From my understanding of the refresh interval the next update of dex.trades would fail to remove all of yesterday's duplicate records.

Here is a POC query demonstrating that the results are as intended:

https://dune.xyz/queries/288467

Note that the following `order_uids` are of special interest here as picked out of [this query](https://dune.xyz/queries/309159) which displays all the duplicate records.

```sh
\x6c433117175d075d3b29ae97b84a6ceb810c7e863a56323503f8d5da7efb1655042b32ac6b453485e357938bdc38e0340d4b927661c1b02a
\x4a3927813f512fcc6ba710ee44d2a9204d21e997c5c122a60d1d4a2106fdd848042b32ac6b453485e357938bdc38e0340d4b927661c2639b
\xcd7d287522bced335060b9b8018fda3d1b553bf1d3f543fec0436f99c8b12a21042b32ac6b453485e357938bdc38e0340d4b927661c1afa0
\x68cfcbfd137658f1dc218799b84ced56cfd2a98cc1246bd0821e9f4374a8a839042b32ac6b453485e357938bdc38e0340d4b927661c1af3f
```


Furthermore, although I don't yet have the right query prepared for dropping records from `dex.trades` table the following procedure should be kept in mind.

Drop **all but one** occurrence of a duplicate (i.e. literally identical in all fields) record in dex.trades where project = 'Gnosis Protocol'. Unfortunately, the `order_uid` is not part of the `dex.trades` table but any query dropping duplicates should suffice.


