### PR TITLE
GPv2 - Unique Index on Trades View

### DIFF
--- a/ethereum/gnosis_protocol_v2/view_trades.sql
+++ b/ethereum/gnosis_protocol_v2/view_trades.sql
@@ -147,12 +147,13 @@ SELECT *
 FROM valued_trades
 ORDER BY block_time DESC;
 
-CREATE INDEX view_trades_id ON gnosis_protocol_v2.view_trades (order_uid);
+CREATE UNIQUE INDEX IF NOT EXISTS view_trades_id ON gnosis_protocol_v2.view_trades (order_uid, tx_hash);
 CREATE INDEX view_trades_idx_1 ON gnosis_protocol_v2.view_trades (block_time);
 CREATE INDEX view_trades_idx_2 ON gnosis_protocol_v2.view_trades (sell_token_address);
 CREATE INDEX view_trades_idx_3 ON gnosis_protocol_v2.view_trades (buy_token_address);
 CREATE INDEX view_trades_idx_4 ON gnosis_protocol_v2.view_trades (trader);
 CREATE INDEX view_trades_idx_5 ON gnosis_protocol_v2.view_trades (app_data);
+CREATE INDEX view_trades_idx_6 ON gnosis_protocol_v2.view_trades (tx_hash);
 
 
 INSERT INTO cron.job (schedule, command)


### PR DESCRIPTION
Based on the errors logs refreshing this table it appears that postgres insists we have a unique index defined.
Now that order ids are no longer unique we can at least fall back on the fact that a single order would only be matched one per transaction. This isn't necessarily guaranteed by the [smart contract](https://etherscan.io/address/0x9008D19f58AAbD9eD0D60971565AA8510560ab41#code), but I am confident that we will not be seeing an instance of this anytime soon (if ever).

Note I have additionally created an index for `tx_hash` which was missing for some reason before. Note sure if its against the rules to index on a tuple containing another field being indexed or not....

```
> ERROR:  cannot refresh materialized view "gnosis_protocol_v2.view_trades" concurrently
> HINT:  Create a unique index with no WHERE clause on one or more columns of the materialized view.
```