### PR TITLE
Remove extra whitespace

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1786,11 +1786,11 @@
   address: 0x1416946162b1c2c871a73b07e932d2fb6c932069
   decimals: 18
 - name: bpro_bprotocol
-  id: bpro-bprotocol    
-  symbol: BPRO 				      
-  address: 0xbbbbbbb5aa847a2003fbc6b5c16df0bd1e725f61       
-  decimals: 18              
-  decimals: 18       
+  id: bpro-bprotocol
+  symbol: BPRO
+  address: 0xbbbbbbb5aa847a2003fbc6b5c16df0bd1e725f61
+  decimals: 18
+  decimals: 18
 - name: bent_finance
   id: bent-bent-finance
   symbol: BENT


### PR DESCRIPTION
https://github.com/duneanalytics/abstractions/pull/661 added some extra whitespace which can cause issues when parsing the YAML. This PR just strips the extra whitespace.