### PR TITLE
Add 0xnodes BIOS token 

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1831,3 +1831,8 @@
   symbol: UP
   address: 0xb6c5c839cef46082a2b51164e8db649c121f147e
   decimals: 18
+- name: bios-0xnodes
+  id: bios-0xnodes
+  symbol: BIOS
+  address: 0xAACa86B876ca011844b5798ECA7a67591A9743C8
+  decimals: 18


### PR DESCRIPTION
Added 0xNODES BIOS token: https://coinpaprika.com/coin/bios-0xnodes/

I've checked that:

* [X] the query produces the intended results
* [X] the folder name matches the schema name
* [X] the schema name exists in Dune
* [X] views are prefixed with `view_`, functions with `fn_`.
* [X] the filename matches the defined view, table or function and ends with .sql
* [X] each file has only one view, table or function defined  
* [X] column names are `lowercase_snake_cased`
