### PR TITLE
Update insert_hourly_bridge_token_price_ratios.sql

### DIFF
--- a/optimism2/prices/insert_hourly_bridge_token_price_ratios.sql
+++ b/optimism2/prices/insert_hourly_bridge_token_price_ratios.sql
@@ -143,11 +143,11 @@ SELECT prices.insert_hourly_bridge_token_price_ratios('2021-11-01', '2021-12-01'
 
 SELECT prices.insert_hourly_bridge_token_price_ratios('2021-12-01', '2021-12-16');
 
--- Have the insert script run twice every hour at minute 16 and 46
+-- Have the insert script run twice every hour at minute 15 and 45
 -- `start-time` is set to go back three days in time so that entries can be retroactively updated 
 -- in case `dex.trades` or price data falls behind.
 INSERT INTO cron.job (schedule, command)
-VALUES ('16,46 * * * *', $$
+VALUES ('15,45 * * * *', $$
     SELECT prices.insert_hourly_bridge_token_price_ratios(
         (SELECT date_trunc('hour', now()) - interval '3 days'),
         (SELECT date_trunc('hour', now())));


### PR DESCRIPTION
Updating cron to be 1 min ahead of the full prices update

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
