### PR TITLE
Update date range and cron for optimism prices

### DIFF
--- a/optimism2/prices/insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/insert_approx_prices_from_dex_data.sql
@@ -448,7 +448,7 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('16,46 * * * *', $$
     SELECT prices.insert_approx_prices_from_dex_data(
         (SELECT date_trunc('hour', now()) - interval '3 days'),
-        (SELECT now() )
+        (SELECT DATE_TRUNC('hour',now()) )
     );
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/optimism2/prices/insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/insert_approx_prices_from_dex_data.sql
@@ -6,7 +6,7 @@ BEGIN
 WITH 
 
 hour_gs AS (
-SELECT generate_series(DATE_TRUNC('hour',start_time - interval '3 days') , DATE_TRUNC('hour',end_time) , '1 hour') AS hour
+SELECT generate_series(DATE_TRUNC('hour',start_time) , DATE_TRUNC('hour',end_time) , '1 hour') AS hour
 )
 
 , dex_price_stables AS (
@@ -447,8 +447,8 @@ WHERE NOT EXISTS (SELECT * FROM prices.approx_prices_from_dex_data WHERE hour >=
 INSERT INTO cron.job (schedule, command)
 VALUES ('16,46 * * * *', $$
     SELECT prices.insert_approx_prices_from_dex_data(
-        (SELECT date_trunc('hour', now()) - interval '3 days'),
-        (SELECT DATE_TRUNC('hour',now()) )
+        (SELECT DATE_TRUNC('hour', now()) - interval '3 days'),
+        (SELECT DATE_TRUNC('hour', now()) + interval '1 hour')
     );
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;


### PR DESCRIPTION
I noticed that dex trades isn't pulling in prices because this table seems to be ~12 hours behind. Any ideas? I can't recreate this this issue in my user generated version.

- Adding date_trunc back in to the cron job since we do this in the query anyway.
- Adding 1 hour interval to the end to pull forward prices to handle for minutes 1 - 15 of the next hour. Price and sample size should be updated on conflict.
- Removing 3 day interval from 'hour_gs' on start_time since we already account for this in the cron.

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
