### PR TITLE
Fix 1inch Uniswap V3 integration tokens order

### DIFF
--- a/ethereum/dex/trades/insert_1inch.sql
+++ b/ethereum/dex/trades/insert_1inch.sql
@@ -162,6 +162,7 @@ WITH rows AS (
                         and substring(tr1.input from 1 for 4) = '\x23b872dd' -- transferFrom()
                         and substring(tr1.input from 17 for 20) = sender
                         and substring(tr1.input from 49 for 20) = substring(numeric2bytea(mod(pools[1], 2^160::numeric)) from 13 for 20)
+                        and COALESCE(call_trace_address, array[]::int[]) = tr1.trace_address[:COALESCE(ARRAY_LENGTH(call_trace_address, 1), 0)]
                     limit 1
                 ), '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') as "srcToken",
                 COALESCE((
@@ -170,6 +171,7 @@ WITH rows AS (
                         and substring(tr2.input from 1 for 4) = '\xa9059cbb' -- transfer()
                         and substring(tr2.input from 17 for 20) = recipient
                         and tr2.from = substring(numeric2bytea(mod(pools[array_length(pools, 1)], 2^160::numeric)) from 13 for 20)
+                        and COALESCE(call_trace_address, array[]::int[]) = tr2.trace_address[:COALESCE(ARRAY_LENGTH(call_trace_address, 1), 0)]
                     limit 1
                 ), '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') as "dstToken",
                 "pools",


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
