### PR TITLE
add POOL to token list

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1851,3 +1851,8 @@
   symbol: BIOS
   address: 0xAACa86B876ca011844b5798ECA7a67591A9743C8
   decimals: 18
+- name: pooltogether
+  id: pool-pooltogether
+  symbol: POOL
+  address: 0x0cec1a9154ff802e7934fc916ed7ca50bde6844e
+  decimals: 18


### PR DESCRIPTION
adding $POOL to the list.

https://coinpaprika.com/coin/pool-pooltogether/

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
