### PR TITLE
Backfill OP2 Prices + Add Logic for Gaps

### DIFF
--- a/optimism2/prices/backfill_gaps_insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/backfill_gaps_insert_approx_prices_from_dex_data.sql
@@ -1,0 +1,84 @@
+CREATE OR REPLACE FUNCTION prices.backfill_gaps_insert_approx_prices_from_dex_data(start_time timestamptz, end_time timestamptz=now()) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+
+WITH
+hour_gs AS (
+SELECT generate_series(DATE_TRUNC('hour',start_time) , DATE_TRUNC('hour',end_time) , '1 hour') AS hour
+)
+--Fill in gaps
+
+, hour_token_gs AS (
+WITH token_list AS (
+    SELECT token, symbol, decimals FROM  prices.approx_prices_from_dex_data
+    GROUP BY 1,2,3
+    )
+
+SELECT 
+hour, token, symbol, decimals
+FROM
+token_list, hour_gs
+
+)
+
+
+
+--logic to fill in gaps https://dba.stackexchange.com/questions/186218/carry-over-long-sequence-of-missing-values-with-postgres
+, final_prices AS (
+SELECT
+token AS contract_address, hour
+, first_value(median_price) OVER (PARTITION BY token, grp ORDER BY hour) AS median_price
+, first_value(num_samples) OVER (PARTITION BY token, grp ORDER BY hour) AS sample_size
+
+, symbol, decimals
+     
+FROM (
+    SELECT 
+    gs.hour, gs.token, gs.symbol, gs.decimals, p.median_price, p.num_samples, 
+        count(p.median_price) OVER (PARTITION BY gs.token ORDER BY gs.hour) AS grp
+    FROM hour_token_gs gs
+    LEFT JOIN prices.approx_prices_from_dex_data p
+        ON gs.hour = p.hour
+        AND gs.token = p.contract_address
+        AND gs.symbol = p.symbol
+        AND gs.decimals = p.decimals
+    ) fill
+)
+,
+rows AS (
+    INSERT INTO prices.approx_prices_from_dex_data (
+        contract_address,
+        hour,
+        median_price,
+        sample_size,
+        symbol,
+        decimals
+    )
+
+    SELECT 
+        contract_address,
+        hour,
+        median_price,
+        sample_size,
+        symbol,
+        decimals
+    FROM final_prices
+
+    ON CONFLICT (contract_address, hour) DO UPDATE SET median_price = EXCLUDED.median_price, sample_size = EXCLUDED.sample_size
+    RETURNING 1
+)
+
+SELECT count(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+-- Monthly backfill starting 11 Nov 2021 (regenesis
+--TODO: Add pre-regenesis prices
+
+SELECT prices.backfill_gaps_insert_approx_prices_from_dex_data('2021-11-01', '2021-30-01')
+
+
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/optimism2/prices/backfill_gaps_insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/backfill_gaps_insert_approx_prices_from_dex_data.sql
@@ -11,7 +11,7 @@ SELECT generate_series(DATE_TRUNC('hour',start_time) , DATE_TRUNC('hour',end_tim
 
 , hour_token_gs AS (
 WITH token_list AS (
-    SELECT token, symbol, decimals FROM  prices.approx_prices_from_dex_data
+    SELECT contract_address AS token, symbol, decimals FROM  prices.approx_prices_from_dex_data
     GROUP BY 1,2,3
     )
 
@@ -35,7 +35,7 @@ token AS contract_address, hour
      
 FROM (
     SELECT 
-    gs.hour, gs.token, gs.symbol, gs.decimals, p.median_price, p.num_samples, 
+    gs.hour, gs.token, gs.symbol, gs.decimals, p.median_price, p.sample_size AS num_samples,
         count(p.median_price) OVER (PARTITION BY gs.token ORDER BY gs.hour) AS grp
     FROM hour_token_gs gs
     LEFT JOIN prices.approx_prices_from_dex_data p
@@ -77,8 +77,5 @@ $function$;
 -- Monthly backfill starting 11 Nov 2021 (regenesis
 --TODO: Add pre-regenesis prices
 
-SELECT prices.backfill_gaps_insert_approx_prices_from_dex_data('2021-11-01', '2021-30-01')
+SELECT prices.backfill_gaps_insert_approx_prices_from_dex_data('2021-11-11', '2021-12-30')
 
-
-$$)
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/optimism2/prices/backfill_gaps_insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/backfill_gaps_insert_approx_prices_from_dex_data.sql
@@ -1,3 +1,5 @@
+--Intended for one-off use to backfill price gaps.
+
 CREATE OR REPLACE FUNCTION prices.backfill_gaps_insert_approx_prices_from_dex_data(start_time timestamptz, end_time timestamptz=now()) RETURNS integer
 LANGUAGE plpgsql AS $function$
 DECLARE r integer;

--- a/optimism2/prices/insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/insert_approx_prices_from_dex_data.sql
@@ -9,6 +9,25 @@ hour_gs AS (
 SELECT generate_series(DATE_TRUNC('hour',start_time) , DATE_TRUNC('hour',end_time) , '1 hour') AS hour
 )
 
+, starting_prices AS ( --carry over previous prices if no trades (to avoid gaps)
+	WITH last_updates AS (
+		SELECT        
+		contract_address,
+		MAX(hour) AS last_hour
+		FROM dune_user_generated.test_approx_prices_from_dex_data
+		WHERE median_price IS NOT NULL
+		AND hour <= (start_time - interval '3 days')
+		AND contract_address != '\xdeaddeaddeaddeaddeaddeaddeaddeaddead0000' --Raw ETH, gets auto-filled in from WETH later
+		GROUP BY 1
+		)
+	SELECT p.contract_address AS token, DATE_TRUNC('hour',(start_time - interval '3 days')) AS hour, p.median_price, 1 AS num_samples, p.symbol, p.decimals
+	FROM dune_user_generated.test_approx_prices_from_dex_data p
+	INNER JOIN last_updates u
+		ON u.contract_address = p.contract_address
+		AND u.last_hour = p.hour
+	GROUP BY 1,2,3,4,5,6
+)
+
 , dex_price_stables AS (
 --for tokens where dune doesn't have the price, calculate the median price, assuming USDT, DAI, USDC = 1
 SELECT
@@ -344,9 +363,9 @@ INNER JOIN prices_vs_stables p
 
 , price AS (
 WITH get_best_price_estimate AS (
-SELECT hour, token, symbol, decimals, median_price, num_samples
+SELECT hour, token, symbol, decimals, median_price, num_samples, rnk
     FROM (    
-        SELECT *, DENSE_RANK() OVER (PARTITION BY hour, token ORDER BY num_samples DESC, rnk ASC) AS p_rank --pick which price to take
+        SELECT *, ROW_NUMBER() OVER (PARTITION BY hour, token ORDER BY num_samples DESC, rnk ASC) AS p_rank --pick which price to take
         FROM (
             SELECT hour, token, symbol, decimals, median_price, num_samples, 1 AS rnk FROM prices_vs_stables WHERE "window" = 1 --when trades happened
 		UNION ALL
@@ -355,13 +374,16 @@ SELECT hour, token, symbol, decimals, median_price, num_samples
             SELECT hour, token, symbol, decimals, median_price, num_samples, -1 AS rnk FROM dex_price_synths --always use synths for susd
 		UNION ALL
             SELECT hour, token, symbol, decimals, median_price, num_samples, -1 AS rnk FROM dex_price_bridge_tokens --bridge tokens
+        	UNION ALL
+            SELECT hour, token, symbol, decimals, median_price, num_samples, 99 AS rnk FROM starting_prices --starting point if null
             ) a
+            WHERE median_price IS NOT NULL
         ) r
     WHERE p_rank = 1
     )
-SELECT hour, token, symbol, decimals, median_price, num_samples FROM get_best_price_estimate
+SELECT hour, token, symbol, decimals, median_price, num_samples, rnk FROM get_best_price_estimate
 UNION ALL
-SELECT hour, '\xdeaddeaddeaddeaddeaddeaddeaddeaddead0000' AS token, 'ETH' AS symbol, 18 AS decimals, median_price, num_samples
+SELECT hour, '\xdeaddeaddeaddeaddeaddeaddeaddeaddead0000' AS token, 'ETH' AS symbol, 18 AS decimals, median_price, num_samples, rnk
 FROM get_best_price_estimate WHERE token = '\x4200000000000000000000000000000000000006'
 
 )

--- a/optimism2/prices/insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/insert_approx_prices_from_dex_data.sql
@@ -14,14 +14,14 @@ SELECT generate_series(DATE_TRUNC('hour',start_time) , DATE_TRUNC('hour',end_tim
 		SELECT        
 		contract_address,
 		MAX(hour) AS last_hour
-		FROM dune_user_generated.test_approx_prices_from_dex_data
+		FROM prices.approx_prices_from_dex_data
 		WHERE median_price IS NOT NULL
 		AND hour <= (start_time - interval '3 days')
 		AND contract_address != '\xdeaddeaddeaddeaddeaddeaddeaddeaddead0000' --Raw ETH, gets auto-filled in from WETH later
 		GROUP BY 1
 		)
 	SELECT p.contract_address AS token, DATE_TRUNC('hour',(start_time - interval '3 days')) AS hour, p.median_price, 1 AS num_samples, p.symbol, p.decimals
-	FROM dune_user_generated.test_approx_prices_from_dex_data p
+	FROM prices.approx_prices_from_dex_data p
 	INNER JOIN last_updates u
 		ON u.contract_address = p.contract_address
 		AND u.last_hour = p.hour


### PR DESCRIPTION
This creates a one-off backfill job "backfill_gaps_insert_approx_prices_from_dex_data.sql" add adds logic to pull the most recent price for each token at the start of a new price update in "insert_approx_prices_from_dex_data.sql" to *hopefully* fix the error where tokens would show a null price if they did not have any trades during the first hour of the time range.

I've checked that:

* [ x] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
