### PR TITLE
Add BICO token to prices abstraction yaml

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1856,3 +1856,8 @@
   symbol: POOL
   address: 0x0cec1a9154ff802e7934fc916ed7ca50bde6844e
   decimals: 18
+- name: biconomy
+  id: bico-biconomy
+  symbol: BICO
+  address: 0xf17e65822b568b3903685a7c9f496cf7656cc6c2
+  decimals: 18


### PR DESCRIPTION
I've checked that:

* [ x ] the query produces the intended results
* [ x ] the folder name matches the schema name
* [ x ] the schema name exists in Dune
* [ x ] views are prefixed with `view_`, functions with `fn_`.
* [ x ] the filename matches the defined view, table or function and ends with .sql
* [ x ] each file has only one view, table or function defined  
* [ x ] column names are `lowercase_snake_cased`
-note, these don't apply