### PR TITLE
Update backfill_gaps_insert_approx_prices_from_dex_data.sql

### DIFF
--- a/optimism2/prices/backfill_gaps_insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/backfill_gaps_insert_approx_prices_from_dex_data.sql
@@ -84,7 +84,7 @@ WHERE NOT EXISTS (SELECT * FROM prices.approx_prices_from_dex_data WHERE median_
                     AND hour >= '2021-11-11'::timestamptz AND hour <= '2021-12-30'::timestamptz);
 
 INSERT INTO cron.job (schedule, command)
-VALUES ('15,45 * * * *', $$
+VALUES ('13,43 * * * *', $$
     SELECT prices.backfill_gaps_insert_approx_prices_from_dex_data(
         (SELECT DATE_TRUNC('hour', now()) - interval '3 days'),
         (SELECT DATE_TRUNC('hour', now()) + interval '1 hour')

--- a/optimism2/prices/backfill_gaps_insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/backfill_gaps_insert_approx_prices_from_dex_data.sql
@@ -79,5 +79,15 @@ $function$;
 -- Monthly backfill starting 11 Nov 2021 (regenesis
 --TODO: Add pre-regenesis prices
 
-SELECT prices.backfill_gaps_insert_approx_prices_from_dex_data('2021-11-11', '2021-12-30')
+SELECT prices.backfill_gaps_insert_approx_prices_from_dex_data('2021-11-11'::timestamptz, '2021-12-30'::timestamptz)
+WHERE NOT EXISTS (SELECT * FROM prices.approx_prices_from_dex_data WHERE median_price IS NULL
+                    AND hour >= '2021-11-11'::timestamptz AND hour <= '2021-12-30'::timestamptz);
 
+INSERT INTO cron.job (schedule, command)
+VALUES ('15,45 * * * *', $$
+    SELECT prices.backfill_gaps_insert_approx_prices_from_dex_data(
+        (SELECT DATE_TRUNC('hour', now()) - interval '3 days'),
+        (SELECT DATE_TRUNC('hour', now()) + interval '1 hour')
+    );
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;


### PR DESCRIPTION
Some gaps are still appearing... Adding a backfill  cron while I figure it out.

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
