### PR TITLE
Add views for ERC-721 owners and CryptoPunk owners

### DIFF
--- a/ethereum/nft/view_cryptopunk_owners.sql
+++ b/ethereum/nft/view_cryptopunk_owners.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE VIEW nft.view_cryptopunk_owners AS
+
+WITH
+    initial_owners AS (
+        SELECT DISTINCT UNNEST(indices) as token_id, UNNEST(addresses) as owner
+        FROM cryptopunks."CryptoPunksMarket_call_setInitialOwners"
+    ),
+    current_owners AS (
+        SELECT token_id, owner FROM (
+            SELECT
+                "punkIndex" AS token_id,
+                "to" AS owner,
+                evt_block_number AS block_number,
+                ROW_NUMBER() OVER (PARTITION BY "punkIndex" ORDER BY evt_block_number DESC) AS idx
+            FROM cryptopunks."CryptoPunksMarket_evt_PunkTransfer"
+        ) owner_history WHERE idx = 1
+    ),
+    wrapped_owners AS (
+        SELECT token_id, owner FROM view_erc721_owners
+        WHERE contract_address = '\xb7f7f6c52f2e2fdb1963eab30438024864c313f6'
+        AND owner != '\x0000000000000000000000000000000000000000'
+    )
+
+SELECT
+    token_id.token_id AS token_id,
+    COALESCE(wrapped.owner, current.owner, initial.owner) AS owner
+FROM generate_series(0::numeric, 9999::numeric) token_id
+LEFT JOIN initial_owners initial ON initial.token_id = token_id.token_id
+LEFT JOIN current_owners current ON current.token_id = token_id.token_id
+LEFT JOIN wrapped_owners wrapped ON wrapped.token_id = token_id.token_id

--- a/ethereum/nft/view_erc721_owners.sql
+++ b/ethereum/nft/view_erc721_owners.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE VIEW nft.view_erc721_owners AS
+
+SELECT contract_address, token_id, owner FROM (
+    SELECT
+        contract_address,
+        "tokenId" AS token_id,
+        "to" AS owner,
+        ROW_NUMBER() OVER (PARTITION BY contract_address, "tokenId" ORDER BY evt_block_time DESC) AS idx
+    FROM erc721."ERC721_evt_Transfer"
+) owner_history WHERE idx = 1


### PR DESCRIPTION
I am currently using these exact queries (copy+pasted and renamed) to build some other queries for [this dashboard](https://dune.xyz/frolic/PROOF-Collective) and thought they'd be useful views for others.

Let me know if it makes more sense to turn these into true tables with a regular update cron.

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
