### PR TITLE
Update optimism2 dex price approximations

### DIFF
--- a/optimism2/dex/backfill_insert_missing_prices.sql
+++ b/optimism2/dex/backfill_insert_missing_prices.sql
@@ -4,7 +4,7 @@
 -- But these most recent trades may not have a usd amount if we haven't yet calculated a dex price from previous trades. So, we:
 -- 3. Backfill the usd_amount of the most recent dex.trades, in order to fill this gap
 
-CREATE OR REPLACE FUNCTION dex.backfill_update_missing_prices(start_ts timestamptz, end_ts timestamptz=now(), start_block numeric=0, end_block numeric=9e18) RETURNS integer
+CREATE OR REPLACE FUNCTION dex.backfill_insert_missing_prices(start_ts timestamptz, end_ts timestamptz=now(), start_block numeric=0, end_block numeric=9e18) RETURNS integer
 LANGUAGE plpgsql AS $function$
 DECLARE r integer;
 BEGIN
@@ -97,7 +97,7 @@ $function$;
 
 INSERT INTO cron.job (schedule, command)
 VALUES ('18,48 * * * *', $$
-    SELECT dex.backfill_update_missing_prices(
+    SELECT dex.backfill_insert_missing_prices(
         (SELECT max(block_time) - interval '25 hours' FROM dex.trades), --small 1 hr buffer for safety with time offsets
         (SELECT now() - interval '20 minutes'),
         (SELECT max(number) FROM optimism.blocks WHERE time < (SELECT max(block_time) - interval '25 hours' FROM dex.trades)), 

--- a/optimism2/dex/backfill_insert_missing_prices.sql
+++ b/optimism2/dex/backfill_insert_missing_prices.sql
@@ -62,7 +62,7 @@ WITH rows AS (
         trade_id
         
         FROM dex.trades dexs
-        WHERE dexs.block_time >= start_ts AND dexs.block_time < end_ts
+        
         
         LEFT JOIN erc20.tokens erc20a ON erc20a.contract_address = dexs.token_a_address
         LEFT JOIN erc20.tokens erc20b ON erc20b.contract_address = dexs.token_b_address
@@ -77,6 +77,7 @@ WITH rows AS (
           AND pb.hour >= start_ts
           AND pb.hour < end_ts
     
+    WHERE dexs.block_time >= start_ts AND dexs.block_time < end_ts
     
     -- update if we have new info on prices or the erc20
     ON CONFLICT (project, tx_hash, evt_index, trade_id)

--- a/optimism2/dex/backfill_update_missing_prices.sql
+++ b/optimism2/dex/backfill_update_missing_prices.sql
@@ -1,0 +1,106 @@
+-- Since we're pulling prices from dex trades, we:
+-- 1. Add in dex.trades
+-- 2. Calculate token prices from those dex.trades
+-- But these most recent trades may not have a usd amount if we haven't yet calculated a dex price from previous trades. So, we:
+-- 3. Backfill the usd_amount of the most recent dex.trades, in order to fill this gap
+
+CREATE OR REPLACE FUNCTION dex.backfill_update_missing_prices(start_ts timestamptz, end_ts timestamptz=now(), start_block numeric=0, end_block numeric=9e18) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH rows AS (
+    INSERT INTO dex.trades (
+        block_time,
+        token_a_symbol,
+        token_b_symbol,
+        token_a_amount,
+        token_b_amount,
+        project,
+        version,
+        category,
+        trader_a,
+        trader_b,
+        token_a_amount_raw,
+        token_b_amount_raw,
+        usd_amount,
+        token_a_address,
+        token_b_address,
+        exchange_contract_address,
+        tx_hash,
+        tx_from,
+        tx_to,
+        trace_address,
+        evt_index,
+        trade_id
+    )
+    SELECT
+      block_time,
+        erc20a.symbol AS token_a_symbol,
+        erc20b.symbol AS token_b_symbol,
+        token_a_amount_raw / 10 ^ erc20a.decimals AS token_a_amount,
+        token_b_amount_raw / 10 ^ erc20b.decimals AS token_b_amount,
+        project,
+        version,
+        category,
+        trader_a,
+        trader_b,
+        token_a_amount_raw,
+        token_b_amount_raw,
+        coalesce(
+            usd_amount,
+            token_a_amount_raw / 10 ^ pa.decimals * pa.median_price,
+            token_b_amount_raw / 10 ^ pb.decimals * pb.median_price
+        ) as usd_amount,
+        token_a_address,
+        token_b_address,
+        exchange_contract_address,
+        tx_hash,
+        tx_from,
+        tx_to,
+        trace_address,
+        evt_index,
+        trade_id
+        
+        FROM dex.trades dexs
+        WHERE dexs.block_time >= start_ts AND dexs.block_time < end_ts
+        
+        LEFT JOIN erc20.tokens erc20a ON erc20a.contract_address = dexs.token_a_address
+        LEFT JOIN erc20.tokens erc20b ON erc20b.contract_address = dexs.token_b_address
+        LEFT JOIN prices.approx_prices_from_dex_data pa
+        ON pa.hour = date_trunc('hour', dexs.block_time)
+          AND pa.contract_address = dexs.token_a_address
+          AND pa.hour >= start_ts
+          AND pa.hour < end_ts
+        LEFT JOIN prices.approx_prices_from_dex_data pb
+        ON pb.hour = date_trunc('hour', dexs.block_time)
+          AND pb.contract_address = dexs.token_b_address
+          AND pb.hour >= start_ts
+          AND pb.hour < end_ts
+    
+    
+    -- update if we have new info on prices or the erc20
+    ON CONFLICT (project, tx_hash, evt_index, trade_id)
+    DO UPDATE SET
+        usd_amount = EXCLUDED.usd_amount,
+        token_a_amount = EXCLUDED.token_a_amount,
+        token_b_amount = EXCLUDED.token_b_amount,
+        token_a_symbol = EXCLUDED.token_a_symbol,
+        token_b_symbol = EXCLUDED.token_b_symbol
+    RETURNING 1
+)
+SELECT count(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+
+
+INSERT INTO cron.job (schedule, command)
+VALUES ('18,48 * * * *', $$
+    SELECT dex.backfill_update_missing_prices(
+        (SELECT max(block_time) - interval '25 hours' FROM dex.trades), --small 1 hr buffer for safety with time offsets
+        (SELECT now() - interval '20 minutes'),
+        (SELECT max(number) FROM optimism.blocks WHERE time < (SELECT max(block_time) - interval '25 hours' FROM dex.trades)), 
+        (SELECT MAX(number) FROM optimism.blocks where time < now() - interval '20 minutes'));
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/optimism2/dex/insert_uniswap_v3.sql
+++ b/optimism2/dex/insert_uniswap_v3.sql
@@ -123,7 +123,7 @@ WHERE NOT EXISTS (
 );
 
 INSERT INTO cron.job (schedule, command)
-VALUES ('27,57 * * * *', $$
+VALUES ('15,45 * * * *', $$
     SELECT dex.insert_uniswap_v3(
         (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap' AND version = '3'),
         (SELECT now() - interval '20 minutes'),

--- a/optimism2/dex/insert_uniswap_v3.sql
+++ b/optimism2/dex/insert_uniswap_v3.sql
@@ -99,7 +99,14 @@ WITH rows AS (
         AND pb.hour >= start_ts
         AND pb.hour < end_ts
 
-    ON CONFLICT DO NOTHING
+    -- update if we have new info on prices or the erc20
+    ON CONFLICT (project, tx_hash, evt_index, trade_id)
+    DO UPDATE SET
+        usd_amount = EXCLUDED.usd_amount,
+        token_a_amount = EXCLUDED.token_a_amount,
+        token_b_amount = EXCLUDED.token_b_amount,
+        token_a_symbol = EXCLUDED.token_a_symbol,
+        token_b_symbol = EXCLUDED.token_b_symbol
     RETURNING 1
 )
 SELECT count(*) INTO r from rows;

--- a/optimism2/dex/trades.sql
+++ b/optimism2/dex/trades.sql
@@ -22,7 +22,8 @@ CREATE TABLE IF NOT EXISTS dex.trades (
     tx_to bytea,
     trace_address integer[],
     evt_index integer,
-    trade_id integer
+    trade_id integer,
+        UNIQUE (project, tx_hash, evt_index, trade_id)
 );
 
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS dex_trades_proj_tr_addr_uniq_idx ON dex.trades (project, tx_hash, trace_address, trade_id);

--- a/optimism2/prices/insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/insert_approx_prices_from_dex_data.sql
@@ -471,7 +471,7 @@ WHERE NOT EXISTS (SELECT * FROM prices.approx_prices_from_dex_data WHERE hour >=
 INSERT INTO cron.job (schedule, command)
 VALUES ('16,46 * * * *', $$
     SELECT prices.insert_approx_prices_from_dex_data(
-        (SELECT DATE_TRUNC('hour', now()) - interval '3 days'),
+        (SELECT MAX(hour) - interval '1 hour' FROM prices.approx_prices_from_dex_data),
         (SELECT DATE_TRUNC('hour', now()) + interval '1 hour')
     );
 $$)


### PR DESCRIPTION
Adding logic to run this order of operations:
1. Insert dex trades (may or may not have an up to date price)
2. Run price calculations, update the prices table.
3. Backfill dex trades with the prices just calculated.

Plus some other required fixes (i.e. adding unique modifiers to table creates)

I've checked that:

* [x ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
