### PR TITLE
Update backfill_gaps_insert_approx_prices_from_dex_data.sql

### DIFF
--- a/optimism2/prices/backfill_gaps_insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/backfill_gaps_insert_approx_prices_from_dex_data.sql
@@ -66,6 +66,7 @@ rows AS (
         symbol,
         decimals
     FROM final_prices
+        WHERE median_price IS NOT NULL
 
     ON CONFLICT (contract_address, hour) DO UPDATE SET median_price = EXCLUDED.median_price, sample_size = EXCLUDED.sample_size
     RETURNING 1


### PR DESCRIPTION
Adding in a not null check to make sure we don't overwrite good prices with null prices.

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
