### PR TITLE
Update backfill_gaps_insert_approx_prices_from_dex_data.sql

### DIFF
--- a/optimism2/prices/backfill_gaps_insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/backfill_gaps_insert_approx_prices_from_dex_data.sql
@@ -1,6 +1,6 @@
 --Intended for one-off use to backfill price gaps.
 
-CREATE OR REPLACE FUNCTION prices.backfill_gaps_insert_approx_prices_from_dex_data(start_time timestamptz, end_time timestamptz=now()) RETURNS integer
+CREATE OR REPLACE FUNCTION prices.backfill_gaps_insert_approx_prices_from_dex_data(start_time timestamp, end_time timestamp=now()) RETURNS integer
 LANGUAGE plpgsql AS $function$
 DECLARE r integer;
 BEGIN


### PR DESCRIPTION
testing if making these timestamps instead of timestamptz helps

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
