### PR TITLE
Update insert_hourly_bridge_token_price_ratios.sql

### DIFF
--- a/optimism2/prices/insert_hourly_bridge_token_price_ratios.sql
+++ b/optimism2/prices/insert_hourly_bridge_token_price_ratios.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION prices.insert_hourly_bridge_token_price_ratios(start_time timestamp, end_time timestamp=now()) RETURNS integer
+CREATE OR REPLACE FUNCTION prices.insert_hourly_bridge_token_price_ratios(start_time timestamptz, end_time timestamptz=now()) RETURNS integer
 LANGUAGE plpgsql AS $function$
 DECLARE r integer;
 BEGIN


### PR DESCRIPTION
testing if making these timestamps instead of timestamptz helps.

Fixing a divide by zero error

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
