### PR TITLE
Price backfill for eth pairs

### DIFF
--- a/ethereum/dex/backfill_usd_prices.sql
+++ b/ethereum/dex/backfill_usd_prices.sql
@@ -18,13 +18,13 @@ FROM
 			d.evt_index,
 			d.trade_id,
 			d.usd_amount as original,
-			d.token_a_amount_raw / 10 ^ pa.decimals * pa.price as pa_price,
-			d.token_b_amount_raw / 10 ^ pb.decimals * pb.price as pb_price,
+			d.token_a_amount_raw / 10 ^ (CASE token_a_address WHEN '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN 18 ELSE pa.decimals END) * (CASE token_a_address WHEN '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN pe.price ELSE pa.price END) as pa_price,
+			d.token_b_amount_raw / 10 ^ (CASE token_b_address WHEN '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN 18 ELSE pb.decimals END) * (CASE token_b_address WHEN '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN pe.price ELSE pb.price END) as pb_price,
 			d.token_a_symbol as pa_symb,
 			d.token_b_symbol as pb_symb,
 			coalesce(
-				d.token_a_amount_raw / 10 ^ pa.decimals * pa.price,
-				d.token_b_amount_raw / 10 ^ pb.decimals * pb.price
+				d.token_a_amount_raw / 10 ^ (CASE token_a_address WHEN '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN 18 ELSE pa.decimals END) * (CASE token_a_address WHEN '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN pe.price ELSE pa.price END),
+				d.token_b_amount_raw / 10 ^ (CASE token_b_address WHEN '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN 18 ELSE pb.decimals END) * (CASE token_b_address WHEN '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN pe.price ELSE pb.price END)
 			) as usd_amount
 		FROM
 			dex.trades d
@@ -36,6 +36,10 @@ FROM
 			AND pb."minute" >= start_ts
 			AND pb."minute" < end_ts
 			AND date_trunc('minute', d.block_time) = pb."minute"
+			LEFT JOIN prices.layer1_usd pe ON pe.minute = date_trunc('minute', dexs.block_time)
+			AND pe.symbol = 'ETH'
+			AND pe.minute >= start_ts
+			AND pe.minute < end_ts
 		WHERE
 			block_time >= start_ts
 			AND block_time < end_ts

--- a/ethereum/dex/backfill_usd_prices.sql
+++ b/ethereum/dex/backfill_usd_prices.sql
@@ -36,7 +36,7 @@ FROM
 			AND pb."minute" >= start_ts
 			AND pb."minute" < end_ts
 			AND date_trunc('minute', d.block_time) = pb."minute"
-			LEFT JOIN prices.layer1_usd pe ON pe.minute = date_trunc('minute', dexs.block_time)
+			LEFT JOIN prices.layer1_usd pe ON pe.minute = date_trunc('minute', d.block_time)
 			AND pe.symbol = 'ETH'
 			AND pe.minute >= start_ts
 			AND pe.minute < end_ts
@@ -44,7 +44,7 @@ FROM
 			block_time >= start_ts
 			AND block_time < end_ts
 			and d.usd_amount is NULL
-			and (pa.price is not NULL or pb.price is not null)
+			and (pa.price is not NULL or pb.price is not null or pe.price is not null)
 	) as new_prices
 where
 	block_time >= start_ts

--- a/ethereum/dex/backfill_usd_prices.sql
+++ b/ethereum/dex/backfill_usd_prices.sql
@@ -64,7 +64,7 @@ $function$;
 -- daily backfill run
 -- back fill last 3 days in case something goes wrong over the weekend
 INSERT INTO cron.job (schedule, command)
-VALUES ('52 3 * * *', $$
+VALUES ('52 * * * *', $$
     SELECT dex.backfill_usd_amount(
         (SELECT now() - interval '3 days'),
         (SELECT now() - interval '20 minutes'));


### PR DESCRIPTION
**Problem:**
The prices for new altcoins are not available on the platform right after their creation. This [function](https://github.com/duneanalytics/abstractions/blob/master/ethereum/dex/backfill_usd_prices.sql) is used to backfill the prices when new coins are added to the platform. However it overwrites the usd_values for the swaps where the price was taken from the ETH value and the price for the swapped altcoin is still not available.

**Solution proposed:**
Add `prices.layer1_usd` for ETH pairs, to use ETH values during backfill.

**Documentation:**
I created two different queries. The first one only uses `prices.usd` and the second one uses `prices.layer1_usd` in addition to that.

**[query1](https://dune.xyz/queries/333086)**

**[query2](https://dune.xyz/queries/330647)**