### PR TITLE
Add Sandbox to the list of synced prices on Polygon

### DIFF
--- a/prices/polygon/coingecko.yaml
+++ b/prices/polygon/coingecko.yaml
@@ -398,4 +398,3 @@
 - id: btc-2x-flexible-leverage-index
 - id: index-cooperative
 - id: the-sandbox
-

--- a/prices/polygon/coingecko.yaml
+++ b/prices/polygon/coingecko.yaml
@@ -397,3 +397,5 @@
 - id: eth-2x-flexible-leverage-index
 - id: btc-2x-flexible-leverage-index
 - id: index-cooperative
+- id: the-sandbox
+


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
