### PR TITLE
Add ens_names_reverse labels on Ethereum

### DIFF
--- a/labels/ethereum/ens_names_reverse.sql
+++ b/labels/ethereum/ens_names_reverse.sql
@@ -1,0 +1,10 @@
+SELECT
+    DISTINCT ON (name) lower(name) AS label,
+    (SELECT "from" FROM ethereum."transactions" WHERE block_time >= '{{timestamp}}' AND hash = call_tx_hash LIMIT 1) AS address,
+    'ens name reverse' AS type,
+    'twodam' AS author
+FROM ethereumnameservice."ReverseRegistrar_v2_call_setName"
+WHERE call_success
+AND call_block_time >= '{{timestamp}}'
+-- only select newest record
+ORDER BY name, call_block_time DESC


### PR DESCRIPTION
Track `ENS Reverse Register.setName` to get reverse record on ENS

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
