### PR TITLE
Add ens_names_reverse labels

### DIFF
--- a/labels/ethereum/ens_names_reverse.sql
+++ b/labels/ethereum/ens_names_reverse.sql
@@ -9,6 +9,7 @@ ens_transactions AS (
         ("to" = '\x9062c0a6dbd6108336bcbe4593a3d1ce05512069' OR "to" = '\x084b1c3c81545d370f3634392de611caabff8148')
          -- Only successful transactions
         AND success IS TRUE
+        AND call_block_time >= '{{timestamp}}'
     ORDER BY "from", block_number DESC
 ),
 
@@ -18,13 +19,13 @@ ens_calls AS (
     -- Old Reverse Registrar
     FROM ethereumnameservice."ReverseRegistrar_v1_call_setName"
     -- To avoid issues with long names on Dune's side
-    WHERE char_length(name) < 10000 AND call_success IS TRUE
+    WHERE char_length(name) < 10000 AND call_success IS TRUE AND call_block_time >= '{{timestamp}}'
     UNION
     -- Reverse Registrar
     SELECT name AS ens_name, call_block_number AS block_number, call_tx_hash AS hash
     FROM ethereumnameservice."ReverseRegistrar_v2_call_setName"
     -- To avoid issues with long names on Dune's side
-    WHERE char_length(name) < 10000 AND call_success IS TRUE
+    WHERE char_length(name) < 10000 AND call_success IS TRUE AND call_block_time >= '{{timestamp}}'
 )
 
 -- Latest snapshot of ENS Reverse Records

--- a/labels/ethereum/ens_names_reverse.sql
+++ b/labels/ethereum/ens_names_reverse.sql
@@ -19,13 +19,13 @@ ens_calls AS (
     -- Old Reverse Registrar
     FROM ethereumnameservice."ReverseRegistrar_v1_call_setName"
     -- To avoid issues with long names on Dune's side
-    WHERE char_length(name) < 10000 AND call_success IS TRUE AND call_block_time >= '{{timestamp}}'
+    WHERE length(name) < 10000 AND call_success IS TRUE AND call_block_time >= '{{timestamp}}'
     UNION
     -- Reverse Registrar
     SELECT name AS ens_name, call_block_number AS block_number, call_tx_hash AS hash
     FROM ethereumnameservice."ReverseRegistrar_v2_call_setName"
     -- To avoid issues with long names on Dune's side
-    WHERE char_length(name) < 10000 AND call_success IS TRUE AND call_block_time >= '{{timestamp}}'
+    WHERE length(name) < 10000 AND call_success IS TRUE AND call_block_time >= '{{timestamp}}'
 )
 
 -- Latest snapshot of ENS Reverse Records

--- a/labels/ethereum/ens_names_reverse.sql
+++ b/labels/ethereum/ens_names_reverse.sql
@@ -1,0 +1,37 @@
+WITH 
+
+-- Only last Reverse Registrar transaction per eth_addr
+ens_transactions AS (
+    SELECT DISTINCT ON ("from") "from" AS eth_addr, block_number, block_time, hash as tx_hash
+    FROM ethereum."transactions" 
+    WHERE
+        -- Old Reverse Registrar and Reverse Registrar contracts
+        ("to" = '\x9062c0a6dbd6108336bcbe4593a3d1ce05512069' OR "to" = '\x084b1c3c81545d370f3634392de611caabff8148')
+         -- Only successful transactions
+        AND success IS TRUE
+    ORDER BY "from", block_number DESC
+),
+
+-- Reverse Registrar setName calls
+ens_calls AS (
+    SELECT name AS ens_name, call_block_number AS block_number, call_tx_hash AS tx_hash
+    -- Old Reverse Registrar
+    FROM ethereumnameservice."ReverseRegistrar_v1_call_setName"
+    -- To avoid issues with long names on Dune's side
+    WHERE char_length(name) < 10000 AND call_success IS TRUE
+    UNION
+    -- Reverse Registrar
+    SELECT name AS ens_name, call_block_number AS block_number, call_tx_hash AS hash
+    FROM ethereumnameservice."ReverseRegistrar_v2_call_setName"
+    -- To avoid issues with long names on Dune's side
+    WHERE char_length(name) < 10000 AND call_success IS TRUE
+)
+
+-- Latest snapshot of ENS Reverse Records
+SELECT 
+    t.eth_addr AS address, 
+    c.ens_name AS label,
+    'ens name reverse' AS type,
+    'sashaxyz' AS author
+FROM ens_transactions AS t
+INNER JOIN ens_calls AS c ON c.block_number = t.block_number AND c.tx_hash = t.tx_hash AND t.block_time >= '{{timestamp}}' AND c.ens_name != '0x0000000000000000000000000000000000000000'

--- a/labels/ethereum/ens_names_reverse.sql
+++ b/labels/ethereum/ens_names_reverse.sql
@@ -33,6 +33,6 @@ SELECT
     t.eth_addr AS address, 
     c.ens_name AS label,
     'ens name reverse' AS type,
-    'sashaxyz' AS author
+    'zxsasha' AS author
 FROM ens_transactions AS t
 INNER JOIN ens_calls AS c ON c.block_number = t.block_number AND c.tx_hash = t.tx_hash AND c.ens_name != '0x0000000000000000000000000000000000000000'

--- a/labels/ethereum/ens_names_reverse.sql
+++ b/labels/ethereum/ens_names_reverse.sql
@@ -35,4 +35,4 @@ SELECT
     'ens name reverse' AS type,
     'sashaxyz' AS author
 FROM ens_transactions AS t
-INNER JOIN ens_calls AS c ON c.block_number = t.block_number AND c.tx_hash = t.tx_hash AND t.block_time >= '{{timestamp}}' AND c.ens_name != '0x0000000000000000000000000000000000000000'
+INNER JOIN ens_calls AS c ON c.block_number = t.block_number AND c.tx_hash = t.tx_hash AND c.ens_name != '0x0000000000000000000000000000000000000000'


### PR DESCRIPTION
Latest snapshot of ENS Reverse Records

I've checked that:

* [ y] the query produces the intended results
* [ y] the folder name matches the schema name
* [ y] the schema name exists in Dune
* [ y] views are prefixed with `view_`, functions with `fn_`.
* [ y] the filename matches the defined view, table or function and ends with .sql
* [ y] each file has only one view, table or function defined  
* [ y] column names are `lowercase_snake_cased`
