### PR TITLE
Update l1 gas price oracle cron in op2

### DIFF
--- a/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
+++ b/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
@@ -97,7 +97,7 @@ WHERE NOT EXISTS (
 INSERT INTO cron.job (schedule, command)
 VALUES ('5,15,25,35,45,55 * * * *', $$
  SELECT ovm2.insert_l1_gas_price_oracle_updates(
-        (SELECT MAX(block_number) FROM ovm2.l1_gas_price_oracle_updates),
+        (SELECT MAX(block_number) - 5001 FROM ovm2.l1_gas_price_oracle_updates),
         (SELECT MAX(number) +5000 FROM optimism.blocks)
         );
 $$)

--- a/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
+++ b/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
@@ -95,10 +95,10 @@ WHERE NOT EXISTS (
 );
 
 INSERT INTO cron.job (schedule, command)
-VALUES ('5,15,25,35,45,55 * * * *', $$
+VALUES ('* * * * *', $$
  SELECT ovm2.insert_l1_gas_price_oracle_updates(
-        (SELECT MAX(block_number) - 5001 FROM ovm2.l1_gas_price_oracle_updates WHERE block_time > NOW() - interval '1 week'),
-        (SELECT MAX(number) +5000 FROM optimism.blocks WHERE "time" > NOW() - interval '1 week')
+        (SELECT MAX(block_number) FROM ovm2.l1_gas_price_oracle_updates WHERE block_time > NOW() - interval '1 week'),
+        (SELECT MAX(number) FROM optimism.blocks WHERE "time" > NOW() - interval '1 week')
         );
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
+++ b/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
@@ -71,7 +71,7 @@ WITH rows AS (
 		) e_list
 	WHERE (block_number IS NOT NULL) AND (l1_gas_price IS NOT NULL) AND (block_time IS NOT NULL)
 
-	ON CONFLICT DO NOTHING
+	ON CONFLICT (block_number) DO UPDATE SET l1_gas_price = EXCLUDED.l1_gas_price, block_time = EXCLUDED.block_time
 	RETURNING 1
 )
 SELECT count(*) INTO r from rows;
@@ -98,7 +98,7 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('5,15,25,35,45,55 * * * *', $$
  SELECT ovm2.insert_l1_gas_price_oracle_updates(
         (SELECT MAX(block_number) FROM ovm2.l1_gas_price_oracle_updates),
-        (SELECT MAX(number) FROM optimism.blocks)
+        (SELECT MAX(number) +5000 FROM optimism.blocks)
         );
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
+++ b/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
@@ -97,8 +97,8 @@ WHERE NOT EXISTS (
 INSERT INTO cron.job (schedule, command)
 VALUES ('5,15,25,35,45,55 * * * *', $$
  SELECT ovm2.insert_l1_gas_price_oracle_updates(
-        (SELECT MAX(block_number) - 5001 FROM ovm2.l1_gas_price_oracle_updates),
-        (SELECT MAX(number) +5000 FROM optimism.blocks)
+        (SELECT MAX(block_number) - 5001 FROM ovm2.l1_gas_price_oracle_updates WHERE block_time > NOW() - interval '1 week'),
+        (SELECT MAX(number) +5000 FROM optimism.blocks WHERE "time" > NOW() - interval '1 week')
         );
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;


### PR DESCRIPTION
It works! But adding a 5000 block buffer to the end of the cron so that inner joins with this table work when blocks are produced in between cron runs. Let me know if you have other potential solution ideas!

I've checked that:

* [x] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
