### PR TITLE
fix balancer trades

### DIFF
--- a/ethereum/balancer_v2/view_bpt_prices.sql
+++ b/ethereum/balancer_v2/view_bpt_prices.sql
@@ -1,0 +1,66 @@
+BEGIN;
+
+DROP MATERIALIZED VIEW IF EXISTS balancer_v2.view_bpt_prices;
+
+CREATE MATERIALIZED VIEW balancer_v2.view_bpt_prices AS (
+    WITH bpt_trades AS (
+        SELECT
+            block_time,
+            bpt_address,
+            bpt_amount_raw,
+            bpt_amount_raw / 10 ^ erc20a.decimals AS bpt_amount,
+            token_amount_raw,
+            token_amount_raw / 10 ^ erc20b.decimals AS token_amount,
+            p.price * token_amount_raw / 10 ^ erc20b.decimals AS usd_amount
+        FROM (
+            SELECT
+                t.evt_block_time AS block_time,
+                CASE 
+                    WHEN t."tokenIn" = SUBSTRING(t."poolId" FOR 20) THEN t."tokenIn"
+                    ELSE t."tokenOut"
+                END AS bpt_address,
+                CASE 
+                    WHEN t."tokenIn" = SUBSTRING(t."poolId" FOR 20) THEN t."amountIn"
+                    ELSE t."amountOut"
+                END AS bpt_amount_raw,
+                CASE 
+                    WHEN t."tokenIn" = SUBSTRING(t."poolId" FOR 20) THEN t."tokenOut"
+                    ELSE t."tokenIn"
+                END AS token_address,
+                CASE 
+                    WHEN t."tokenIn" = SUBSTRING(t."poolId" FOR 20) THEN t."amountOut"
+                    ELSE t."amountIn"
+                END AS token_amount_raw
+            FROM balancer_v2."Vault_evt_Swap" t
+            WHERE t."tokenIn" = SUBSTRING(t."poolId" FOR 20)
+            OR t."tokenOut" = SUBSTRING(t."poolId" FOR 20)
+        ) dexs
+        JOIN erc20.tokens erc20a ON erc20a.contract_address = dexs.bpt_address
+        JOIN erc20.tokens erc20b ON erc20b.contract_address = dexs.token_address
+        LEFT JOIN prices.usd p ON p.minute = date_trunc('minute', dexs.block_time)
+        AND p.contract_address = dexs.token_address
+    ),
+
+    bpt_estimated_prices AS (
+        SELECT
+            block_time,
+            bpt_address,
+            usd_amount / bpt_amount AS price
+        FROM
+            bpt_trades
+    )
+
+    SELECT
+        date_trunc('hour', block_time) as hour,
+        bpt_address AS contract_address,
+        (PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY price)) AS median_price
+    FROM bpt_estimated_prices
+    GROUP BY 1, 2
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS dex_token_prices_unique ON balancer_v2.view_bpt_prices (hour, contract_address);
+
+INSERT INTO cron.job(schedule, command)
+VALUES ('* 1 * * *', $$REFRESH MATERIALIZED VIEW CONCURRENTLY balancer_v2.view_bpt_prices$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+COMMIT;

--- a/ethereum/dex/trades/insert_balancer.sql
+++ b/ethereum/dex/trades/insert_balancer.sql
@@ -45,7 +45,7 @@ WITH rows AS (
             token_a_amount_raw / 10 ^ pa.decimals * pa.price,
             token_b_amount_raw / 10 ^ pb.decimals * pb.price,
             token_a_amount_raw / 10 ^ erc20a.decimals * bpa.price,
-            token_b_amount_raw / 10 ^ erc20b.decimals * bpb.price,
+            token_b_amount_raw / 10 ^ erc20b.decimals * bpb.price
         ) as usd_amount,
         token_a_address,
         token_b_address,

--- a/ethereum/dex/trades/insert_balancer.sql
+++ b/ethereum/dex/trades/insert_balancer.sql
@@ -43,7 +43,9 @@ WITH rows AS (
         coalesce(
             usd_amount,
             token_a_amount_raw / 10 ^ pa.decimals * pa.price,
-            token_b_amount_raw / 10 ^ pb.decimals * pb.price
+            token_b_amount_raw / 10 ^ pb.decimals * pb.price,
+            token_a_amount_raw / 10 ^ erc20a.decimals * bpa.price,
+            token_b_amount_raw / 10 ^ erc20b.decimals * bpb.price,
         ) as usd_amount,
         token_a_address,
         token_b_address,
@@ -97,6 +99,8 @@ WITH rows AS (
             t.evt_index
         FROM
             balancer_v2."Vault_evt_Swap" t
+        WHERE t."tokenIn" != SUBSTRING(t."poolId" FOR 20)
+        AND t."tokenOut" != SUBSTRING(t."poolId" FOR 20)
     ) dexs
     INNER JOIN ethereum.transactions tx
         ON dexs.tx_hash = tx.hash
@@ -114,6 +118,24 @@ WITH rows AS (
         AND pb.contract_address = dexs.token_b_address
         AND pb.minute >= start_ts
         AND pb.minute < end_ts
+    LEFT JOIN balancer_v2.view_bpt_prices bpa ON bpa.contract_address = dexs.token_a_address
+        AND bpa.hour = (
+            SELECT MAX(hour)
+            FROM balancer_v2.view_bpt_prices
+            WHERE hour <= dexs.block_time
+            AND contract_address = dexs.token_b_address
+        )
+        AND bpa.hour >= start_ts
+        AND bpa.hour < end_ts
+    LEFT JOIN balancer_v2.view_bpt_prices bpb ON bpb.contract_address = dexs.token_b_address
+        AND bpb.hour = (
+            SELECT MAX(hour)
+            FROM balancer_v2.view_bpt_prices
+            WHERE hour <= dexs.block_time
+            AND contract_address = dexs.token_b_address
+        )
+        AND bpb.hour >= start_ts
+        AND bpb.hour < end_ts
     WHERE dexs.block_time >= start_ts
     AND dexs.block_time < end_ts
     ON CONFLICT DO NOTHING

--- a/ethereum/dex/trades/insert_balancer.sql
+++ b/ethereum/dex/trades/insert_balancer.sql
@@ -44,8 +44,8 @@ WITH rows AS (
             usd_amount,
             token_a_amount_raw / 10 ^ pa.decimals * pa.price,
             token_b_amount_raw / 10 ^ pb.decimals * pb.price,
-            token_a_amount_raw / 10 ^ erc20a.decimals * bpa.price,
-            token_b_amount_raw / 10 ^ erc20b.decimals * bpb.price
+            token_a_amount_raw / 10 ^ erc20a.decimals * bpa.median_price,
+            token_b_amount_raw / 10 ^ erc20b.decimals * bpb.median_price
         ) as usd_amount,
         token_a_address,
         token_b_address,


### PR DESCRIPTION
Balancer recently launched a Boosted Pool which broke a bit the `dex.trades` logic. 

1. Swaps where `tokenIn` or `tokenOut` is the pool token are actually joins/exits in that kind of pool. I added a `WHERE` clause at lines 102-103 to exclude them.

2. Trading against the Boosted Pool will lead to swaps between BPTs (Balancer Pool Tokens). Since we don't have them in the `prices.usd` table, the pool volume is currently zero. I created a `VIEW` to estimate the BPT prices and added to `dex.trades`. 

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
