### PR TITLE
Update to pull actual block_time

### DIFF
--- a/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
+++ b/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
@@ -62,13 +62,17 @@ WITH rows AS (
 
 	--https://dba.stackexchange.com/questions/186218/carry-over-long-sequence-of-missing-values-with-postgres
 
-	SELECT * FROM (
+	SELECT block_number, l1_gas_price, b.block_time --grab actual block time
+	FROM (
 	    SELECT block_number
 		, first_value(l1_gas_price) OVER (PARTITION BY grp ORDER BY block_number) AS l1_gas_price
 		, first_value(block_time) OVER (PARTITION BY grp ORDER BY block_number) AS block_time
 
 		FROM events
 		) e_list
+	INNER JOIN optimism.blocks b
+		ON b.block_number = e_list.block_number
+	
 	WHERE (block_number IS NOT NULL) AND (l1_gas_price IS NOT NULL) AND (block_time IS NOT NULL)
 
 	ON CONFLICT (block_number) DO UPDATE SET l1_gas_price = EXCLUDED.l1_gas_price, block_time = EXCLUDED.block_time

--- a/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
+++ b/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
@@ -62,7 +62,7 @@ WITH rows AS (
 
 	--https://dba.stackexchange.com/questions/186218/carry-over-long-sequence-of-missing-values-with-postgres
 
-	SELECT block_number, l1_gas_price, b.block_time --grab actual block time
+	SELECT e_list.block_number, e_list.l1_gas_price, b.block_time --grab actual block time
 	FROM (
 	    SELECT block_number
 		, first_value(l1_gas_price) OVER (PARTITION BY grp ORDER BY block_number) AS l1_gas_price

--- a/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
+++ b/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
@@ -62,7 +62,7 @@ WITH rows AS (
 
 	--https://dba.stackexchange.com/questions/186218/carry-over-long-sequence-of-missing-values-with-postgres
 
-	SELECT e_list.block_number, e_list.l1_gas_price, b.block_time --grab actual block time
+	SELECT e_list.block_number, e_list.l1_gas_price, b.time --grab actual block time
 	FROM (
 	    SELECT block_number
 		, first_value(l1_gas_price) OVER (PARTITION BY grp ORDER BY block_number) AS l1_gas_price
@@ -71,7 +71,7 @@ WITH rows AS (
 		FROM events
 		) e_list
 	INNER JOIN optimism.blocks b
-		ON b.block_number = e_list.block_number
+		ON b."number" = e_list.block_number
 	
 	WHERE (block_number IS NOT NULL) AND (l1_gas_price IS NOT NULL) AND (block_time IS NOT NULL)
 


### PR DESCRIPTION
Currently, this insert pulls the block time of when the gas price oracle was last updated. This change pulls the block_time from the actual block. This should help join performance, since we can join on block time and block number, rather than only block_number.

Would we be able to drop a regenerate the `ovm2.l1_gas_price_oracle_updates` so this change is reflected throughout?

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
