### PR TITLE
Update insert_approx_prices_from_dex_data.sql

### DIFF
--- a/optimism2/prices/insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/insert_approx_prices_from_dex_data.sql
@@ -481,7 +481,7 @@ ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
 INSERT INTO cron.job (schedule, command)
 VALUES ('1 0 * * *', $$
     SELECT prices.insert_approx_prices_from_dex_data(
-        (SELECT MAX(hour) - interval '1 hour' FROM prices.approx_prices_from_dex_data),
+        (SELECT MAX(hour) - interval '30 days' FROM prices.approx_prices_from_dex_data),
         (SELECT DATE_TRUNC('hour', now()) + interval '1 hour')
     );
 $$)

--- a/optimism2/prices/insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/insert_approx_prices_from_dex_data.sql
@@ -476,3 +476,13 @@ VALUES ('16,46 * * * *', $$
     );
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+
+--once per day run of the last 30 days to handle for new tokens
+INSERT INTO cron.job (schedule, command)
+VALUES ('1 0 * * *', $$
+    SELECT prices.insert_approx_prices_from_dex_data(
+        (SELECT MAX(hour) - interval '1 hour' FROM prices.approx_prices_from_dex_data),
+        (SELECT DATE_TRUNC('hour', now()) + interval '1 hour')
+    );
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;


### PR DESCRIPTION
Adding a once per day run of the last 30 days, so that tokens will show price history before they're added.

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
