### PR TITLE
Create view_private_transactions.sql

### DIFF
--- a/ethereum/mev/view_private_transactions.sql
+++ b/ethereum/mev/view_private_transactions.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE VIEW mev.view_private_transactions AS
+SELECT
+    tx.block_time,
+    tx.block_number,
+    tx.hash,
+    tx.from,
+    tx.to,
+    tx.gas_price,
+    miner as miner_address,
+    miner_bribe.value as bribe
+FROM ethereum.transactions tx
+INNER JOIN ethereum.blocks ON ethereum.blocks."number" = tx.block_number 
+LEFT JOIN ethereum.traces miner_bribe on miner_bribe.tx_hash = tx."hash" 
+          AND miner_bribe.success = True 
+          AND (call_type NOT IN ('delegatecall', 'callcode', 'staticcall') OR call_type IS null)
+          AND miner_bribe."to" = miner
+WHERE tx.gas_price = 0  AND tx.block_number < 12965000 -- pre eip 1559 method


### PR DESCRIPTION
add mev abstraction folder and first pass at private transactions

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
