### PR TITLE
Update insert_oneinch.sql

### DIFF
--- a/optimism2/dex/insert_oneinch.sql
+++ b/optimism2/dex/insert_oneinch.sql
@@ -168,9 +168,9 @@ WHERE NOT EXISTS (
 INSERT INTO cron.job (schedule, command)
 VALUES ('15,45 * * * *', $$
     SELECT dex.insert_oneinch(
-        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='1Inch'),
+        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='1inch'),
         (SELECT now() - interval '20 minutes'),
-        (SELECT max(number) FROM optimism.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Uniswap' AND version = '3')),
+        (SELECT max(number) FROM optimism.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='1inch')),
         (SELECT MAX(number) FROM optimism.blocks where time < now() - interval '20 minutes'),
     0);
 $$)


### PR DESCRIPTION
Fixing 1Inch -> 1inch typo + making the block number check only use 1inch rather than Uniswap. cc @sui414

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
