### PR TITLE
add 0x tables and dex.trades insertion on OP

### DIFF
--- a/optimism2/dex/insert_zeroex.sql
+++ b/optimism2/dex/insert_zeroex.sql
@@ -1,0 +1,159 @@
+CREATE OR REPLACE FUNCTION dex.insert_zeroex(start_ts timestamptz, end_ts timestamptz=now(), start_block numeric=0, end_block numeric=9e18) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH rows AS (
+    INSERT INTO dex.trades (
+        block_time,
+        token_a_symbol,
+        token_b_symbol,
+        token_a_amount,
+        token_b_amount,
+        project,
+        version,
+        category,
+        trader_a,
+        trader_b,
+        token_a_amount_raw,
+        token_b_amount_raw,
+        usd_amount,
+        token_a_address,
+        token_b_address,
+        exchange_contract_address,
+        tx_hash,
+        tx_from,
+        tx_to,
+        trace_address,
+        evt_index,
+        trade_id
+    )
+    SELECT
+        dexs.block_time,
+        erc20a.symbol AS token_a_symbol,
+        erc20b.symbol AS token_b_symbol,
+        token_a_amount_raw / 10 ^ erc20a.decimals AS token_a_amount,
+        token_b_amount_raw / 10 ^ erc20b.decimals AS token_b_amount,
+        project,
+        version,
+        category,
+        coalesce(trader_a, tx."from") as trader_a, -- subqueries rely on this COALESCE to avoid redundant joins with the transactions table
+        trader_b,
+        token_a_amount_raw,
+        token_b_amount_raw,
+        coalesce(
+            usd_amount,
+            token_a_amount_raw / 10 ^ pa.decimals * pa.median_price,
+            token_b_amount_raw / 10 ^ pb.decimals * pb.median_price
+        ) as usd_amount,
+        token_a_address,
+        token_b_address,
+        exchange_contract_address,
+        tx_hash,
+        tx."from" as tx_from,
+        tx."to" as tx_to,
+        trace_address,
+        evt_index,
+        row_number() OVER (PARTITION BY project, tx_hash, evt_index, trace_address ORDER BY version, category) AS trade_id
+    FROM (
+      -- 0x api
+      SELECT
+          block_time,
+          '0x API' AS project,
+          NULL AS version,
+          'Aggregator' AS category,
+          "taker" AS trader_a,
+          "maker" AS trader_b,
+          "taker_token_amount_raw" AS token_a_amount_raw,
+          "maker_token_amount_raw" AS token_b_amount_raw,
+          NULL::numeric AS usd_amount,
+          taker_token_address AS token_a_address,
+          maker_token_address AS token_b_address,
+          contract_address AS exchange_contract_address,
+          tx_hash,
+          NULL::integer[] AS trace_address,
+          evt_index
+      FROM zeroex."view_0x_api_fills"
+      where swap_flag is TRUE
+
+      UNION ALL
+
+      -- Matcha
+      SELECT
+          block_time,
+          'Matcha' AS project,
+          NULL AS version,
+          'Aggregator' AS category,
+          "taker" AS trader_a,
+          "maker" AS trader_b,
+          "taker_token_amount_raw" AS token_a_amount_raw,
+          "maker_token_amount_raw" AS token_b_amount_raw,
+          NULL::numeric AS usd_amount,
+          taker_token_address AS token_a_address,
+          maker_token_address AS token_b_address,
+          contract_address AS exchange_contract_address,
+          tx_hash,
+          NULL::integer[] AS trace_address,
+          evt_index
+      FROM zeroex."view_0x_api_fills"
+      where affiliate_address ='\x86003b044f70dac0abc80ac8957305b6370893ed'
+
+    ) dexs
+    INNER JOIN optimism.transactions tx
+        ON dexs.tx_hash = tx.hash
+        AND tx.block_time >= start_ts
+        AND tx.block_time < end_ts
+        AND tx.block_number >= start_block
+        AND tx.block_number < end_block
+    LEFT JOIN erc20.tokens erc20a ON erc20a.contract_address = dexs.token_a_address
+    LEFT JOIN erc20.tokens erc20b ON erc20b.contract_address = dexs.token_b_address
+    LEFT JOIN prices.approx_prices_from_dex_data pa
+      ON pa.hour = date_trunc('hour', dexs.block_time)
+        AND pa.contract_address = dexs.token_a_address
+        AND pa.hour >= start_ts
+        AND pa.hour < end_ts
+    LEFT JOIN prices.approx_prices_from_dex_data pb
+      ON pb.hour = date_trunc('hour', dexs.block_time)
+        AND pb.contract_address = dexs.token_b_address
+        AND pb.hour >= start_ts
+        AND pb.hour < end_ts
+
+    -- update if we have new info on prices or the erc20
+    ON CONFLICT (project, tx_hash, evt_index, trade_id)
+    DO UPDATE SET
+        usd_amount = EXCLUDED.usd_amount,
+        token_a_amount = EXCLUDED.token_a_amount,
+        token_b_amount = EXCLUDED.token_b_amount,
+        token_a_symbol = EXCLUDED.token_a_symbol,
+        token_b_symbol = EXCLUDED.token_b_symbol
+    RETURNING 1
+)
+SELECT count(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+-- fill 2021, 0x only launched after op2
+SELECT dex.insert_zeroex(
+    '2021-12-28',
+    now(),
+    0,
+    (SELECT MAX(number) FROM optimism.blocks where time < now() - interval '20 minutes')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM dex.trades
+    WHERE block_time > '2021-12-28'
+    AND block_time <= now() - interval '20 minutes'
+    AND project IN ('0x API', 'Matcha')
+);
+
+INSERT INTO cron.job (schedule, command)
+VALUES ('15,45 * * * *', $$
+    SELECT dex.insert_zeroex(
+        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project IN ('0x API', 'Matcha')),
+        (SELECT now() - interval '20 minutes'),
+        (SELECT max(number) FROM optimism.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project IN ('0x API', 'Matcha'))),
+        (SELECT MAX(number) FROM optimism.blocks where time < now() - interval '20 minutes'),
+    0);
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/optimism2/zeroex/view_0x_api_fills.sql
+++ b/optimism2/zeroex/view_0x_api_fills.sql
@@ -1,0 +1,167 @@
+CREATE TABLE IF NOT EXISTS zeroex.view_0x_api_fills (
+    tx_hash bytea,
+    evt_index integer,
+    contract_address bytea,
+    block_time timestamptz,
+    maker bytea,
+    taker bytea,
+    taker_token_address bytea,
+    taker_token_symbol text,
+    maker_token_address bytea,
+    maker_token_symbol text,
+    taker_token_amount float,
+    taker_token_amount_raw numeric,
+    maker_token_amount float,
+    maker_token_amount_raw numeric,
+    "type" text,
+    affiliate_address bytea,
+    swap_flag boolean,
+    matcha_limit_order_flag boolean,
+    volume_usd float
+);
+
+CREATE OR REPLACE FUNCTION zeroex.insert_0x_api_fills (start_ts timestamptz, end_ts timestamptz=now()) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH zeroex_tx AS (
+          SELECT
+              tx_hash
+              , MAX(affiliate_address::text)::bytea as affiliate_address
+          from zeroex."view_api_affiliate_data"
+          WHERE block_time >= start_ts AND block_time < end_ts
+          GROUP BY 1
+        ),
+        bridge_fill AS (
+          SELECT
+            logs.tx_hash,
+            INDEX AS evt_index,
+            logs.contract_address,
+            block_time AS block_time,
+            substring(DATA,13,20) AS maker,
+            '\xdef1c0ded9bec7f1a1670819833240f027b25eff'::bytea AS taker,
+            substring(DATA,45,20) AS taker_token,
+            substring(DATA,77,20) AS maker_token,
+            bytea2numeric(substring(DATA,109,20)) AS taker_token_amount_raw,
+            bytea2numeric(substring(DATA,141,20)) AS maker_token_amount_raw,
+            'Bridge Fill' AS type,
+            zeroex_tx.affiliate_address as affiliate_address,
+            TRUE AS swap_flag,
+            FALSE AS matcha_limit_order_flag
+        FROM ethereum."logs" logs
+        join zeroex_tx on zeroex_tx.tx_hash = logs.tx_hash
+        WHERE topic1 = '\xe59e71a14fe90157eedc866c4f8c767d3943d6b6b2e8cd64dddcc92ab4c55af8'::bytea
+                and contract_address = '\xa3128d9b7cca7d5af29780a56abeec12b05a6740'::bytea
+                AND block_time >= start_ts AND block_time < end_ts
+      ),
+    	total_volume AS (
+        SELECT
+            all_tx.tx_hash,
+            all_tx.evt_index,
+            all_tx.contract_address,
+            all_tx.block_time,
+            maker,
+            case when taker = '\xdef1c0ded9bec7f1a1670819833240f027b25eff'::bytea then tx."from" else taker end as taker, -- fix the user masked by ProxyContract issue
+            taker_token as taker_token_address,
+            tt.symbol as taker_token_symbol,
+            maker_token as maker_token_address,
+            mt.symbol as maker_token_symbol,
+            taker_token_amount_raw / (10^tt.decimals) AS taker_token_amount,
+            taker_token_amount_raw,
+            maker_token_amount_raw / (10^mt.decimals) AS maker_token_amount,
+            maker_token_amount_raw,
+            all_tx.type,
+            affiliate_address,
+            swap_flag,
+            matcha_limit_order_flag,
+      			CASE
+      				WHEN tp.symbol = 'USDC' THEN (all_tx.taker_token_amount_raw / 1e6)--don't multiply by anything as these assets are USD
+      				WHEN mp.symbol = 'USDC' THEN (all_tx.maker_token_amount_raw / 1e6)--don't multiply by anything as these assets are USD
+      				WHEN tp.symbol = 'TUSD' THEN (all_tx.taker_token_amount_raw / 1e18)--don't multiply by anything as these assets are USD
+      				WHEN mp.symbol = 'TUSD' THEN (all_tx.maker_token_amount_raw / 1e18)--don't multiply by anything as these assets are USD
+      				WHEN tp.symbol = 'USDT' THEN (all_tx.taker_token_amount_raw / 1e6) * tp.median_price
+      				WHEN mp.symbol = 'USDT' THEN (all_tx.maker_token_amount_raw / 1e6) * mp.median_price
+      				WHEN tp.symbol = 'DAI' THEN (all_tx.taker_token_amount_raw / 1e18) * tp.median_price
+      				WHEN mp.symbol = 'DAI' THEN (all_tx.maker_token_amount_raw / 1e18) * mp.median_price
+      				WHEN tp.symbol = 'WETH' THEN (all_tx.taker_token_amount_raw / 1e18) * tp.median_price
+      				WHEN mp.symbol = 'WETH' THEN (all_tx.maker_token_amount_raw / 1e18) * mp.median_price
+      				ELSE COALESCE((all_tx.maker_token_amount_raw / (10^mt.decimals))*mp.median_price,(all_tx.taker_token_amount_raw / (10^tt.decimals))*tp.median_price)
+      				END AS volume_usd
+  		FROM bridge_fill all_tx
+  		INNER JOIN optimism.transactions tx
+              ON all_tx.tx_hash = tx.hash
+                AND tx.block_time >= start_ts
+                AND tx.block_time < end_ts
+      	LEFT JOIN prices.approx_prices_from_dex_data tp
+      	        ON date_trunc('hour', all_tx.block_time) = tp.hour
+  					AND all_tx.taker_token = tp.contract_address
+                    AND tp.hour >= start_ts
+                    AND tp.hour < end_ts
+  		LEFT JOIN prices.approx_prices_from_dex_data mp
+  		        ON DATE_TRUNC('hour', all_tx.block_time) = mp.hour
+  				    AND all_tx.maker_token = mp.contract_address
+                    AND mp.hour >= start_ts
+                    AND mp.hour < end_ts
+  		LEFT JOIN erc20.tokens mt ON mt.contract_address = all_tx.maker_token
+  		LEFT JOIN erc20.tokens tt ON tt.contract_address = all_tx.taker_token
+      ),
+        rows AS (
+            INSERT INTO zeroex.view_0x_api_fills (
+                tx_hash,
+                evt_index,
+                contract_address,
+                block_time,
+                maker,
+                taker,
+                taker_token_address,
+                taker_token_symbol,
+                maker_token_address,
+                maker_token_symbol,
+                taker_token_amount,
+                taker_token_amount_raw,
+                maker_token_amount,
+                maker_token_amount_raw,
+                "type",
+                affiliate_address,
+                swap_flag,
+                matcha_limit_order_flag,
+                volume_usd
+            )
+            SELECT
+                tx_hash,
+                evt_index,
+                contract_address,
+                block_time,
+                maker,
+                taker,
+                taker_token_address,
+                taker_token_symbol,
+                maker_token_address,
+                maker_token_symbol,
+                taker_token_amount,
+                taker_token_amount_raw,
+                maker_token_amount,
+                maker_token_amount_raw,
+                "type",
+                affiliate_address,
+                swap_flag,
+                matcha_limit_order_flag,
+                volume_usd
+            FROM total_volume
+            ON CONFLICT DO NOTHING
+            RETURNING 1
+    )
+    SELECT count(*) INTO r from rows;
+    RETURN r;
+    END
+    $function$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS zeroex_api_fills_unique ON zeroex.view_0x_api_fills (tx_hash, evt_index);
+CREATE INDEX IF NOT EXISTS zeroex_api_fills_time_index ON zeroex.view_0x_api_fills (block_time);
+
+--backfill
+SELECT zeroex.insert_0x_api_fills('2021-12-28', (SELECT now() - interval '20 minutes')) WHERE NOT EXISTS (SELECT * FROM zeroex.view_0x_api_fills LIMIT 1);
+
+INSERT INTO cron.job (schedule, command)
+VALUES ('15 * * * *', $$SELECT zeroex.insert_0x_api_fills((SELECT max(block_time) - interval '2 days' FROM zeroex.view_0x_api_fills), (SELECT now() - interval '20 minutes'));$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/optimism2/zeroex/view_0x_api_fills.sql
+++ b/optimism2/zeroex/view_0x_api_fills.sql
@@ -48,7 +48,7 @@ WITH zeroex_tx AS (
             zeroex_tx.affiliate_address as affiliate_address,
             TRUE AS swap_flag,
             FALSE AS matcha_limit_order_flag
-        FROM ethereum."logs" logs
+        FROM optimism."logs" logs
         join zeroex_tx on zeroex_tx.tx_hash = logs.tx_hash
         WHERE topic1 = '\xe59e71a14fe90157eedc866c4f8c767d3943d6b6b2e8cd64dddcc92ab4c55af8'::bytea
                 and contract_address = '\xa3128d9b7cca7d5af29780a56abeec12b05a6740'::bytea

--- a/optimism2/zeroex/view_affiliate_data.sql
+++ b/optimism2/zeroex/view_affiliate_data.sql
@@ -1,0 +1,58 @@
+BEGIN;
+DROP TABLE IF EXISTS zeroex.view_api_affiliate_data;
+CREATE TABLE IF NOT EXISTS zeroex.view_api_affiliate_data (
+    tx_hash BYTEA
+    , trace_address INTEGER[]
+    , block_number BIGINT
+    , block_time TIMESTAMPTZ
+    , caller BYTEA
+    , callee BYTEA
+    , affiliate_address BYTEA
+    , quote_timestamp BIGINT
+    , UNIQUE(tx_hash, trace_address)
+);
+
+CREATE INDEX IF NOT EXISTS api_affiliate_tx_index ON zeroex.view_api_affiliate_data (tx_hash);
+CREATE INDEX IF NOT EXISTS api_affiliate_timestamp_index ON zeroex.view_api_affiliate_data (block_time);
+CREATE INDEX IF NOT EXISTS api_affiliate_affiliate_index ON zeroex.view_api_affiliate_data (affiliate_address);
+
+CREATE OR REPLACE FUNCTION zeroex.insert_api_data(start_ts timestamptz, end_ts timestamptz=now()) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH rows AS (
+    INSERT INTO zeroex.view_api_affiliate_data
+    SELECT
+        tr.tx_hash
+        , tr.trace_address
+        , tr.block_number
+        , tr.block_time
+        , "from" AS caller
+        , "to" AS callee
+        , CASE
+                WHEN POSITION('\x869584cd'::BYTEA IN input) <> 0 THEN SUBSTRING(input from (position('\x869584cd'::BYTEA IN input) + 16) for 20)
+                WHEN POSITION('\xfbc019a7'::BYTEA IN input) <> 0 THEN SUBSTRING(input from (position('\xfbc019a7'::BYTEA IN input) + 16) for 20)
+            END AS affiliate_address
+        , NULL AS quote_timestamp
+    FROM optimism."traces" tr
+    WHERE tr."to" ='\xdef1abe32c034e558cdd535791643c58a13acc10'::BYTEA
+    AND (
+        POSITION('\x869584cd'::BYTEA IN input) <> 0
+        OR POSITION('\xfbc019a7'::BYTEA IN input) <> 0
+    )
+    AND tr.block_time >= start_ts
+    AND tr.block_time < end_ts
+    ON CONFLICT DO NOTHING
+    RETURNING 1
+)
+SELECT count(*) INTO r FROM rows;
+RETURN r;
+END
+$function$;
+
+SELECT zeroex.insert_api_data('2021-12-08', now()) WHERE NOT EXISTS (SELECT * FROM zeroex.view_api_affiliate_data);
+
+INSERT INTO cron.job (schedule, command)
+VALUES ('*/15 * * * *',  $$SELECT zeroex.insert_api_data((SELECT max(block_time) from zeroex.view_api_affiliate_data) - interval '1 day', now())$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+COMMIT;


### PR DESCRIPTION
Notes:
- tested queries
- not sure if the cron job schedule makes sense, plz feel free to tune to most reasonable params
- the 3 sql files have dependency sequence, so it has to be created in order of: 
 `zeroex.view_affiliate_data.sql` >> `zeroex.view_0x_api_fills` >>  dex.trades insert_zeroex


------
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
