### PR TITLE
Fix whitespace constraint in ens_reverse_name

### DIFF
--- a/labels/ethereum/ens_name_reverse.sql
+++ b/labels/ethereum/ens_name_reverse.sql
@@ -35,4 +35,5 @@ SELECT
     'ens name reverse' AS type,
     'zxsasha' AS author
 FROM ens_transactions AS t
-INNER JOIN ens_calls AS c ON c.block_number = t.block_number AND c.tx_hash = t.tx_hash AND c.ens_name <> '0x0000000000000000000000000000000000000000';
+INNER JOIN ens_calls AS c ON c.block_number = t.block_number AND c.tx_hash = t.tx_hash AND c.ens_name <> '0x0000000000000000000000000000000000000000'
+WHERE LOWER(c.ens_name) not ilike '% %';


### PR DESCRIPTION
Fixes whitespace constraint that was being broken by weird records
```
                  address                   |                               label                               |       type       | author  
--------------------------------------------+-------------------------------------------------------------------+------------------+---------
 \x07f01fbc2980777f5cf809038d207568c81ecac9 | hello world!                                                      | ens name reverse | zxsasha
 \x1ab5b3227ed9d7baeaf89acea1db447ce741c57b |  kamemondayakbak2.umbra.eth                                       | ens name reverse | zxsasha
 \x23760e2d82422e993cda9ea580566e116877ef3c | polyn8, inc.                                                      | ens name reverse | zxsasha
 \x87cee048669d58006c7c7fbc2a9ff2940be07dbb | drsohtea .umbra.eth                                               | ens name reverse | zxsasha
 \xab466f6077dc0f2611f984f8c988912b26bc3a17 | luckyyoutoken owner                                               | ens name reverse | zxsasha
 \xac61b7d3a5d9805ec7ee0f32ce0bacb3c34f8aa3 |                                                                   | ens name reverse | zxsasha
 \xc3a83019431a92559f795ef0dfee1964dfc498d9 | '"><img src=x onerror=alert(1)>.eth                               | ens name reverse | zxsasha
 \xcee18a6772ea66cbef5f9ab6c7bfcbb2c515082c |                                                                   | ens name reverse | zxsasha
 \xf550e8ac985a7e530c557230ada7c710bae6b71c | reverseregistrar.setname('r3venge.eth', {from: eth.accounts[0]}); | ens name reverse | zxsasha
 ```