### PR TITLE
Update insert_approx_prices_from_dex_data.sql

### DIFF
--- a/optimism2/prices/insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/insert_approx_prices_from_dex_data.sql
@@ -481,11 +481,11 @@ $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
 
 --once per day run of the last 30 days to handle for new tokens
-INSERT INTO cron.job (schedule, command)
-VALUES ('1 0 * * *', $$
-    SELECT prices.insert_approx_prices_from_dex_data(
-        (SELECT MAX(hour) - interval '30 days' FROM prices.approx_prices_from_dex_data),
-        (SELECT DATE_TRUNC('hour', now()) + interval '1 hour')
-    );
-$$)
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('1 0 * * *', $$
+--     SELECT prices.insert_approx_prices_from_dex_data(
+--         (SELECT MAX(hour) - interval '30 days' FROM prices.approx_prices_from_dex_data),
+--         (SELECT DATE_TRUNC('hour', now()) + interval '1 hour')
+--     );
+-- $$)
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/optimism2/prices/insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/insert_approx_prices_from_dex_data.sql
@@ -380,6 +380,7 @@ SELECT hour, token, symbol, decimals, median_price, num_samples, rnk
             WHERE median_price IS NOT NULL
         ) r
     WHERE p_rank = 1
+	AND token != '\xdeaddeaddeaddeaddeaddeaddeaddeaddead0000' --make sure native ETH's ERC20 deposit token isn't pulled in
     )
 SELECT hour, token, symbol, decimals, median_price, num_samples, rnk FROM get_best_price_estimate
 UNION ALL
@@ -443,6 +444,8 @@ rows AS (
         symbol,
         decimals
     FROM final_prices
+	
+	WHERE median_price IS NOT NULL
 
     ON CONFLICT (contract_address, hour) DO UPDATE SET median_price = EXCLUDED.median_price, sample_size = EXCLUDED.sample_size
     RETURNING 1


### PR DESCRIPTION
Adding in a check to make sure we don't pull in DEX calculated prices for the ETH address which represents L1 deposits.

Also adding in a NULL check for the final insert.

Will add in a follow-up script to delete the old ETH token prices and rewrite as a copy of WETH prices.

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
