### PR TITLE
Add nft trades index

### DIFF
--- a/ethereum/nft/trades/trades.sql
+++ b/ethereum/nft/trades/trades.sql
@@ -1,4 +1,4 @@
-CREATE TABLE nft.trades (
+CREATE TABLE IF NOT EXISTS nft.trades (
     block_time timestamptz NOT NULL,
     nft_project_name text,
     nft_token_id text,
@@ -36,12 +36,12 @@ CREATE TABLE nft.trades (
 
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_platform_tx_hash_evt_index_trade_id_uniq_idx ON nft.trades (platform, tx_hash, evt_index, trade_id);
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_platform_tx_hash_trace_address_trade_id_uniq_idx ON nft.trades (platform, tx_hash, trace_address, trade_id);
-CREATE INDEX IF NOT EXISTS nft_trades_block_time_idx ON nft.trades USING BRIN (block_time);
-CREATE INDEX IF NOT EXISTS nft_trades_seller_idx ON nft.trades (seller);
-CREATE INDEX IF NOT EXISTS nft_trades_buyer_idx ON nft.trades (buyer);
-CREATE INDEX IF NOT EXISTS nft_trades_nft_project_name_nft_token_id_block_time_idx ON nft.trades (nft_project_name, nft_token_id, block_time);
-CREATE INDEX IF NOT EXISTS nft_trades_block_time_platform_seller_buyer_nft_project_name_nft_token_id_idx ON nft.trades (block_time, platform, seller, buyer, nft_project_name, nft_token_id);
-CREATE INDEX IF NOT EXISTS nft_trades_nft_token_ids_array_idx ON nft.trades USING GIN(nft_token_ids_array);
-CREATE INDEX IF NOT EXISTS nft_trades_nft_contract_addresses_array_idx ON nft.trades USING GIN(nft_contract_addresses_array);
-CREATE INDEX IF NOT EXISTS nft_trades_senders_array_idx ON nft.trades USING GIN(senders_array);
-CREATE INDEX IF NOT EXISTS nft_trades_recipients_array_idx ON nft.trades USING GIN(recipients_array);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_block_time_idx ON nft.trades USING BRIN (block_time);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_seller_idx ON nft.trades (seller);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_buyer_idx ON nft.trades (buyer);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_nft_project_name_nft_token_id_block_time_idx ON nft.trades (nft_project_name, nft_token_id, block_time);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_block_time_platform_seller_buyer_nft_project_name_nft_token_id_idx ON nft.trades (block_time, platform, seller, buyer, nft_project_name, nft_token_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_nft_token_ids_array_idx ON nft.trades USING GIN(nft_token_ids_array);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_nft_contract_addresses_array_idx ON nft.trades USING GIN(nft_contract_addresses_array);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_senders_array_idx ON nft.trades USING GIN(senders_array);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_recipients_array_idx ON nft.trades USING GIN(recipients_array);

--- a/ethereum/nft/trades/trades.sql
+++ b/ethereum/nft/trades/trades.sql
@@ -34,6 +34,8 @@ CREATE TABLE IF NOT EXISTS nft.trades (
     trade_id integer
 );
 
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_platform_tx_hash_evt_index_trade_id_uniq_idx ON nft.trades (platform, tx_hash, evt_index, trade_id);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_platform_tx_hash_trace_address_trade_id_uniq_idx ON nft.trades (platform, tx_hash, trace_address, trade_id);
 CREATE INDEX IF NOT EXISTS nft_trades_block_time_idx ON nft.trades USING BRIN (block_time);
 CREATE INDEX IF NOT EXISTS nft_trades_seller_idx ON nft.trades (seller);
 CREATE INDEX IF NOT EXISTS nft_trades_buyer_idx ON nft.trades (buyer);

--- a/ethereum/nft/trades/trades.sql
+++ b/ethereum/nft/trades/trades.sql
@@ -39,6 +39,7 @@ CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_platform_tx_hash_trace
 CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_block_time_idx ON nft.trades USING BRIN (block_time);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_seller_idx ON nft.trades (seller);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_buyer_idx ON nft.trades (buyer);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_nft_contract_address_nft_token_id_block_time_idx ON nft.trades (nft_contract_address, nft_token_id, block_time);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_nft_project_name_nft_token_id_block_time_idx ON nft.trades (nft_project_name, nft_token_id, block_time);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_block_time_platform_seller_buyer_nft_project_name_nft_token_id_idx ON nft.trades (block_time, platform, seller, buyer, nft_project_name, nft_token_id);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_nft_token_ids_array_idx ON nft.trades USING GIN(nft_token_ids_array);

--- a/ethereum/nft/trades/trades.sql
+++ b/ethereum/nft/trades/trades.sql
@@ -39,6 +39,7 @@ CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_platform_tx_hash_trace
 CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_block_time_idx ON nft.trades USING BRIN (block_time);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_seller_idx ON nft.trades (seller);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_buyer_idx ON nft.trades (buyer);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_tx_hash_idx ON nft.trades (tx_hash);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_nft_contract_address_nft_token_id_block_time_idx ON nft.trades (nft_contract_address, nft_token_id, block_time);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_nft_project_name_nft_token_id_block_time_idx ON nft.trades (nft_project_name, nft_token_id, block_time);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_block_time_platform_seller_buyer_nft_project_name_nft_token_id_idx ON nft.trades (block_time, platform, seller, buyer, nft_project_name, nft_token_id);

--- a/ethereum/nft/trades/trades.sql
+++ b/ethereum/nft/trades/trades.sql
@@ -34,16 +34,14 @@ CREATE TABLE IF NOT EXISTS nft.trades (
     trade_id integer
 );
 
-CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_platform_tx_hash_evt_index_trade_id_uniq_idx ON nft.trades (platform, tx_hash, evt_index, trade_id);
-CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_platform_tx_hash_trace_address_trade_id_uniq_idx ON nft.trades (platform, tx_hash, trace_address, trade_id);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_block_time_idx ON nft.trades USING BRIN (block_time);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_seller_idx ON nft.trades (seller);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_buyer_idx ON nft.trades (buyer);
+CREATE INDEX IF NOT EXISTS nft_trades_block_time_idx ON nft.trades USING BRIN (block_time);
+CREATE INDEX IF NOT EXISTS nft_trades_seller_idx ON nft.trades (seller);
+CREATE INDEX IF NOT EXISTS nft_trades_buyer_idx ON nft.trades (buyer);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_tx_hash_idx ON nft.trades (tx_hash);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_nft_contract_address_nft_token_id_block_time_idx ON nft.trades (nft_contract_address, nft_token_id, block_time);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_nft_project_name_nft_token_id_block_time_idx ON nft.trades (nft_project_name, nft_token_id, block_time);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_block_time_platform_seller_buyer_nft_project_name_nft_token_id_idx ON nft.trades (block_time, platform, seller, buyer, nft_project_name, nft_token_id);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_nft_token_ids_array_idx ON nft.trades USING GIN(nft_token_ids_array);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_nft_contract_addresses_array_idx ON nft.trades USING GIN(nft_contract_addresses_array);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_senders_array_idx ON nft.trades USING GIN(senders_array);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS nft_trades_recipients_array_idx ON nft.trades USING GIN(recipients_array);
+CREATE INDEX IF NOT EXISTS nft_trades_nft_project_name_nft_token_id_block_time_idx ON nft.trades (nft_project_name, nft_token_id, block_time);
+CREATE INDEX IF NOT EXISTS nft_trades_block_time_platform_seller_buyer_nft_project_name_nft_token_id_idx ON nft.trades (block_time, platform, seller, buyer, nft_project_name, nft_token_id);
+CREATE INDEX IF NOT EXISTS nft_trades_nft_token_ids_array_idx ON nft.trades USING GIN(nft_token_ids_array);
+CREATE INDEX IF NOT EXISTS nft_trades_nft_contract_addresses_array_idx ON nft.trades USING GIN(nft_contract_addresses_array);
+CREATE INDEX IF NOT EXISTS nft_trades_senders_array_idx ON nft.trades USING GIN(senders_array);
+CREATE INDEX IF NOT EXISTS nft_trades_recipients_array_idx ON nft.trades USING GIN(recipients_array);


### PR DESCRIPTION
I've checked that:

* [x ] the query produces the intended results
* [x ] the folder name matches the schema name
* [x ] the schema name exists in Dune
* [x ] views are prefixed with `view_`, functions with `fn_`.
* [x ] the filename matches the defined view, table or function and ends with .sql
* [x ] each file has only one view, table or function defined  
* [x ] column names are `lowercase_snake_cased`

this adds 2 indexes to nft.trades for querying (contract_address, token_id) and (tx_hash). i added IF NOT EXISTS and CONCURRENTLY to existing table + index creation. i'm happy to unwind that if you like. the actual index addition is the 2nd and 3rd commits of this PR.
