### PR TITLE
Update optimism2 token balances cron job

### DIFF
--- a/optimism2/erc20/insert_daily_token_balances.sql
+++ b/optimism2/erc20/insert_daily_token_balances.sql
@@ -198,9 +198,9 @@ WHERE NOT EXISTS (
 
 INSERT INTO cron.job (schedule, command)
 VALUES ('15,45 * * * *', $$
-    SELECT erc20.insert_daily_token_balances.sql(
-        (SELECT max(block_time) - interval '3 days' FROM erc20.daily_token_balances),
-        (SELECT now() - interval '5 minutes'),
+    SELECT erc20.insert_daily_token_balances(
+        (SELECT max(day) - interval '3 days' FROM erc20.daily_token_balances),
+        (SELECT now() - interval '5 minutes')
         );
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
