### PR TITLE
adding BABL - now babl in coinpaprika

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1911,3 +1911,8 @@
   symbol: PHONON
   address: 0x758b4684be769e92eefea93f60dda0181ea303ec
   decimals: 18
+- name: babl-babylon
+  id: babl-babylon
+  symbol: BABL
+  address: 0xf4dc48d260c93ad6a96c5ce563e70ca578987c74
+  decimals: 18


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
