### PR TITLE
Add Metavatar to NFT tokens table

### DIFF
--- a/ethereum/nft/tokens.sql
+++ b/ethereum/nft/tokens.sql
@@ -14500,6 +14500,7 @@ COPY nft.tokens (contract_address, name, symbol, standard) FROM stdin;
 \\x13e89276bd71fca653bef21d144f4a24d501ce1b	salty tooth	SALTY	erc721
 \\x60f03169cb00ea0774cf4bdf5b9c55d33442affc	Floating Cities	CITIES	erc721
 \\xec71ed650722ef6f98c1c28f0b34c9846c1ba10b	DRIVE // DAVE KRUGMAN	DRIVE	erc721
+\\x880509ff28915fa62cdc7b07d1ea951bd5cfe882 Metavatar	MVTR	erc721
 \.
 
 

--- a/ethereum/nft/tokens.sql
+++ b/ethereum/nft/tokens.sql
@@ -14500,7 +14500,7 @@ COPY nft.tokens (contract_address, name, symbol, standard) FROM stdin;
 \\x13e89276bd71fca653bef21d144f4a24d501ce1b	salty tooth	SALTY	erc721
 \\x60f03169cb00ea0774cf4bdf5b9c55d33442affc	Floating Cities	CITIES	erc721
 \\xec71ed650722ef6f98c1c28f0b34c9846c1ba10b	DRIVE // DAVE KRUGMAN	DRIVE	erc721
-\\x880509ff28915fa62cdc7b07d1ea951bd5cfe882 Metavatar	MVTR	erc721
+\\x880509ff28915fa62cdc7b07d1ea951bd5cfe882	Metavatar	MVTR	erc721
 \.
 
 


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
