### PR TITLE
Fix typo in insert_1inch to Polygon

### DIFF
--- a/polygon/dex/trades/insert_1inch.sql
+++ b/polygon/dex/trades/insert_1inch.sql
@@ -132,7 +132,7 @@ WHERE NOT EXISTS (
     FROM dex.trades
     WHERE block_time > '2021-01-01'
     AND block_time <= now() - interval '20 minutes'
-    AND project = 'Curve'
+    AND project = '1inch'
 );
 
 INSERT INTO cron.job (schedule, command)


### PR DESCRIPTION
Hey @masquot ,
This is just a quick fix to a typo on the `insert_1inch` script on Polygon 🐛 