### PR TITLE
[Trivial] Typo in Solver name

### DIFF
--- a/ethereum/gnosis_protocol_v2/view_batches.sql
+++ b/ethereum/gnosis_protocol_v2/view_batches.sql
@@ -36,7 +36,7 @@ WITH batch_counts AS (
                 num_trades,
                 CASE
                     WHEN name = '1inch'
-                        OR name = 'Paraswap'
+                        OR name = 'ParaSwap'
                         OR name = '0x'
                         OR name = 'Legacy'
                         THEN (select count(*) from dex.trades where tx_hash = evt_tx_hash and category = 'DEX')


### PR DESCRIPTION
Looks like our string comparison is case sensitive and the Paraswap dex-swaps counter was not returning expected results because of the typo `ParaSwap != Paraswap`
