### PR TITLE
Update coingecko.yaml to include Scalara-NFT-Index

### DIFF
--- a/prices/polygon/coingecko.yaml
+++ b/prices/polygon/coingecko.yaml
@@ -409,3 +409,4 @@
 - id: milk
 - id: radar
 - id: dogecoin
+- id: scalara-nft-index


### PR DESCRIPTION
Followed steps outlined in the document. Wish for NFTI to appear under prices."usd" in Polygon.

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
