### PR TITLE
Update coingecko.yaml to include BTC2X-FLI-P & iBTC-FLI-P

### DIFF
--- a/prices/polygon/coingecko.yaml
+++ b/prices/polygon/coingecko.yaml
@@ -410,3 +410,5 @@
 - id: radar
 - id: dogecoin
 - id: scalara-nft-index
+- id: btc-2x-flexible-leverage-index-polygon
+- id: inverse-btc-flexible-leverage-index


### PR DESCRIPTION
Want BTC2X-FLI-P & iBTC-FLI-P pricing data once available to show up within the prices."usd" table on Polygon.

