### PR TITLE
ethereum/prices.usd: add cUSDT

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1946,3 +1946,8 @@
   symbol: DSLA
   address: 0x3aFfCCa64c2A6f4e3B6Bd9c64CD2C969EFd1ECBe
   decimals: 18
+- name: cusdt-compound-usdt
+  id: cusdt-compound-usdt
+  symbol: cUSDT
+  address: 0xf650c3d88d12db855b8bf7d11be6c55a4e07dcc9
+  decimals: 8


### PR DESCRIPTION
Add cUSDT to coinpaprika.yml

I've checked that:

* [X] the query produces the intended results
* [X] the folder name matches the schema name
* [X] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
