### PR TITLE
Add block token for prices.usd

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1,3 +1,8 @@
+- name: critterz-block
+  id: critterz-block
+  symbol: BLOCK
+  address: 0x807a0774236A0fBE9e7f8E7Df49EDFED0e6777Ea
+  decimals: 18
 - name: dmg_dmm_governance
   id: dmg-dmm-governance
   symbol: DMG


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
