### PR TITLE
Added THX Network to the Ethereum prices

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1951,3 +1951,8 @@
   symbol: cUSDT
   address: 0xf650c3d88d12db855b8bf7d11be6c55a4e07dcc9
   decimals: 8
+- name: thx-network
+  id: thx-network
+  symbol: THX
+  address: 0xe632ea2eF2CFD8Fc4a2731C76F99078Aef6a4B31
+  decimals: 18


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
