### PR TITLE
Add mimo governance token to coingekko prices

### DIFF
--- a/prices/polygon/coingecko.yaml
+++ b/prices/polygon/coingecko.yaml
@@ -415,3 +415,4 @@
 - id: btc-2x-flexible-leverage-index-polygon
 - id: inverse-btc-flexible-leverage-index
 - id: thx-network
+- id: mimo-parallel-governance-token


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
