### PR TITLE
Add GALA price to BSC

### DIFF
--- a/prices/bsc/coinpaprika.yaml
+++ b/prices/bsc/coinpaprika.yaml
@@ -494,3 +494,8 @@
   id: aggl-aggleio
   name: aggl_aggleio
   symbol: AGGL
+- address: '0x7dDEE176F665cD201F93eEDE625770E2fD911990'
+  decimals: 18
+  id: gala-gala
+  name: gala
+  symbol: GALA


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
