### PR TITLE
Update 0x table on Ethereum and OP and Add tables for BSC and Polygon

### DIFF
--- a/ethereum/dex/trades/insert_zeroex.sql
+++ b/ethereum/dex/trades/insert_zeroex.sql
@@ -139,6 +139,24 @@ WITH rows AS (
 
         UNION ALL
 
+        SELECT evt_block_time AS block_time,
+                '0x Native' AS project,
+                '4' AS version,
+                'DEX' AS category,
+                taker AS trader_a,
+                maker AS trader_b,
+                "takerTokenFilledAmount" AS token_a_amount_raw,
+                "makerTokenFilledAmount" AS token_b_amount_raw,
+                NULL::numeric AS usd_amount,
+                "takerToken" AS token_a_address,
+                "makerToken" AS token_b_address,
+                contract_address AS exchange_contract_address,
+                evt_tx_hash AS tx_hash,
+                NULL::integer[] AS trace_address,
+                evt_index
+        FROM zeroex."ExchangeProxy_evt_OtcOrderFilled"
+
+        UNION ALL
         -- 0x api
         SELECT
             block_time,


### PR DESCRIPTION
- added OTC order on Ethereum for `0x Native` DEX **on dex.trades table**
      - will need backfill/rescrape for `0x Native` (only, not for `0x API` or `Matcha`) on dex.trades table starts from `2021-12-03 14:34` (timestamp) or block number `13734129` (first tx on [etherscan](https://etherscan.io/tx/0xe81d59d0857c236f0d75f0e3d3efc500a82ea06d66c5a093832e555d111dd1df))
