### PR TITLE
add backfill UPDATE logic and fix a placeholder address

### DIFF
--- a/optimism2/zeroex/view_0x_api_fills.sql
+++ b/optimism2/zeroex/view_0x_api_fills.sql
@@ -39,7 +39,7 @@ WITH zeroex_tx AS (
             logs.contract_address,
             block_time AS block_time,
             substring(DATA,13,20) AS maker,
-            '\xdef1c0ded9bec7f1a1670819833240f027b25eff'::bytea AS taker,
+            '\xdef1abe32c034e558cdd535791643c58a13acc10'::bytea AS taker,
             substring(DATA,45,20) AS taker_token,
             substring(DATA,77,20) AS maker_token,
             bytea2numeric(substring(DATA,109,20)) AS taker_token_amount_raw,
@@ -61,7 +61,7 @@ WITH zeroex_tx AS (
             all_tx.contract_address,
             all_tx.block_time,
             maker,
-            case when taker = '\xdef1c0ded9bec7f1a1670819833240f027b25eff'::bytea then tx."from" else taker end as taker, -- fix the user masked by ProxyContract issue
+            case when taker = '\xdef1abe32c034e558cdd535791643c58a13acc10'::bytea then tx."from" else taker end as taker, -- fix the user masked by ProxyContract issue
             taker_token as taker_token_address,
             tt.symbol as taker_token_symbol,
             maker_token as maker_token_address,
@@ -148,7 +148,13 @@ WITH zeroex_tx AS (
                 matcha_limit_order_flag,
                 volume_usd
             FROM total_volume
-            ON CONFLICT DO NOTHING
+            ON CONFLICT (tx_hash, evt_index)
+            DO UPDATE SET
+                usd_amount = EXCLUDED.usd_amount,
+                taker_token_symbol = EXCLUDED.taker_token_symbol,
+                maker_token_symbol = EXCLUDED.maker_token_symbol,
+                taker_token_amount = EXCLUDED.taker_token_amount,
+                maker_token_amount = EXCLUDED.maker_token_amount
             RETURNING 1
     )
     SELECT count(*) INTO r from rows;

--- a/optimism2/zeroex/view_0x_api_fills.sql
+++ b/optimism2/zeroex/view_0x_api_fills.sql
@@ -150,7 +150,7 @@ WITH zeroex_tx AS (
             FROM total_volume
             ON CONFLICT (tx_hash, evt_index)
             DO UPDATE SET
-                usd_amount = EXCLUDED.usd_amount,
+                volume_usd = EXCLUDED.volume_usd,
                 taker_token_symbol = EXCLUDED.taker_token_symbol,
                 maker_token_symbol = EXCLUDED.maker_token_symbol,
                 taker_token_amount = EXCLUDED.taker_token_amount,


### PR DESCRIPTION
this PR is initially because our [table](https://dune.xyz/0x/0x-API-and-Matcha-on-Optimism) was missing token price for a period. & @MSilb7 had a improvement recently.

- updated the constants (the OP 0x Exchange Proxy) address we use for taker addr placeholder. (a side small issue i found recently)
- added the backfill ON CONFLICT DO UPDATE SET logic in `zeroex.insert_0x_api_fills()` function per @masquot 's suggestion. (thank you!!)

would love a complete backfill for the OP table `zeroex.view_0x_api_fills` 🙏 first tx for reference: https://optimistic.etherscan.io/tx/1691336

* might need to be careful about coordinating the task's schedule dependency with `dex.insert_zeroex()` for `dex.trades` table to make sure that one won't miss out records during this backfill. 