### PR TITLE
Add unique index on view_safes

### DIFF
--- a/ethereum/gnosis_safe/view_safes.sql
+++ b/ethereum/gnosis_safe/view_safes.sql
@@ -7,7 +7,7 @@ CREATE MATERIALIZED VIEW gnosis_safe.view_safes AS
     	et.block_time AS creation_time
     FROM ethereum.traces et 
     WHERE et.success = True
-        AND et.call_type = 'delegatecall' -- the delegate call to the master copy is the Safe address
+        AND et.call_type = 'delegatecall' -- The delegate call to the master copy is the Safe address
         AND (
             (substring(et."input" for 4) = '\x0ec78d9e' -- setup methods of v0.1.0
                 AND et."to" = '\x8942595A2dC5181Df0465AF0D7be08c8f23C93af') -- mastercopy v0.1.0
@@ -17,8 +17,8 @@ CREATE MATERIALIZED VIEW gnosis_safe.view_safes AS
             OR
             (substring(et."input" for 4) = '\xb63e800d' -- setup methods of v1.1.0, v1.1.1, 1.2.0
             AND et."to" IN (
-                '\xae32496491b53841efb51829d6f886387708f99b', -- mastercopyv1.1.0
-                '\x34cfac646f301356faa8b21e94227e3583fe3f5f', -- mastercopyv1.1.1
+                '\xae32496491b53841efb51829d6f886387708f99b',  -- mastercopy v1.1.0
+                '\x34cfac646f301356faa8b21e94227e3583fe3f5f',  -- mastercopy v1.1.1
                 '\x6851d6fdfafd08c0295c392436245e5bc78b0185')  -- mastercopy v1.2.0
             )
         )

--- a/ethereum/gnosis_safe/view_safes.sql
+++ b/ethereum/gnosis_safe/view_safes.sql
@@ -4,7 +4,7 @@ DROP MATERIALIZED VIEW IF EXISTS gnosis_safe.view_safes;
 CREATE MATERIALIZED VIEW gnosis_safe.view_safes AS
     SELECT
     	et.from AS address,
-    	et.block_time AS creation_time 
+    	et.block_time AS creation_time
     FROM ethereum.traces et 
     WHERE et.success = True
         AND et.call_type = 'delegatecall' -- the delegate call to the master copy is the Safe address

--- a/ethereum/gnosis_safe/view_safes.sql
+++ b/ethereum/gnosis_safe/view_safes.sql
@@ -4,17 +4,23 @@ DROP MATERIALIZED VIEW IF EXISTS gnosis_safe.view_safes;
 CREATE MATERIALIZED VIEW gnosis_safe.view_safes AS
     SELECT
     	et.from AS address,
-    	et.block_time AS creation_time
+    	et.block_time AS creation_time 
     FROM ethereum.traces et 
     WHERE et.success = True
-        AND substring(et."input" for 4) IN ('\x0ec78d9e', '\xa97ab18a', '\xb63e800d') -- setup methods of v0.1.0, v1.0.0, v1.1.0 (=v1.1.1=1.2.0)
         AND et.call_type = 'delegatecall' -- the delegate call to the master copy is the Safe address
-        AND et."to" IN (
-            '\x8942595A2dC5181Df0465AF0D7be08c8f23C93af', -- mastercopy address v0.1.0
-            '\xb6029ea3b2c51d09a50b53ca8012feeb05bda35a', -- v1.0.0
-            '\xae32496491b53841efb51829d6f886387708f99b', -- v1.1.0
-            '\x34cfac646f301356faa8b21e94227e3583fe3f5f', -- v1.1.1
-            '\x6851d6fdfafd08c0295c392436245e5bc78b0185'   -- v1.2.0
+        AND (
+            (substring(et."input" for 4) = '\x0ec78d9e' -- setup methods of v0.1.0
+                AND et."to" = '\x8942595A2dC5181Df0465AF0D7be08c8f23C93af') -- mastercopy v0.1.0
+            OR
+            (substring(et."input" for 4) = '\xa97ab18a' -- setup methods of v1.0.0
+                AND et."to" = '\xb6029ea3b2c51d09a50b53ca8012feeb05bda35a') -- mastercopy v1.0.0
+            OR
+            (substring(et."input" for 4) = '\xb63e800d' -- setup methods of v1.1.0, v1.1.1, 1.2.0
+            AND et."to" IN (
+                '\xae32496491b53841efb51829d6f886387708f99b', -- mastercopyv1.1.0
+                '\x34cfac646f301356faa8b21e94227e3583fe3f5f', -- mastercopyv1.1.1
+                '\x6851d6fdfafd08c0295c392436245e5bc78b0185')  -- mastercopy v1.2.0
+            )
         )
         
     UNION ALL

--- a/ethereum/gnosis_safe/view_safes.sql
+++ b/ethereum/gnosis_safe/view_safes.sql
@@ -22,6 +22,8 @@ CREATE MATERIALIZED VIEW gnosis_safe.view_safes AS
     SELECT contract_address AS address, evt_block_time AS creation_time
     FROM gnosis_safe."GnosisSafev1.3.0_evt_SafeSetup";
 
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS view_safes_unique_idx ON gnosis_safe.view_safes (address);
+
 INSERT INTO cron.job (schedule, command)
 VALUES ('0 0 * * *', $$REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_safe.view_safes$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
