### PR TITLE
Update coinpaprika.yaml

### DIFF
--- a/prices/bsc/coinpaprika.yaml
+++ b/prices/bsc/coinpaprika.yaml
@@ -509,3 +509,8 @@
   id: tlm-alien-worlds
   name: tlm_alien_worlds
   symbol: TLM
+- address: '0x670De9f45561a2D02f283248F65cbd26EAd861C8'
+  decimals: 18
+  id: uranium-u92
+  name: uranium_u92
+  symbol: U92


### PR DESCRIPTION
Add Uranium Finance U92 historical prices for people to query for loss reporting.

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
