### PR TITLE
Add TerraUSD to prices dataset

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1966,3 +1966,8 @@
   symbol: SYLO
   address: 0xf293d23BF2CDc05411Ca0edDD588eb1977e8dcd4
   decimals: 18
+- name: TerraUSD
+  id: ust-terrausd
+  symbol: UST
+  address: 0xa47c8bf37f92aBed4A126BDA807A7b7498661acD
+  decimals: 18


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
