### PR TITLE
adding sphere-finance

### DIFF
--- a/prices/polygon/coingecko.yaml
+++ b/prices/polygon/coingecko.yaml
@@ -288,6 +288,7 @@
 - id: shiba-inu
 - id: showcase-token
 - id: spacerat
+- id: sphere-finance
 - id: stablegaj
 - id: stacker-ventures
 - id: stacktical


### PR DESCRIPTION
I've checked that:

* [ x] the query produces the intended results
* [ x] the folder name matches the schema name
* [ x] the schema name exists in Dune
* [ x] views are prefixed with `view_`, functions with `fn_`.
* [ x] the filename matches the defined view, table or function and ends with .sql
* [ x] each file has only one view, table or function defined  
* [ x] column names are `lowercase_snake_cased`
