### PR TITLE
Set protocol component prices

### DIFF
--- a/ethereum/setprotocol_v2/README.md
+++ b/ethereum/setprotocol_v2/README.md
@@ -1,0 +1,15 @@
+# Set Protocol Abstractions
+
+This folder contains all of the heavy duty abstractions used to track Set components, TVL, etc. For now, the only abstraction that requires a dedicated cron job is the component-level price feed.
+
+## Daily Component Prices
+
+This table assembles daily prices for all Set components that we can find, preferentially using the coinpaprika feed
+from `prices.usd`, and then looking into dex trades from `prices.prices_from_dex_data`. Since a lot of low liquidity tokens
+have massive price spikes, we've taken a more conservative approach to working with `prices.prices_from_dex_data` and erred on the side
+of throwing out data that has less certainty. For any given day, we only use that day's trade data if the total sample size is > 5 and if
+there is data across at least 5 different hours that day. Then, we take the median price as the day's average price.
+
+Another thing we do is that many of our Sets use components that don't have active trading but are closely pegged to other tokens, most
+notably Aave Interest Bearing tokens. For these tokens, we map the price directly from the underlying, e.g. we map `astETH`'s directly to
+`stETH`. That token pricing map we are maintaining in the Set Protocol repo, in the table `dune_user_generated.set_component_token_mappings`.

--- a/ethereum/setprotocol_v2/README.md
+++ b/ethereum/setprotocol_v2/README.md
@@ -12,4 +12,4 @@ there is data across at least 5 different hours that day. Then, we take the medi
 
 Another thing we do is that many of our Sets use components that don't have active trading but are closely pegged to other tokens, most
 notably Aave Interest Bearing tokens. For these tokens, we map the price directly from the underlying, e.g. we map `astETH`'s directly to
-`stETH`. That token pricing map we are maintaining in the Set Protocol repo, in the table `dune_user_generated.set_component_token_mappings`.
+`stETH`. We're still working on trying to get price feeds for Compound's tokens.

--- a/ethereum/setprotocol_v2/daily_component_prices.sql
+++ b/ethereum/setprotocol_v2/daily_component_prices.sql
@@ -33,4 +33,4 @@ CREATE INDEX IF NOT EXISTS setprotocol_v2_daily_component_prices_date_idx on dun
 CREATE INDEX IF NOT EXISTS setprotocol_v2_daily_component_prices_symbol_idx on dune_user_generated.daily_component_prices (symbol);
 CREATE INDEX IF NOT EXISTS setprotocol_v2_daily_component_prices_avg_price_usd_idx on dune_user_generated.daily_component_prices (avg_price_usd);
 */
--- don't forget to drop it because the index names will conflict
+-- don't forget to drop the test table before deploying because the index names will conflict

--- a/ethereum/setprotocol_v2/daily_component_prices.sql
+++ b/ethereum/setprotocol_v2/daily_component_prices.sql
@@ -1,0 +1,36 @@
+
+CREATE TABLE IF NOT EXISTS setprotocol_v2.daily_component_prices(
+    component_address bytea NOT NULL
+    , symbol text
+    , date date NOT NULL
+    , data_source text
+    , avg_price_usd numeric
+    , eth_price numeric
+    , avg_price_eth numeric
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS setprotocol_v2_daily_component_prices_addr_date_uniq_idx on setprotocol_v2.daily_component_prices (component_address, date);
+CREATE INDEX IF NOT EXISTS setprotocol_v2_daily_component_prices_addr_idx on setprotocol_v2.daily_component_prices (component_address);
+CREATE INDEX IF NOT EXISTS setprotocol_v2_daily_component_prices_date_idx on setprotocol_v2.daily_component_prices (date);
+CREATE INDEX IF NOT EXISTS setprotocol_v2_daily_component_prices_symbol_idx on setprotocol_v2.daily_component_prices (symbol);
+CREATE INDEX IF NOT EXISTS setprotocol_v2_daily_component_prices_avg_price_usd_idx on setprotocol_v2.daily_component_prices (avg_price_usd);
+
+-- use this version for testing on the user-enabled schema
+/*
+CREATE TABLE IF NOT EXISTS dune_user_generated.daily_component_prices(
+    component_address bytea NOT NULL
+    , symbol text
+    , date date NOT NULL
+    , data_source text
+    , avg_price_usd numeric
+    , eth_price numeric
+    , avg_price_eth numeric
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS setprotocol_v2_daily_component_prices_addr_date_uniq_idx on dune_user_generated.daily_component_prices (component_address, date);
+CREATE INDEX IF NOT EXISTS setprotocol_v2_daily_component_prices_addr_idx on dune_user_generated.daily_component_prices (component_address);
+CREATE INDEX IF NOT EXISTS setprotocol_v2_daily_component_prices_date_idx on dune_user_generated.daily_component_prices (date);
+CREATE INDEX IF NOT EXISTS setprotocol_v2_daily_component_prices_symbol_idx on dune_user_generated.daily_component_prices (symbol);
+CREATE INDEX IF NOT EXISTS setprotocol_v2_daily_component_prices_avg_price_usd_idx on dune_user_generated.daily_component_prices (avg_price_usd);
+*/
+-- don't forget to drop it because the index names will conflict

--- a/ethereum/setprotocol_v2/insert_daily_component_prices.sql
+++ b/ethereum/setprotocol_v2/insert_daily_component_prices.sql
@@ -1,0 +1,265 @@
+-- test query here: https://dune.xyz/queries/594861
+-- This insert query is modeled off of insert_prices_from_dex_data: 
+-- https://github.com/duneanalytics/abstractions/blob/master/ethereum/prices/insert_prices_from_dex_data.sql
+CREATE OR REPLACE FUNCTION setprotocol_v2.insert_daily_component_prices(start_time timestamptz, end_time timestamptz=now()) RETURNS integer
+-- CREATE OR REPLACE FUNCTION dune_user_generated.insert_daily_component_prices(start_time timestamptz, end_time timestamptz=now()) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+
+--Step 1: Grab components from coinpaprika
+with initial_components as (
+  -- Get the initial components from the create function
+  select output_0 as set_address
+    , unnest(_components) as component_address
+    , unnest(_units) as unit
+    , call_block_time as timestamp
+    , call_block_time::date as day
+  from setprotocol_v2."SetTokenCreator_call_create"
+  where call_success is true
+)
+, all_components as (
+  select distinct component_address
+  from initial_components
+  union
+  select distinct _component as component_address
+  from setprotocol_v2."SetToken_evt_ComponentAdded"
+)
+, components_mapped as ( -- don't even bother checking if the pre-mapped components have prices - use the map directly
+  select coalesce(m.mapped_component_address, ac.component_address) as mapped_component_address
+    , m.symbol as pre_mapped_symbol
+    , ac.component_address
+  from all_components ac
+  left join dune_user_generated.set_component_token_mappings m on ac.component_address = m.component_address
+)
+, daily_component_prices_usd as (
+  -- so we're taking the average of a time series here, which is not fully valid, but this part of the query was benchmarked to 3 minutes
+  -- whereas if we were to take the open instead, that gets a 4.5x runtime of 13 minutes, so I think taking the average
+  -- is a reasonable approximation for the performance we get.
+  select ac.component_address
+    , upper(coalesce(ac.pre_mapped_symbol, p.symbol)) as symbol -- have to force all caps because prices.usd.symbol is inconsistently capitalized
+    , p.minute::date as date
+    , avg(price) as avg_price_usd
+  from components_mapped ac
+  inner join prices.usd p on ac.mapped_component_address = p.contract_address
+  where p.minute >= start_time
+   and p.minute < end_time
+  group by 1,2,3
+)
+, daily_eth_price_usd as (
+  select minute::date as date
+    , avg(price) as eth_price
+  from prices.layer1_usd p
+  where p.minute >= start_time
+   and p.minute < end_time
+  and symbol = 'ETH'
+  group by 1
+)
+, paprika_price_feed as (
+  select p.component_address
+    , p.symbol
+    , p.date
+    , 'prices.usd' as data_source
+    , p.avg_price_usd
+    , e.eth_price
+    , p.avg_price_usd / e.eth_price as avg_price_eth
+  from daily_component_prices_usd p
+  inner join daily_eth_price_usd e on p.date = e.date
+)
+, rows as (
+  insert into setprotocol_v2.daily_component_prices (
+  -- insert into dune_user_generated.daily_component_prices (
+    component_address
+    , symbol
+    , date
+    , data_source
+    , avg_price_usd
+    , eth_price
+    , avg_price_eth
+  )
+  select
+    component_address
+    , symbol
+    , date
+    , data_source
+    , avg_price_usd
+    , eth_price
+    , avg_price_eth
+  from paprika_price_feed
+
+  on CONFLICT(component_address, date) do update set 
+    avg_price_usd = EXCLUDED.avg_price_usd
+    , eth_price = EXCLUDED.eth_price
+    , avg_price_eth = EXCLUDED.avg_price_eth
+  RETURNING 1
+  
+)
+SELECT count(*) INTO r from rows;
+
+--Step 2: Grab components from dex trades
+with initial_components as (
+  -- Get the initial components from the create function
+  select output_0 as set_address
+    , unnest(_components) as component_address
+    , unnest(_units) as unit
+    , call_block_time as timestamp
+    , call_block_time::date as day
+  from setprotocol_v2."SetTokenCreator_call_create"
+)
+, all_components as (
+  select distinct component_address
+  from initial_components
+  union
+  select distinct _component as component_address
+  from setprotocol_v2."SetToken_evt_ComponentAdded"
+)
+, components_mapped as ( -- don't even bother checking if the pre-mapped components have prices - use the map directly
+  select coalesce(m.mapped_component_address, ac.component_address) as mapped_component_address
+    , m.symbol as pre_mapped_symbol
+    , ac.component_address
+  from all_components ac
+  left join dune_user_generated.set_component_token_mappings m on ac.component_address = m.component_address
+)
+, tokens_from_paprika as (
+  select distinct contract_address 
+  from prices.usd p 
+  where p.minute >= start_time
+   and p.minute < end_time
+)
+, missing_components_mapped as (
+  select ac.component_address
+    , ac.mapped_component_address
+    , ac.pre_mapped_symbol
+  from components_mapped ac
+  left join tokens_from_paprika tfp on ac.mapped_component_address = tfp.contract_address
+  where tfp.contract_address is null
+)
+, daily_component_prices_usd_passing as (
+  select p.hour::date as date
+    , mc.component_address
+    , coalesce(mc.pre_mapped_symbol, p.symbol) as symbol
+    -- , sum(sample_size) as daily_samples
+    , percentile_disc(0.5) within group (order by median_price) as avg_price -- use the median price for the day to remove outliers
+    -- , sum(median_price* sample_size) / sum(sample_size) as avg_price -- sample size weighted average median price
+  from prices.prices_from_dex_data p
+  inner join missing_components_mapped mc on p.contract_address = mc.mapped_component_address
+  where p.hour >= start_time
+   and p.hour < end_time
+    and sample_size > 0
+  group by 1,2,3
+  having sum(sample_size) > 5 -- minimum of 6 samples required to set a daily price
+     and count(distinct median_price) > 5 -- minimum of 6 unique rows required
+)
+, daily_component_prices_usd_passing_lead as (
+  select date
+        , component_address
+        , symbol
+        , avg_price
+        , lead(date, 1) over (partition by component_address order by date) as next_date
+            -- this gives the day that this particular snapshot value is valid until
+    from daily_component_prices_usd_passing 
+)
+, day_series as (
+  SELECT generate_series(min(date), now(), '1 day') AS day 
+        FROM daily_component_prices_usd_passing
+)
+, imputed_component_prices_usd as (
+    select d.day as date
+        , p.component_address
+        , p.symbol
+        , p.avg_price as avg_price_usd
+    from day_series d 
+    inner join daily_component_prices_usd_passing_lead p
+        on d.day >= p.date
+        and d.day < coalesce(p.next_date,now()::date) -- if it's missing that means it's the last entry in the series
+)
+, daily_eth_price_usd as (
+  select minute::date as date
+    , avg(price) as eth_price
+  from prices.layer1_usd p
+  where p.minute >= start_time
+   and p.minute < end_time
+  and symbol = 'ETH'
+  group by 1
+)
+, dex_price_feed as (
+  select p.component_address
+    , p.symbol
+    , p.date
+    , 'prices.prices_from_dex_data' as data_source
+    , p.avg_price_usd
+    , e.eth_price
+    , p.avg_price_usd / e.eth_price as avg_price_eth
+  from imputed_component_prices_usd p
+  inner join daily_eth_price_usd e on p.date = e.date
+)
+, rows as (
+  insert into setprotocol_v2.daily_component_prices (
+  -- insert into dune_user_generated.daily_component_prices (
+    component_address
+    , symbol
+    , date
+    , data_source
+    , avg_price_usd
+    , eth_price
+    , avg_price_eth
+  )
+  select
+    component_address
+    , symbol
+    , date
+    , data_source
+    , avg_price_usd
+    , eth_price
+    , avg_price_eth
+  from dex_price_feed
+
+  on CONFLICT(component_address, date) do update set 
+    avg_price_usd = EXCLUDED.avg_price_usd
+    , eth_price = EXCLUDED.eth_price
+    , avg_price_eth = EXCLUDED.avg_price_eth
+  RETURNING 1
+  
+)
+SELECT count(*) + r INTO r from rows;
+RETURN r;
+END
+$function$;
+
+-- half-yearly backfill starting '2020-09-10', the date of the first Set contract deployment
+SELECT setprotocol_v2.insert_daily_component_prices('2020-09-10', '2021-01-01')
+WHERE NOT EXISTS (SELECT * FROM setprotocol_v2.daily_component_prices WHERE date >= '2020-09-10' and date < '2021-01-01');
+
+SELECT setprotocol_v2.insert_daily_component_prices('2021-01-01', '2021-06-01')
+WHERE NOT EXISTS (SELECT * FROM setprotocol_v2.daily_component_prices WHERE date >= '2021-01-01' and date < '2021-06-01');
+
+SELECT setprotocol_v2.insert_daily_component_prices('2021-06-01', '2022-01-01')
+WHERE NOT EXISTS (SELECT * FROM setprotocol_v2.daily_component_prices WHERE date >= '2021-06-01' and date < '2022-01-01');
+
+SELECT setprotocol_v2.insert_daily_component_prices('2022-01-01', now());
+
+-- Have the insert script run once a day 20 minutes after midnight and noon
+-- `start-time` is set to go back three days in time so that entries can be retroactively updated 
+-- in case `dex.trades` or price data falls behind.
+INSERT INTO cron.job (schedule, command)
+VALUES ('20 0,12 * * *', $$
+    SELECT setprotocol_v2.insert_daily_component_prices(
+        (SELECT date_trunc('day', now()) - interval '3 days'),
+        (SELECT date_trunc('day', now())));
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+
+/*
+use the following code to test the script
+SELECT dune_user_generated.insert_daily_component_prices('2020-09-10', '2021-01-01')
+WHERE NOT EXISTS (SELECT * FROM dune_user_generated.daily_component_prices WHERE date >= '2020-09-10' and date < '2021-01-01');
+
+SELECT dune_user_generated.insert_daily_component_prices('2021-01-01', '2021-06-01')
+WHERE NOT EXISTS (SELECT * FROM dune_user_generated.daily_component_prices WHERE date >= '2021-01-01' and date < '2021-06-01');
+
+SELECT dune_user_generated.insert_daily_component_prices('2021-06-01', '2022-01-01')
+WHERE NOT EXISTS (SELECT * FROM dune_user_generated.daily_component_prices WHERE date >= '2021-06-01' and date < '2022-01-01');
+
+SELECT dune_user_generated.insert_daily_component_prices('2022-01-01', now());
+
+*/

--- a/ethereum/setprotocol_v2/insert_daily_component_prices.sql
+++ b/ethereum/setprotocol_v2/insert_daily_component_prices.sql
@@ -30,7 +30,7 @@ with initial_components as (
     , m.symbol as pre_mapped_symbol
     , ac.component_address
   from all_components ac
-  left join dune_user_generated.set_component_token_mappings m on ac.component_address = m.component_address
+  left join setprotocol_v2.set_component_token_mappings m on ac.component_address = m.component_address
 )
 , daily_component_prices_usd as (
   -- so we're taking the average of a time series here, which is not fully valid, but this part of the query was benchmarked to 3 minutes
@@ -118,7 +118,7 @@ with initial_components as (
     , m.symbol as pre_mapped_symbol
     , ac.component_address
   from all_components ac
-  left join dune_user_generated.set_component_token_mappings m on ac.component_address = m.component_address
+  left join setprotocol_v2.set_component_token_mappings m on ac.component_address = m.component_address
 )
 , tokens_from_paprika as (
   select distinct contract_address 

--- a/ethereum/setprotocol_v2/set_component_token_mapping.sql
+++ b/ethereum/setprotocol_v2/set_component_token_mapping.sql
@@ -1,0 +1,33 @@
+-- https://dune.xyz/queries/576574
+-- There are certain wrapped components of Set tokens that map closely 1:1 with their corresponding token
+-- but are not actively traded, since they're just individual tokens that represent claims on other tokens
+
+
+create table if not exists setprotocol_v2.set_component_token_mappings
+(
+  symbol varchar,
+  component_address bytea,
+  token_type varchar,
+  mapped_symbol varchar,
+  mapped_component_address bytea         
+);
+
+create index if not exists on setprotocol_v2.set_component_token_mappings(component_address, mapped_component_address);
+create index if not exists on setprotocol_v2.set_component_token_mappings(component_address);
+create index if not exists on setprotocol_v2.set_component_token_mappings(mapped_component_address); 
+
+truncate table setprotocol_v2.set_component_token_mappings;
+
+insert into setprotocol_v2.set_component_token_mappings 
+(symbol,          component_address,                                    token_type,               mapped_symbol,  mapped_component_address                                ) values 
+('astETH',        '\x1982b2f5814301d4e9a8b0201555376e62f82428'::bytea,  'AAVE Interest Bearing',  'stETH',        '\xae7ab96520de3a18e5e111b5eaab095312d7fe84'::bytea     ),
+-- https://docs.lido.fi/integrations/aave/specification/ indicates that astETH is pegged to underlying asset 1:1
+('aWETH',         '\x030ba81f1c18d280636f32af80b9aad02cf0854e'::bytea,  'AAVE Interest Bearing',  'WETH',         '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'::bytea     ),
+('ALINK',         '\xa06bc25b5805d5f8d82847d191cb4af5a3e873e0'::bytea,  'AAVE Interest Bearing',  'LINK',         '\x514910771af9ca656af840dff83e8264ecf986ca'::bytea     ),
+('ALINK',         '\xa64bd6c70cb9051f6a9ba1f163fdc07e0dfb5f84'::bytea,  'AAVE Interest Bearing',  'LINK',         '\x514910771af9ca656af840dff83e8264ecf986ca'::bytea     ),
+('AWBTC',         '\x9ff58f4ffb29fa2266ab25e75e2a8b3503311656'::bytea,  'AAVE Interest Bearing',  'WBTC',         '\x2260fac5e5542a773aa44fbcfedf7c193bc2c599'::bytea     ),
+('aUSDC(v2)',     '\xbcca60bb61934080951369a648fb03df4f96263c'::bytea,  'AAVE Interest Bearing',  'USDC',         '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea     ),
+('aBUSD',         '\xA361718326c15715591c299427c62086F69923D9'::bytea,  'AAVE Interest Bearing',  'BUSD',         '\x4Fabb145d64652a948d72533023f6E7A623C7C53'::bytea     ),
+('aDAI',          '\xfc1e690f61efd961294b3e1ce3313fbd8aa4f85d'::bytea,  'AAVE Interest Bearing',  'DAI',          '\x6b175474e89094c44da98b954eedeac495271d0f'::bytea     ),
+('aDAI(v2)',      '\x028171bca77440897b824ca71d1c56cac55b68a3'::bytea,  'AAVE Interest Bearing',  'DAI',          '\x6b175474e89094c44da98b954eedeac495271d0f'::bytea     )
+;

--- a/ethereum/setprotocol_v2/set_component_token_mapping.sql
+++ b/ethereum/setprotocol_v2/set_component_token_mapping.sql
@@ -12,9 +12,9 @@ create table if not exists setprotocol_v2.set_component_token_mappings
   mapped_component_address bytea         
 );
 
-create index if not exists on setprotocol_v2.set_component_token_mappings(component_address, mapped_component_address);
-create index if not exists on setprotocol_v2.set_component_token_mappings(component_address);
-create index if not exists on setprotocol_v2.set_component_token_mappings(mapped_component_address); 
+create index if not exists setprotocol_v2_set_component_mappings_comp_map_adr_idx on setprotocol_v2.set_component_token_mappings(component_address, mapped_component_address);
+create index if not exists setprotocol_v2_set_component_mappings_comp_adr_idx on setprotocol_v2.set_component_token_mappings(component_address);
+create index if not exists setprotocol_v2_set_component_mappings_comp_map_idx on setprotocol_v2.set_component_token_mappings(mapped_component_address); 
 
 truncate table setprotocol_v2.set_component_token_mappings;
 


### PR DESCRIPTION
I've checked that:

* [X] the query produces the intended results
* [X] the folder name matches the schema name
* [X] the schema name exists in Dune
* [X] views are prefixed with `view_`, functions with `fn_`.
* [X] the filename matches the defined view, table or function and ends with .sql
* [X] each file has only one view, table or function defined  
* [X] column names are `lowercase_snake_cased`

This PR is for a daily price feed for the underlying components of Sets created using Set Protocol. These prices are important for estimating TVL and whatnot, and is intended to work across the entire ecosystem.

I've validated the insert function and backfilling function in this query here:
https://dune.xyz/queries/594861
This doesn't run in one go because the backfilling operation takes longer than 30 minutes, but you can execute each insert statement individually.

Most of the operative logic is clarified in the README. Architecturally it's modeled off of insert_prices_from_dex_data, and uses the dex pricing as a key input.

Update: Addressed feedback on putting the token mapping into the PR instead of relying on `dune_user_generated`