### PR TITLE
Add eth_transfers to OP2

### DIFF
--- a/optimism2/eth/eth_transfers.sql
+++ b/optimism2/eth/eth_transfers.sql
@@ -1,6 +1,6 @@
-CREATE SCHEMA IF NOT EXISTS erc20;
+CREATE SCHEMA IF NOT EXISTS eth;
 
-CREATE TABLE IF NOT EXISTS erc20.daily_token_balances (
+CREATE TABLE IF NOT EXISTS eth.eth_transfers (
 from	bytea,
 to	bytea,
 value	decimal,

--- a/optimism2/eth/eth_transfers.sql
+++ b/optimism2/eth/eth_transfers.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS eth.eth_transfers (
 	value	numeric,
 	value_decimal	numeric,
 	tx_hash	bytea,
-	trace_address	integer[],
+	trace_address	_int4,
 	tx_block_time 	timestamptz,
 	tx_block_number	int8,
 	tx_method_id	bytea,

--- a/optimism2/eth/eth_transfers.sql
+++ b/optimism2/eth/eth_transfers.sql
@@ -14,21 +14,21 @@ CREATE TABLE IF NOT EXISTS eth.eth_transfers (
 	);
 
 
-CREATE UNIQUE INDEX "eth_transfer_pkey" ON eth."eth_transfer" USING btree (tx_hash, tx_index)
-CREATE INDEX "eth_transfer_contract_address_from_tx_block_time_val_idx" ON eth."eth_transfer" USING btree (contract_address, "from", tx_block_time) INCLUDE (value, value_decimal)
-CREATE INDEX "eth_transfer_contract_address_to_tx_block_time_value_idx" ON eth."eth_transfer" USING btree (contract_address, "to", tx_block_time) INCLUDE (value, value_decimal)
-CREATE INDEX "eth_transfer_tx_block_number_idx" ON eth."eth_transfer" USING brin (tx_block_number)
-CREATE INDEX "eth_transfer_tx_block_time_idx" ON eth."eth_transfer" USING brin (tx_block_time)
-CREATE INDEX "eth_transfer_from_contract_address_tx_block_time_val_idx" ON eth."eth_transfer" USING btree ("from", contract_address, tx_block_time) INCLUDE (value, value_decimal)
-CREATE INDEX "eth_transfer_from_idx" ON eth."eth_transfer" USING btree ("from")
-CREATE INDEX "eth_transfer_to_contract_address_tx_block_time_value_idx" ON eth."eth_transfer" USING btree ("to", contract_address, tx_block_time) INCLUDE (value, value_decimal)
-CREATE INDEX "eth_transfer_incl_value_tx_idx_using_to_contract_addr_ev" ON eth."eth_transfer" USING btree ("to", contract_address, tx_block_time) INCLUDE (value, value_decimal, tx_index)
-CREATE INDEX "eth_transfer_incl_value_tx_idx_using_from_contract_time_" ON eth."eth_transfer" USING btree ("from", contract_address, tx_block_time) INCLUDE (value, value_decimal, tx_index)
-CREATE INDEX "eth_transfer_incl_value_tx_idx_using_contract_from_time_" ON eth."eth_transfer" USING btree (contract_address, "from", tx_block_time) INCLUDE (value, value_decimal, tx_index)
-CREATE INDEX "eth_transfer_incl_value_tx_idx_using_contract_to_time_id" ON eth."eth_transfer" USING btree (contract_address, "to", tx_block_time) INCLUDE (value, value_decimal, tx_index)
+CREATE UNIQUE INDEX "eth_transfer_pkey" ON eth."eth_transfers" USING btree (tx_hash, tx_index)
+CREATE INDEX "eth_transfer_contract_address_from_tx_block_time_val_idx" ON eth."eth_transfers" USING btree (contract_address, "from", tx_block_time) INCLUDE (value, value_decimal)
+CREATE INDEX "eth_transfer_contract_address_to_tx_block_time_value_idx" ON eth."eth_transfers" USING btree (contract_address, "to", tx_block_time) INCLUDE (value, value_decimal)
+CREATE INDEX "eth_transfer_tx_block_number_idx" ON eth."eth_transfers" USING brin (tx_block_number)
+CREATE INDEX "eth_transfer_tx_block_time_idx" ON eth."eth_transfers" USING brin (tx_block_time)
+CREATE INDEX "eth_transfer_from_contract_address_tx_block_time_val_idx" ON eth."eth_transfers" USING btree ("from", contract_address, tx_block_time) INCLUDE (value, value_decimal)
+CREATE INDEX "eth_transfer_from_idx" ON eth."eth_transfers" USING btree ("from")
+CREATE INDEX "eth_transfer_to_contract_address_tx_block_time_value_idx" ON eth."eth_transfers" USING btree ("to", contract_address, tx_block_time) INCLUDE (value, value_decimal)
+CREATE INDEX "eth_transfer_incl_value_tx_idx_using_to_contract_addr_ev" ON eth."eth_transfers" USING btree ("to", contract_address, tx_block_time) INCLUDE (value, value_decimal, tx_index)
+CREATE INDEX "eth_transfer_incl_value_tx_idx_using_from_contract_time_" ON eth."eth_transfers" USING btree ("from", contract_address, tx_block_time) INCLUDE (value, value_decimal, tx_index)
+CREATE INDEX "eth_transfer_incl_value_tx_idx_using_contract_from_time_" ON eth."eth_transfers" USING btree (contract_address, "from", tx_block_time) INCLUDE (value, value_decimal, tx_index)
+CREATE INDEX "eth_transfer_incl_value_tx_idx_using_contract_to_time_id" ON eth."eth_transfers" USING btree (contract_address, "to", tx_block_time) INCLUDE (value, value_decimal, tx_index)
 
-CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id" ON eth.eth_transfer (tx_method_id);
-CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id_block_time" ON eth.eth_transfer (tx_method_id,tx_block_time);
-CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id_to" ON eth.eth_transfer (tx_method_id, "to");
-CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id_to_from" ON eth.eth_transfer (tx_method_id, "to","from");
-CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id_to_block_time" ON eth.eth_transfer (tx_method_id, "to",tx_block_time);
+CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id" ON eth.eth_transfers (tx_method_id);
+CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id_block_time" ON eth.eth_transfers (tx_method_id,tx_block_time);
+CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id_to" ON eth.eth_transfers (tx_method_id, "to");
+CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id_to_from" ON eth.eth_transfers (tx_method_id, "to","from");
+CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id_to_block_time" ON eth.eth_transfers (tx_method_id, "to",tx_block_time);

--- a/optimism2/eth/eth_transfers.sql
+++ b/optimism2/eth/eth_transfers.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS eth.eth_transfers (
 	value	numeric,
 	value_decimal	numeric,
 	tx_hash	bytea,
-	trace_address	int8,
+	trace_address	integer[],
 	tx_block_time 	timestamptz,
 	tx_block_number	int8,
 	tx_method_id	bytea,

--- a/optimism2/eth/eth_transfers.sql
+++ b/optimism2/eth/eth_transfers.sql
@@ -3,6 +3,7 @@ CREATE SCHEMA IF NOT EXISTS eth;
 CREATE TABLE IF NOT EXISTS eth.eth_transfers (
 	"from"	bytea,
 	"to"	bytea,
+	"contract_address"	bytea,
 	value	numeric,
 	value_decimal	numeric,
 	tx_hash	bytea,

--- a/optimism2/eth/eth_transfers.sql
+++ b/optimism2/eth/eth_transfers.sql
@@ -3,7 +3,8 @@ CREATE SCHEMA IF NOT EXISTS eth;
 CREATE TABLE IF NOT EXISTS eth.eth_transfers (
 "from"	bytea,
 "to"	bytea,
-value	decimal,
+value	numeric,
+value_decimal_adjusted	numeric,
 trace_tx_hash	bytea,
 trace_index	int8,
 trace_block_time 	timestamptz,
@@ -13,14 +14,14 @@ trace_block_number	int8,
 
 
 CREATE UNIQUE INDEX "eth_transfer_pkey" ON eth."eth_transfer" USING btree (trace_tx_hash, trace_index)
-CREATE INDEX "eth_transfer_contract_address_from_trace_block_time_val_idx" ON eth."eth_transfer" USING btree (contract_address, "from", trace_block_time) INCLUDE (value)
-CREATE INDEX "eth_transfer_contract_address_to_trace_block_time_value_idx" ON eth."eth_transfer" USING btree (contract_address, "to", trace_block_time) INCLUDE (value)
+CREATE INDEX "eth_transfer_contract_address_from_trace_block_time_val_idx" ON eth."eth_transfer" USING btree (contract_address, "from", trace_block_time) INCLUDE (value, value_decimal_adjusted)
+CREATE INDEX "eth_transfer_contract_address_to_trace_block_time_value_idx" ON eth."eth_transfer" USING btree (contract_address, "to", trace_block_time) INCLUDE (value, value_decimal_adjusted)
 CREATE INDEX "eth_transfer_trace_block_number_idx" ON eth."eth_transfer" USING brin (trace_block_number)
 CREATE INDEX "eth_transfer_trace_block_time_idx" ON eth."eth_transfer" USING brin (trace_block_time)
-CREATE INDEX "eth_transfer_from_contract_address_trace_block_time_val_idx" ON eth."eth_transfer" USING btree ("from", contract_address, trace_block_time) INCLUDE (value)
+CREATE INDEX "eth_transfer_from_contract_address_trace_block_time_val_idx" ON eth."eth_transfer" USING btree ("from", contract_address, trace_block_time) INCLUDE (value, value_decimal_adjusted)
 CREATE INDEX "eth_transfer_from_idx" ON eth."eth_transfer" USING btree ("from")
-CREATE INDEX "eth_transfer_to_contract_address_trace_block_time_value_idx" ON eth."eth_transfer" USING btree ("to", contract_address, trace_block_time) INCLUDE (value)
-CREATE INDEX "eth_transfer_incl_value_trace_idx_using_to_contract_addr_ev" ON eth."eth_transfer" USING btree ("to", contract_address, trace_block_time) INCLUDE (value, trace_index)
-CREATE INDEX "eth_transfer_incl_value_trace_idx_using_from_contract_time_" ON eth."eth_transfer" USING btree ("from", contract_address, trace_block_time) INCLUDE (value, trace_index)
-CREATE INDEX "eth_transfer_incl_value_trace_idx_using_contract_from_time_" ON eth."eth_transfer" USING btree (contract_address, "from", trace_block_time) INCLUDE (value, trace_index)
-CREATE INDEX "eth_transfer_incl_value_trace_idx_using_contract_to_time_id" ON eth."eth_transfer" USING btree (contract_address, "to", trace_block_time) INCLUDE (value, trace_index)
+CREATE INDEX "eth_transfer_to_contract_address_trace_block_time_value_idx" ON eth."eth_transfer" USING btree ("to", contract_address, trace_block_time) INCLUDE (value, value_decimal_adjusted)
+CREATE INDEX "eth_transfer_incl_value_trace_idx_using_to_contract_addr_ev" ON eth."eth_transfer" USING btree ("to", contract_address, trace_block_time) INCLUDE (value, value_decimal_adjusted, trace_index)
+CREATE INDEX "eth_transfer_incl_value_trace_idx_using_from_contract_time_" ON eth."eth_transfer" USING btree ("from", contract_address, trace_block_time) INCLUDE (value, value_decimal_adjusted, trace_index)
+CREATE INDEX "eth_transfer_incl_value_trace_idx_using_contract_from_time_" ON eth."eth_transfer" USING btree (contract_address, "from", trace_block_time) INCLUDE (value, value_decimal_adjusted, trace_index)
+CREATE INDEX "eth_transfer_incl_value_trace_idx_using_contract_to_time_id" ON eth."eth_transfer" USING btree (contract_address, "to", trace_block_time) INCLUDE (value, value_decimal_adjusted, trace_index)

--- a/optimism2/eth/eth_transfers.sql
+++ b/optimism2/eth/eth_transfers.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS eth.eth_transfers (
 	value	numeric,
 	value_decimal	numeric,
 	tx_hash	bytea,
-	tx_index	int8,
+	trace_address	int8,
 	tx_block_time 	timestamptz,
 	tx_block_number	int8,
 	tx_method_id	bytea,
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS eth.eth_transfers (
 	);
 
 
-CREATE UNIQUE INDEX "eth_transfer_pkey" ON eth."eth_transfers" USING btree (tx_hash, tx_index);
+CREATE UNIQUE INDEX "eth_transfer_pkey" ON eth."eth_transfers" USING btree (tx_hash, trace_address);
 CREATE INDEX "eth_transfer_contract_address_from_tx_block_time_val_idx" ON eth."eth_transfers" USING btree (contract_address, "from", tx_block_time) INCLUDE (value, value_decimal);
 CREATE INDEX "eth_transfer_contract_address_to_tx_block_time_value_idx" ON eth."eth_transfers" USING btree (contract_address, "to", tx_block_time) INCLUDE (value, value_decimal);
 CREATE INDEX "eth_transfer_tx_block_number_idx" ON eth."eth_transfers" USING brin (tx_block_number);
@@ -23,10 +23,10 @@ CREATE INDEX "eth_transfer_tx_block_time_idx" ON eth."eth_transfers" USING brin 
 CREATE INDEX "eth_transfer_from_contract_address_tx_block_time_val_idx" ON eth."eth_transfers" USING btree ("from", contract_address, tx_block_time) INCLUDE (value, value_decimal);
 CREATE INDEX "eth_transfer_from_idx" ON eth."eth_transfers" USING btree ("from");
 CREATE INDEX "eth_transfer_to_contract_address_tx_block_time_value_idx" ON eth."eth_transfers" USING btree ("to", contract_address, tx_block_time) INCLUDE (value, value_decimal);
-CREATE INDEX "eth_transfer_incl_value_tx_idx_using_to_contract_addr_ev" ON eth."eth_transfers" USING btree ("to", contract_address, tx_block_time) INCLUDE (value, value_decimal, tx_index);
-CREATE INDEX "eth_transfer_incl_value_tx_idx_using_from_contract_time_" ON eth."eth_transfers" USING btree ("from", contract_address, tx_block_time) INCLUDE (value, value_decimal, tx_index);
-CREATE INDEX "eth_transfer_incl_value_tx_idx_using_contract_from_time_" ON eth."eth_transfers" USING btree (contract_address, "from", tx_block_time) INCLUDE (value, value_decimal, tx_index);
-CREATE INDEX "eth_transfer_incl_value_tx_idx_using_contract_to_time_id" ON eth."eth_transfers" USING btree (contract_address, "to", tx_block_time) INCLUDE (value, value_decimal, tx_index);
+CREATE INDEX "eth_transfer_incl_value_tx_idx_using_to_contract_addr_ev" ON eth."eth_transfers" USING btree ("to", contract_address, tx_block_time) INCLUDE (value, value_decimal, trace_address);
+CREATE INDEX "eth_transfer_incl_value_tx_idx_using_from_contract_time_" ON eth."eth_transfers" USING btree ("from", contract_address, tx_block_time) INCLUDE (value, value_decimal, trace_address);
+CREATE INDEX "eth_transfer_incl_value_tx_idx_using_contract_from_time_" ON eth."eth_transfers" USING btree (contract_address, "from", tx_block_time) INCLUDE (value, value_decimal, trace_address);
+CREATE INDEX "eth_transfer_incl_value_tx_idx_using_contract_to_time_id" ON eth."eth_transfers" USING btree (contract_address, "to", tx_block_time) INCLUDE (value, value_decimal, trace_address);
 
 CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id" ON eth.eth_transfers (tx_method_id);
 CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id_block_time" ON eth.eth_transfers (tx_method_id,tx_block_time);

--- a/optimism2/eth/eth_transfers.sql
+++ b/optimism2/eth/eth_transfers.sql
@@ -9,6 +9,7 @@ CREATE TABLE IF NOT EXISTS eth.eth_transfers (
 	tx_index	int8,
 	tx_block_time 	timestamptz,
 	tx_block_number	int8,
+	tx_method_id	bytea,
 		PRIMARY KEY (tx_hash, tx_index)
 	);
 
@@ -25,3 +26,9 @@ CREATE INDEX "eth_transfer_incl_value_tx_idx_using_to_contract_addr_ev" ON eth."
 CREATE INDEX "eth_transfer_incl_value_tx_idx_using_from_contract_time_" ON eth."eth_transfer" USING btree ("from", contract_address, tx_block_time) INCLUDE (value, value_decimal, tx_index)
 CREATE INDEX "eth_transfer_incl_value_tx_idx_using_contract_from_time_" ON eth."eth_transfer" USING btree (contract_address, "from", tx_block_time) INCLUDE (value, value_decimal, tx_index)
 CREATE INDEX "eth_transfer_incl_value_tx_idx_using_contract_to_time_id" ON eth."eth_transfer" USING btree (contract_address, "to", tx_block_time) INCLUDE (value, value_decimal, tx_index)
+
+CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id" ON eth.eth_transfer (tx_method_id);
+CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id_block_time" ON eth.eth_transfer (tx_method_id,tx_block_time);
+CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id_to" ON eth.eth_transfer (tx_method_id, "to");
+CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id_to_from" ON eth.eth_transfer (tx_method_id, "to","from");
+CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id_to_block_time" ON eth.eth_transfer (tx_method_id, "to",tx_block_time);

--- a/optimism2/eth/eth_transfers.sql
+++ b/optimism2/eth/eth_transfers.sql
@@ -1,27 +1,27 @@
 CREATE SCHEMA IF NOT EXISTS eth;
 
 CREATE TABLE IF NOT EXISTS eth.eth_transfers (
-"from"	bytea,
-"to"	bytea,
-value	numeric,
-value_decimal	numeric,
-trace_tx_hash	bytea,
-trace_index	int8,
-trace_block_time 	timestamptz,
-trace_block_number	int8,
-	PRIMARY KEY (trace_tx_hash, trace_index)
-);
+	"from"	bytea,
+	"to"	bytea,
+	value	numeric,
+	value_decimal	numeric,
+	tx_hash	bytea,
+	tx_index	int8,
+	tx_block_time 	timestamptz,
+	tx_block_number	int8,
+		PRIMARY KEY (tx_hash, tx_index)
+	);
 
 
-CREATE UNIQUE INDEX "eth_transfer_pkey" ON eth."eth_transfer" USING btree (trace_tx_hash, trace_index)
-CREATE INDEX "eth_transfer_contract_address_from_trace_block_time_val_idx" ON eth."eth_transfer" USING btree (contract_address, "from", trace_block_time) INCLUDE (value, value_decimal)
-CREATE INDEX "eth_transfer_contract_address_to_trace_block_time_value_idx" ON eth."eth_transfer" USING btree (contract_address, "to", trace_block_time) INCLUDE (value, value_decimal)
-CREATE INDEX "eth_transfer_trace_block_number_idx" ON eth."eth_transfer" USING brin (trace_block_number)
-CREATE INDEX "eth_transfer_trace_block_time_idx" ON eth."eth_transfer" USING brin (trace_block_time)
-CREATE INDEX "eth_transfer_from_contract_address_trace_block_time_val_idx" ON eth."eth_transfer" USING btree ("from", contract_address, trace_block_time) INCLUDE (value, value_decimal)
+CREATE UNIQUE INDEX "eth_transfer_pkey" ON eth."eth_transfer" USING btree (tx_hash, tx_index)
+CREATE INDEX "eth_transfer_contract_address_from_tx_block_time_val_idx" ON eth."eth_transfer" USING btree (contract_address, "from", tx_block_time) INCLUDE (value, value_decimal)
+CREATE INDEX "eth_transfer_contract_address_to_tx_block_time_value_idx" ON eth."eth_transfer" USING btree (contract_address, "to", tx_block_time) INCLUDE (value, value_decimal)
+CREATE INDEX "eth_transfer_tx_block_number_idx" ON eth."eth_transfer" USING brin (tx_block_number)
+CREATE INDEX "eth_transfer_tx_block_time_idx" ON eth."eth_transfer" USING brin (tx_block_time)
+CREATE INDEX "eth_transfer_from_contract_address_tx_block_time_val_idx" ON eth."eth_transfer" USING btree ("from", contract_address, tx_block_time) INCLUDE (value, value_decimal)
 CREATE INDEX "eth_transfer_from_idx" ON eth."eth_transfer" USING btree ("from")
-CREATE INDEX "eth_transfer_to_contract_address_trace_block_time_value_idx" ON eth."eth_transfer" USING btree ("to", contract_address, trace_block_time) INCLUDE (value, value_decimal)
-CREATE INDEX "eth_transfer_incl_value_trace_idx_using_to_contract_addr_ev" ON eth."eth_transfer" USING btree ("to", contract_address, trace_block_time) INCLUDE (value, value_decimal, trace_index)
-CREATE INDEX "eth_transfer_incl_value_trace_idx_using_from_contract_time_" ON eth."eth_transfer" USING btree ("from", contract_address, trace_block_time) INCLUDE (value, value_decimal, trace_index)
-CREATE INDEX "eth_transfer_incl_value_trace_idx_using_contract_from_time_" ON eth."eth_transfer" USING btree (contract_address, "from", trace_block_time) INCLUDE (value, value_decimal, trace_index)
-CREATE INDEX "eth_transfer_incl_value_trace_idx_using_contract_to_time_id" ON eth."eth_transfer" USING btree (contract_address, "to", trace_block_time) INCLUDE (value, value_decimal, trace_index)
+CREATE INDEX "eth_transfer_to_contract_address_tx_block_time_value_idx" ON eth."eth_transfer" USING btree ("to", contract_address, tx_block_time) INCLUDE (value, value_decimal)
+CREATE INDEX "eth_transfer_incl_value_tx_idx_using_to_contract_addr_ev" ON eth."eth_transfer" USING btree ("to", contract_address, tx_block_time) INCLUDE (value, value_decimal, tx_index)
+CREATE INDEX "eth_transfer_incl_value_tx_idx_using_from_contract_time_" ON eth."eth_transfer" USING btree ("from", contract_address, tx_block_time) INCLUDE (value, value_decimal, tx_index)
+CREATE INDEX "eth_transfer_incl_value_tx_idx_using_contract_from_time_" ON eth."eth_transfer" USING btree (contract_address, "from", tx_block_time) INCLUDE (value, value_decimal, tx_index)
+CREATE INDEX "eth_transfer_incl_value_tx_idx_using_contract_to_time_id" ON eth."eth_transfer" USING btree (contract_address, "to", tx_block_time) INCLUDE (value, value_decimal, tx_index)

--- a/optimism2/eth/eth_transfers.sql
+++ b/optimism2/eth/eth_transfers.sql
@@ -1,8 +1,8 @@
 CREATE SCHEMA IF NOT EXISTS eth;
 
 CREATE TABLE IF NOT EXISTS eth.eth_transfers (
-from	bytea,
-to	bytea,
+"from"	bytea,
+"to"	bytea,
 value	decimal,
 trace_tx_hash	bytea,
 trace_index	int8,

--- a/optimism2/eth/eth_transfers.sql
+++ b/optimism2/eth/eth_transfers.sql
@@ -1,0 +1,26 @@
+CREATE SCHEMA IF NOT EXISTS erc20;
+
+CREATE TABLE IF NOT EXISTS erc20.daily_token_balances (
+from	bytea,
+to	bytea,
+value	decimal,
+trace_tx_hash	bytea,
+trace_index	int8,
+trace_block_time 	timestamptz,
+trace_block_number	int8,
+	PRIMARY KEY (trace_tx_hash, trace_index)
+);
+
+
+CREATE UNIQUE INDEX "eth_transfer_pkey" ON eth."eth_transfer" USING btree (trace_tx_hash, trace_index)
+CREATE INDEX "eth_transfer_contract_address_from_trace_block_time_val_idx" ON eth."eth_transfer" USING btree (contract_address, "from", trace_block_time) INCLUDE (value)
+CREATE INDEX "eth_transfer_contract_address_to_trace_block_time_value_idx" ON eth."eth_transfer" USING btree (contract_address, "to", trace_block_time) INCLUDE (value)
+CREATE INDEX "eth_transfer_trace_block_number_idx" ON eth."eth_transfer" USING brin (trace_block_number)
+CREATE INDEX "eth_transfer_trace_block_time_idx" ON eth."eth_transfer" USING brin (trace_block_time)
+CREATE INDEX "eth_transfer_from_contract_address_trace_block_time_val_idx" ON eth."eth_transfer" USING btree ("from", contract_address, trace_block_time) INCLUDE (value)
+CREATE INDEX "eth_transfer_from_idx" ON eth."eth_transfer" USING btree ("from")
+CREATE INDEX "eth_transfer_to_contract_address_trace_block_time_value_idx" ON eth."eth_transfer" USING btree ("to", contract_address, trace_block_time) INCLUDE (value)
+CREATE INDEX "eth_transfer_incl_value_trace_idx_using_to_contract_addr_ev" ON eth."eth_transfer" USING btree ("to", contract_address, trace_block_time) INCLUDE (value, trace_index)
+CREATE INDEX "eth_transfer_incl_value_trace_idx_using_from_contract_time_" ON eth."eth_transfer" USING btree ("from", contract_address, trace_block_time) INCLUDE (value, trace_index)
+CREATE INDEX "eth_transfer_incl_value_trace_idx_using_contract_from_time_" ON eth."eth_transfer" USING btree (contract_address, "from", trace_block_time) INCLUDE (value, trace_index)
+CREATE INDEX "eth_transfer_incl_value_trace_idx_using_contract_to_time_id" ON eth."eth_transfer" USING btree (contract_address, "to", trace_block_time) INCLUDE (value, trace_index)

--- a/optimism2/eth/eth_transfers.sql
+++ b/optimism2/eth/eth_transfers.sql
@@ -15,18 +15,18 @@ CREATE TABLE IF NOT EXISTS eth.eth_transfers (
 	);
 
 
-CREATE UNIQUE INDEX "eth_transfer_pkey" ON eth."eth_transfers" USING btree (tx_hash, tx_index)
-CREATE INDEX "eth_transfer_contract_address_from_tx_block_time_val_idx" ON eth."eth_transfers" USING btree (contract_address, "from", tx_block_time) INCLUDE (value, value_decimal)
-CREATE INDEX "eth_transfer_contract_address_to_tx_block_time_value_idx" ON eth."eth_transfers" USING btree (contract_address, "to", tx_block_time) INCLUDE (value, value_decimal)
-CREATE INDEX "eth_transfer_tx_block_number_idx" ON eth."eth_transfers" USING brin (tx_block_number)
-CREATE INDEX "eth_transfer_tx_block_time_idx" ON eth."eth_transfers" USING brin (tx_block_time)
-CREATE INDEX "eth_transfer_from_contract_address_tx_block_time_val_idx" ON eth."eth_transfers" USING btree ("from", contract_address, tx_block_time) INCLUDE (value, value_decimal)
-CREATE INDEX "eth_transfer_from_idx" ON eth."eth_transfers" USING btree ("from")
-CREATE INDEX "eth_transfer_to_contract_address_tx_block_time_value_idx" ON eth."eth_transfers" USING btree ("to", contract_address, tx_block_time) INCLUDE (value, value_decimal)
-CREATE INDEX "eth_transfer_incl_value_tx_idx_using_to_contract_addr_ev" ON eth."eth_transfers" USING btree ("to", contract_address, tx_block_time) INCLUDE (value, value_decimal, tx_index)
-CREATE INDEX "eth_transfer_incl_value_tx_idx_using_from_contract_time_" ON eth."eth_transfers" USING btree ("from", contract_address, tx_block_time) INCLUDE (value, value_decimal, tx_index)
-CREATE INDEX "eth_transfer_incl_value_tx_idx_using_contract_from_time_" ON eth."eth_transfers" USING btree (contract_address, "from", tx_block_time) INCLUDE (value, value_decimal, tx_index)
-CREATE INDEX "eth_transfer_incl_value_tx_idx_using_contract_to_time_id" ON eth."eth_transfers" USING btree (contract_address, "to", tx_block_time) INCLUDE (value, value_decimal, tx_index)
+CREATE UNIQUE INDEX "eth_transfer_pkey" ON eth."eth_transfers" USING btree (tx_hash, tx_index);
+CREATE INDEX "eth_transfer_contract_address_from_tx_block_time_val_idx" ON eth."eth_transfers" USING btree (contract_address, "from", tx_block_time) INCLUDE (value, value_decimal);
+CREATE INDEX "eth_transfer_contract_address_to_tx_block_time_value_idx" ON eth."eth_transfers" USING btree (contract_address, "to", tx_block_time) INCLUDE (value, value_decimal);
+CREATE INDEX "eth_transfer_tx_block_number_idx" ON eth."eth_transfers" USING brin (tx_block_number);
+CREATE INDEX "eth_transfer_tx_block_time_idx" ON eth."eth_transfers" USING brin (tx_block_time);
+CREATE INDEX "eth_transfer_from_contract_address_tx_block_time_val_idx" ON eth."eth_transfers" USING btree ("from", contract_address, tx_block_time) INCLUDE (value, value_decimal);
+CREATE INDEX "eth_transfer_from_idx" ON eth."eth_transfers" USING btree ("from");
+CREATE INDEX "eth_transfer_to_contract_address_tx_block_time_value_idx" ON eth."eth_transfers" USING btree ("to", contract_address, tx_block_time) INCLUDE (value, value_decimal);
+CREATE INDEX "eth_transfer_incl_value_tx_idx_using_to_contract_addr_ev" ON eth."eth_transfers" USING btree ("to", contract_address, tx_block_time) INCLUDE (value, value_decimal, tx_index);
+CREATE INDEX "eth_transfer_incl_value_tx_idx_using_from_contract_time_" ON eth."eth_transfers" USING btree ("from", contract_address, tx_block_time) INCLUDE (value, value_decimal, tx_index);
+CREATE INDEX "eth_transfer_incl_value_tx_idx_using_contract_from_time_" ON eth."eth_transfers" USING btree (contract_address, "from", tx_block_time) INCLUDE (value, value_decimal, tx_index);
+CREATE INDEX "eth_transfer_incl_value_tx_idx_using_contract_to_time_id" ON eth."eth_transfers" USING btree (contract_address, "to", tx_block_time) INCLUDE (value, value_decimal, tx_index);
 
 CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id" ON eth.eth_transfers (tx_method_id);
 CREATE INDEX IF NOT EXISTS "eth_transfer_tx_method_id_block_time" ON eth.eth_transfers (tx_method_id,tx_block_time);

--- a/optimism2/eth/eth_transfers.sql
+++ b/optimism2/eth/eth_transfers.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS eth.eth_transfers (
 	tx_block_time 	timestamptz,
 	tx_block_number	int8,
 	tx_method_id	bytea,
-		PRIMARY KEY (tx_hash, tx_index)
+		PRIMARY KEY (tx_hash, trace_address)
 	);
 
 

--- a/optimism2/eth/eth_transfers.sql
+++ b/optimism2/eth/eth_transfers.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS eth.eth_transfers (
 "from"	bytea,
 "to"	bytea,
 value	numeric,
-value_decimal_adjusted	numeric,
+value_decimal	numeric,
 trace_tx_hash	bytea,
 trace_index	int8,
 trace_block_time 	timestamptz,
@@ -14,14 +14,14 @@ trace_block_number	int8,
 
 
 CREATE UNIQUE INDEX "eth_transfer_pkey" ON eth."eth_transfer" USING btree (trace_tx_hash, trace_index)
-CREATE INDEX "eth_transfer_contract_address_from_trace_block_time_val_idx" ON eth."eth_transfer" USING btree (contract_address, "from", trace_block_time) INCLUDE (value, value_decimal_adjusted)
-CREATE INDEX "eth_transfer_contract_address_to_trace_block_time_value_idx" ON eth."eth_transfer" USING btree (contract_address, "to", trace_block_time) INCLUDE (value, value_decimal_adjusted)
+CREATE INDEX "eth_transfer_contract_address_from_trace_block_time_val_idx" ON eth."eth_transfer" USING btree (contract_address, "from", trace_block_time) INCLUDE (value, value_decimal)
+CREATE INDEX "eth_transfer_contract_address_to_trace_block_time_value_idx" ON eth."eth_transfer" USING btree (contract_address, "to", trace_block_time) INCLUDE (value, value_decimal)
 CREATE INDEX "eth_transfer_trace_block_number_idx" ON eth."eth_transfer" USING brin (trace_block_number)
 CREATE INDEX "eth_transfer_trace_block_time_idx" ON eth."eth_transfer" USING brin (trace_block_time)
-CREATE INDEX "eth_transfer_from_contract_address_trace_block_time_val_idx" ON eth."eth_transfer" USING btree ("from", contract_address, trace_block_time) INCLUDE (value, value_decimal_adjusted)
+CREATE INDEX "eth_transfer_from_contract_address_trace_block_time_val_idx" ON eth."eth_transfer" USING btree ("from", contract_address, trace_block_time) INCLUDE (value, value_decimal)
 CREATE INDEX "eth_transfer_from_idx" ON eth."eth_transfer" USING btree ("from")
-CREATE INDEX "eth_transfer_to_contract_address_trace_block_time_value_idx" ON eth."eth_transfer" USING btree ("to", contract_address, trace_block_time) INCLUDE (value, value_decimal_adjusted)
-CREATE INDEX "eth_transfer_incl_value_trace_idx_using_to_contract_addr_ev" ON eth."eth_transfer" USING btree ("to", contract_address, trace_block_time) INCLUDE (value, value_decimal_adjusted, trace_index)
-CREATE INDEX "eth_transfer_incl_value_trace_idx_using_from_contract_time_" ON eth."eth_transfer" USING btree ("from", contract_address, trace_block_time) INCLUDE (value, value_decimal_adjusted, trace_index)
-CREATE INDEX "eth_transfer_incl_value_trace_idx_using_contract_from_time_" ON eth."eth_transfer" USING btree (contract_address, "from", trace_block_time) INCLUDE (value, value_decimal_adjusted, trace_index)
-CREATE INDEX "eth_transfer_incl_value_trace_idx_using_contract_to_time_id" ON eth."eth_transfer" USING btree (contract_address, "to", trace_block_time) INCLUDE (value, value_decimal_adjusted, trace_index)
+CREATE INDEX "eth_transfer_to_contract_address_trace_block_time_value_idx" ON eth."eth_transfer" USING btree ("to", contract_address, trace_block_time) INCLUDE (value, value_decimal)
+CREATE INDEX "eth_transfer_incl_value_trace_idx_using_to_contract_addr_ev" ON eth."eth_transfer" USING btree ("to", contract_address, trace_block_time) INCLUDE (value, value_decimal, trace_index)
+CREATE INDEX "eth_transfer_incl_value_trace_idx_using_from_contract_time_" ON eth."eth_transfer" USING btree ("from", contract_address, trace_block_time) INCLUDE (value, value_decimal, trace_index)
+CREATE INDEX "eth_transfer_incl_value_trace_idx_using_contract_from_time_" ON eth."eth_transfer" USING btree (contract_address, "from", trace_block_time) INCLUDE (value, value_decimal, trace_index)
+CREATE INDEX "eth_transfer_incl_value_trace_idx_using_contract_to_time_id" ON eth."eth_transfer" USING btree (contract_address, "to", trace_block_time) INCLUDE (value, value_decimal, trace_index)

--- a/optimism2/eth/insert_eth_transfers.sql
+++ b/optimism2/eth/insert_eth_transfers.sql
@@ -36,7 +36,9 @@ WITH rows AS (
         AND block_time < end_block_time
 
     ON CONFLICT (trace_tx_hash, trace_index)
-    DO NOTHING
+    DO UPDATE SET
+	value = EXCLUDED.value,
+	value_decimal = EXCLUDED.value_decimal
 
     RETURNING 1
 )

--- a/optimism2/eth/insert_eth_transfers.sql
+++ b/optimism2/eth/insert_eth_transfers.sql
@@ -1,0 +1,47 @@
+CREATE OR REPLACE FUNCTION dune_user_generated.eth_insert_eth_transfers(start_block_time timestamptz, end_block_time timestamptz=now()) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH rows AS (
+    INSERT INTO dune_user_generated.eth_eth_transfers (
+       "from",
+        "to",
+        raw_value,
+        value,
+        value_decimal,
+        tx_hash,
+        tx_index,
+        tx_block_time,
+        tx_block_number
+    )
+    
+    SELECT 
+    "from",
+    "to",
+    value,
+    value/1e18 AS value_decimal,
+    "tx_hash",
+    "tx_index",
+    "block_time" AS tx_block_time,
+    "block_number" AS tx_block_number,
+    substring(input from 1 for 4) AS tx_method_id
+        FROM optimism."traces"
+        WHERE (call_type NOT IN ('delegatecall', 'callcode', 'staticcall') or call_type is null)
+        AND "tx_success" = true
+        AND success = true
+        AND value > 0
+        
+        AND block_time >= start_block_time
+        AND block_time < end_block_time
+
+	
+    -- update if we have new info on prices or the erc20
+    ON CONFLICT (trace_tx_hash, trace_index)
+    DO NOTHING
+
+    RETURNING 1
+)
+SELECT count(*) INTO r from rows;
+RETURN r;
+END
+$function$;

--- a/optimism2/eth/insert_eth_transfers.sql
+++ b/optimism2/eth/insert_eth_transfers.sql
@@ -10,7 +10,7 @@ WITH rows AS (
         value,
         value_decimal,
         tx_hash,
-        tx_index,
+        trace_address,
         tx_block_time,
         tx_block_number,
 	    tx_method_id
@@ -23,7 +23,7 @@ WITH rows AS (
     r.value,
     r.value/1e18 AS value_decimal,
     r."tx_hash",
-    r."tx_index",
+    r."trace_address",
     r."block_time" AS tx_block_time,
     r."block_number" AS tx_block_number,
     substring(t.data from 1 for 4) AS tx_method_id
@@ -39,7 +39,7 @@ WITH rows AS (
 	AND t.block_time >= start_block_time
     AND t.block_time < end_block_time
 
-    ON CONFLICT (tx_hash, tx_index)
+    ON CONFLICT (tx_hash, trace_address)
     DO UPDATE SET
 	value = EXCLUDED.value,
 	value_decimal = EXCLUDED.value_decimal

--- a/optimism2/eth/insert_eth_transfers.sql
+++ b/optimism2/eth/insert_eth_transfers.sql
@@ -19,6 +19,7 @@ WITH rows AS (
     SELECT 
     r."from",
     r."to",
+	'\xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000' AS	contract_address, --Using the ETH deposit placeholder address to match with prices tables
     r.value,
     r.value/1e18 AS value_decimal,
     r."tx_hash",
@@ -101,7 +102,7 @@ WHERE NOT EXISTS (
 INSERT INTO cron.job (schedule, command)
 VALUES ('* * * * *', $$
     SELECT eth.insert_daily_token_balances(
-        (SELECT max(tx_block_time) - interval '20 minutes' FROM eth.eth_transfers WHERE block_time > NOW() - interval '1 month'),
+        (SELECT max(tx_block_time) FROM eth.eth_transfers WHERE block_time > NOW() - interval '1 month'),
         (SELECT now())
         );
 $$)

--- a/optimism2/eth/insert_eth_transfers.sql
+++ b/optimism2/eth/insert_eth_transfers.sql
@@ -6,6 +6,7 @@ WITH rows AS (
     INSERT INTO eth.eth_transfers (
        "from",
         "to",
+	contract_address,
         raw_value,
         value,
         value_decimal,

--- a/optimism2/eth/insert_eth_transfers.sql
+++ b/optimism2/eth/insert_eth_transfers.sql
@@ -17,23 +17,28 @@ WITH rows AS (
     )
     
     SELECT 
-    "from",
-    "to",
-    value,
-    value/1e18 AS value_decimal,
-    "tx_hash",
-    "tx_index",
-    "block_time" AS tx_block_time,
-    "block_number" AS tx_block_number,
-    substring(input from 1 for 4) AS tx_method_id
-        FROM optimism."traces"
-        WHERE (call_type NOT IN ('delegatecall', 'callcode', 'staticcall') or call_type is null)
-        AND "tx_success" = true
-        AND success = true
-        AND value > 0
+    r."from",
+    r."to",
+    r.value,
+    r.value/1e18 AS value_decimal,
+    r."tx_hash",
+    r."tx_index",
+    r."block_time" AS tx_block_time,
+    r."block_number" AS tx_block_number,
+    substring(t.data from 1 for 4) AS tx_method_id
+        FROM optimism."traces" r
+	INNER JOIN optimism.transactions t
+                ON t.hash = r.tx_hash
+        WHERE (r.call_type NOT IN ('delegatecall', 'callcode', 'staticcall') or r.call_type is null)
+        AND r."tx_success" = true
+        AND r.success = true
+        AND r.value > 0
         
-        AND block_time >= start_block_time
-        AND block_time < end_block_time
+        AND r.block_time >= start_block_time
+        AND r.block_time < end_block_time
+	
+	AND t.block_time >= start_block_time
+        AND t.block_time < end_block_time
 
     ON CONFLICT (trace_tx_hash, trace_index)
     DO UPDATE SET

--- a/optimism2/eth/readme.md
+++ b/optimism2/eth/readme.md
@@ -1,0 +1,4 @@
+# ETH Schema
+The purpose of these tables are to handle for events of native ETH (i.e transfers).
+
+- **eth_transfers**: This table mimics `erc20.erc20_evt_transfer` but instead contains ETH transfers. This table should become the building block for any query dealing with native ETH transfers.


### PR DESCRIPTION
Re-creating https://github.com/duneanalytics/abstractions/pull/943 with updates:
- Added the placeholder ETH address to match indices + make joins to prices tables easier.

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
