### PR TITLE
add bancor 3 to view_convert

### DIFF
--- a/ethereum/bancornetwork/view_convert.sql
+++ b/ethereum/bancornetwork/view_convert.sql
@@ -26,6 +26,7 @@ SELECT "_smartToken" AS smart_token_address,
        "_toAmount" AS target_token_amount_raw,
        "_trader" AS trader,
        s.contract_address,
+       null as version,
        evt_tx_hash AS tx_hash,
        evt_index,
        evt_block_time AS block_time
@@ -46,6 +47,7 @@ SELECT
     trade."targetAmount" AS target_token_amount_raw,
     trade."trader" AS trader,
     trade."contract_address",
+    3 as version,
     evt_tx_hash AS tx_hash,
     evt_index,
     evt_block_time AS block_time

--- a/ethereum/bancornetwork/view_convert.sql
+++ b/ethereum/bancornetwork/view_convert.sql
@@ -32,4 +32,24 @@ SELECT "_smartToken" AS smart_token_address,
 FROM conversions s
 LEFT JOIN erc20.tokens t1 ON s."_fromToken" = t1.contract_address
 LEFT JOIN erc20.tokens t2 ON s."_toToken" = t2.contract_address
+
+UNION
+SELECT
+    null AS smart_token_address,
+    trade."sourceToken" AS source_token_address,
+    t1.symbol AS source_token_symbol,
+    trade."targetToken" AS target_token_address,
+    t2.symbol AS target_token_symbol,
+    trade."sourceAmount" / 10^t1.decimals AS source_token_amount,
+    trade."targetAmount" / 10^t2.decimals AS target_token_amount,
+    trade."sourceAmount" AS source_token_amount_raw,
+    trade."targetAmount" AS target_token_amount_raw,
+    trade."trader" AS trader,
+    trade."contract_address",
+    evt_tx_hash AS tx_hash,
+    evt_index,
+    evt_block_time AS block_time
+FROM bancor3."BancorNetwork_evt_TokensTraded" trade
+LEFT JOIN erc20.tokens t1 ON trade."sourceToken" = t1.contract_address
+LEFT JOIN erc20.tokens t2 ON trade."targetToken" = t2.contract_address
 ;


### PR DESCRIPTION
I've checked that:

* [ x] the query produces the intended results
* [x ] the folder name matches the schema name
* [ x] the schema name exists in Dune
* [x ] views are prefixed with `view_`, functions with `fn_`.
* [x ] the filename matches the defined view, table or function and ends with .sql
* [x ] each file has only one view, table or function defined  
* [ x] column names are `lowercase_snake_cased`
