### PR TITLE
Adding LPL linkpool

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -2066,3 +2066,8 @@
   symbol: JPEG
   address: 0xe80c0cd204d654cebe8dd64a4857cab6be8345a3
   decimals: 18
+- name: LinkPool
+  id: lpl-linkpool
+  symbol: LPL
+  address: 0x99295f1141d58A99e939F7bE6BBe734916a875B8
+  decimals: 18


### PR DESCRIPTION
Adding LPL linkpool.

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
