### PR TITLE
[Ethereum] [Set Protocol] add anchor prices for daily component prices

### DIFF
--- a/ethereum/setprotocol_v2/insert_daily_component_prices.sql
+++ b/ethereum/setprotocol_v2/insert_daily_component_prices.sql
@@ -140,8 +140,9 @@ with initial_components as (
   select dcp.date
     , dcp.component_address
     , dcp.symbol
-    , dcp.avg_price
+    , dcp.avg_price_usd as avg_price
   from setprotocol_v2.daily_component_prices dcp
+  -- from dune_user_generated.daily_component_prices dcp
   inner join missing_components_mapped mc on dcp.component_address = mc.component_address
   where dcp.date = start_time::date - interval '1 day'
 )

--- a/ethereum/setprotocol_v2/insert_daily_component_prices.sql
+++ b/ethereum/setprotocol_v2/insert_daily_component_prices.sql
@@ -134,7 +134,24 @@ with initial_components as (
   left join tokens_from_paprika tfp on ac.mapped_component_address = tfp.contract_address
   where tfp.contract_address is null
 )
+-- The insertion operation is broken up into multiple queries that "forget" the last known price
+-- so we should re-introduce the "last known price" from the table so it can be used in imputations
+, anchor_prices as (
+  select dcp.date
+    , dcp.component_address
+    , dcp.symbol
+    , dcp.avg_price
+  from setprotocol_v2.daily_component_prices dcp
+  inner join missing_components_mapped mc on dcp.component_address = mc.component_address
+  where dcp.date = start_time::date - interval '1 day'
+)
 , daily_component_prices_usd_passing as (
+  select date
+    , component_address
+    , symbol
+    , avg_price
+  from anchor_prices
+  union
   select p.hour::date as date
     , mc.component_address
     , coalesce(mc.pre_mapped_symbol, p.symbol) as symbol


### PR DESCRIPTION
I noticed a bug where between insertion operations, the query would "forget" the last known price for imputing the component prices. I introduced this fix so that each insertion operation isn't missing a baseline price for all of the components.

Can we truncate the table and rerun the backfill? Or should I include the table truncation operation right before the backfill commands? (`insert_prices_from_dex_data.sql`, which i'm using as a template, doesn't include any pre-backfill truncate commands) 

I've checked that:

* [X] the query produces the intended results
* [X] the folder name matches the schema name
* [X] the schema name exists in Dune
* [X] views are prefixed with `view_`, functions with `fn_`.
* [X] the filename matches the defined view, table or function and ends with .sql
* [X] each file has only one view, table or function defined  
* [X] column names are `lowercase_snake_cased`
