### PR TITLE
GPv2: Batches Table (an alternative to view_batches)

### DIFF
--- a/ethereum/gnosis_protocol_v2/batches.sql
+++ b/ethereum/gnosis_protocol_v2/batches.sql
@@ -1,0 +1,23 @@
+CREATE TABLE gnosis_protocol_v2.batches
+(
+    block_time      timestamptz NOT NULL,
+    num_trades      int8        NOT NULL,
+    dex_swaps       int8        NOT NULL,
+    batch_value     numeric,
+    gas_per_trade   numeric,
+    solver_address  bytea       NOT NULL,
+    solver_name     text,
+    tx_hash         bytea       NOT NULL,
+    gas_price_gwei  float8,
+    gas_used        numeric,
+    tx_cost_usd     numeric,
+    fee_value       numeric,
+    call_data_size  numeric,
+    unwraps         int8,
+    token_approvals int8
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS batches_id ON gnosis_protocol_v2.view_batches (tx_hash);
+CREATE INDEX batches_idx_1 ON gnosis_protocol_v2.view_batches (block_time);
+CREATE INDEX batches_idx_2 ON gnosis_protocol_v2.view_batches (solver_address);
+CREATE INDEX batches_idx_3 ON gnosis_protocol_v2.view_batches (num_trades);

--- a/ethereum/gnosis_protocol_v2/insert_batches.sql
+++ b/ethereum/gnosis_protocol_v2/insert_batches.sql
@@ -3,7 +3,7 @@ CREATE OR REPLACE FUNCTION gnosis_protocol_v2.insert_batches(start_ts timestampt
 $function$
 DECLARE
     r integer;
-BEGIN
+BEGIN;
     WITH rows AS (
         WITH batch_counts AS (
             SELECT s.evt_block_time,
@@ -18,8 +18,8 @@ BEGIN
             FROM gnosis_protocol_v2."GPv2Settlement_evt_Settlement" s
                      LEFT OUTER JOIN gnosis_protocol_v2."GPv2Settlement_evt_Interaction" i
                                      ON i.evt_tx_hash = s.evt_tx_hash
-            WHERE evt_block_time >= start_ts
-              AND evt_block_time < end_ts
+            WHERE s.evt_block_time >= start_ts
+              AND s.evt_block_time < end_ts
             GROUP BY s.evt_tx_hash, solver, s.evt_block_time
             ),
 
@@ -100,6 +100,7 @@ BEGIN
 END
 $function$;
 
+COMMIT;
 
 -- fill 2021: This is only ever relevant 1 time.
 SELECT gnosis_protocol_v2.insert_batches(
@@ -153,4 +154,3 @@ VALUES ('11 0 * * *', $$
     COMMIT;
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
-COMMIT;

--- a/ethereum/gnosis_protocol_v2/insert_batches.sql
+++ b/ethereum/gnosis_protocol_v2/insert_batches.sql
@@ -1,0 +1,156 @@
+CREATE OR REPLACE FUNCTION gnosis_protocol_v2.insert_batches(start_ts timestamptz, end_ts timestamptz=now()) RETURNS integer
+    LANGUAGE plpgsql AS
+$function$
+DECLARE
+    r integer;
+BEGIN
+    WITH rows AS (
+        WITH batch_counts AS (
+            SELECT s.evt_block_time,
+                   s.evt_tx_hash,
+                   solver,
+                   (select count(*)
+                    from gnosis_protocol_v2."GPv2Settlement_evt_Trade" t
+                    where t.evt_tx_hash = s.evt_tx_hash)                                                  as num_trades,
+                   sum(case when selector != '\x2e1a7d4d' and selector != '\x095ea7b3' then 1 else 0 end) as dex_swaps,
+                   sum(case when selector = '\x2e1a7d4d' then 1 else 0 end)                               as unwraps,
+                   sum(case when selector = '\x095ea7b3' then 1 else 0 end)                               as token_approvals
+            FROM gnosis_protocol_v2."GPv2Settlement_evt_Settlement" s
+                     LEFT OUTER JOIN gnosis_protocol_v2."GPv2Settlement_evt_Interaction" i
+                                     ON i.evt_tx_hash = s.evt_tx_hash
+            WHERE evt_block_time >= start_ts
+              AND evt_block_time < end_ts
+            GROUP BY s.evt_tx_hash, solver, s.evt_block_time
+            ),
+
+
+            batch_values as (
+                select tx_hash,
+                       sum(trade_value_usd) as batch_value,
+                       sum(fee_usd)         as fee_value,
+                       price                as eth_price
+                from gnosis_protocol_v2.trades
+                         JOIN prices.usd as p
+                              ON p.contract_address = '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+                                  AND p.minute = date_trunc('minute', block_time)
+                where block_time >= start_ts
+                  and block_time < end_ts
+                group by tx_hash, price
+                ),
+
+            batch_info as (
+                SELECT evt_block_time                               as block_time,
+                       num_trades,
+                       CASE
+                           WHEN name = '1inch'
+                               OR name = 'ParaSwap'
+                               OR name = '0x'
+                               OR name = 'Legacy'
+                               THEN (select count(*) from dex.trades where tx_hash = evt_tx_hash and category = 'DEX')
+                           ELSE dex_swaps END                       as dex_swaps,
+                       batch_value,
+                       tx.gas_used / num_trades                     as gas_per_trade,
+                       solver                                       as solver_address,
+                       CONCAT(environment, CONCAT('-', name))       as solver_name,
+                       evt_tx_hash                                  as tx_hash,
+                       gas_price / pow(10, 9)                       as gas_price_gwei,
+                       tx.gas_used                                  as gas_used,
+                       (gas_price * gas_used * eth_price) / 10 ^ 18 as tx_cost_usd,
+                       fee_value,
+                       length(data)::decimal / 1024                 as call_data_size,
+                       unwraps,
+                       token_approvals
+                FROM batch_counts b
+                         LEFT OUTER JOIN batch_values t
+                                         ON b.evt_tx_hash = t.tx_hash
+                         JOIN ethereum.transactions tx
+                              ON evt_tx_hash = hash
+                         JOIN gnosis_protocol_v2.view_solvers
+                              ON solver = address
+                  WHERE num_trades > 0 -- Exclude Withdrawal Batches
+                )
+            INSERT INTO gnosis_protocol_v2.batches
+                (block_time, num_trades, dex_swaps, batch_value, gas_per_trade, solver_address, solver_name, tx_hash,
+                 gas_price_gwei, gas_used, tx_cost_usd, fee_value, call_data_size, unwraps, token_approvals)
+                SELECT block_time,
+                       num_trades,
+                       dex_swaps,
+                       batch_value,
+                       gas_per_trade,
+                       solver_address,
+                       solver_name,
+                       tx_hash,
+                       gas_price_gwei,
+                       gas_used,
+                       tx_cost_usd,
+                       fee_value,
+                       call_data_size,
+                       unwraps,
+                       token_approvals
+                FROM batch_info
+                ORDER BY block_time DESC
+                -- conflict is by dropping potentially conflicting before executing the insertion (cf. the cronjobs below)
+                ON CONFLICT DO NOTHING
+                RETURNING 1)
+
+    SELECT count(*)
+    INTO r
+    FROM rows;
+    RETURN r;
+END
+$function$;
+
+
+-- fill 2021: This is only ever relevant 1 time.
+SELECT gnosis_protocol_v2.insert_batches(
+               '2021-03-03', --! Deployment date
+               '2022-01-01'
+           )
+WHERE NOT EXISTS(
+        SELECT *
+        FROM gnosis_protocol_v2.batches
+        WHERE block_time >= '2021-03-03'
+          AND block_time < '2022-01-01'
+    );
+
+-- For the two cron jobs defined below,
+-- one is intended to back-fill lagging price feed (while also including most recent trades).
+-- The second, less frequent job is meant to back-fill missing token data that is manually
+-- updated on an irregular schedule. Although there is no token data directly here,
+-- this table depends on gnosis_protocol_v2.trades which does rely on token data.
+-- A six month time window should suffice for manual token updates.
+
+-- Every five minutes we go back 1 day and repopulate the values.
+-- This captures new batches since the previous run, but also includes
+-- previously non-existent price data (since the price feed is slightly behind)
+INSERT INTO cron.job (schedule, command)
+VALUES ('*/5 * * * *', $$
+    BEGIN;
+    DELETE FROM gnosis_protocol_v2.batches
+        WHERE block_time >= (SELECT DATE_TRUNC('day', now()) - INTERVAL '1 days');
+    SELECT gnosis_protocol_v2.insert_batches(
+        (SELECT DATE_TRUNC('day', now()) - INTERVAL '1 days')
+    );
+    COMMIT;
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+
+-- Once per day we go back 6 months repopulate the values.
+-- This is intended to back fill any new token data and prices that may have been introduced.
+-- While simultaneously updating all fields relying on token data. Specifically, these are:
+-- batch_value and fee_value
+--
+-- NOTE that we choose to run this job daily at 11 minutes past midnight,
+-- so not to compete with the every 5 minute job above and the updating trades table which this depends on.
+INSERT INTO cron.job (schedule, command)
+VALUES ('11 0 * * *', $$
+    BEGIN;
+    DELETE FROM gnosis_protocol_v2.batches
+        WHERE block_time >= (SELECT DATE_TRUNC('day', now()) - INTERVAL '6 months');
+    SELECT gnosis_protocol_v2.insert_batches(
+        (SELECT DATE_TRUNC('day', now()) - INTERVAL '6 months')
+    );
+    COMMIT;
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+COMMIT;

--- a/ethereum/gnosis_protocol_v2/view_batches.sql
+++ b/ethereum/gnosis_protocol_v2/view_batches.sql
@@ -24,7 +24,7 @@ WITH batch_counts AS (
                 sum(trade_value_usd) as batch_value,
                 sum(fee_usd)         as fee_value,
                 price                as eth_price
-         from gnosis_protocol_v2."view_trades"
+         from gnosis_protocol_v2.trades
                   JOIN prices.usd as p
                        ON p.contract_address = '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
                            AND p.minute = date_trunc('minute', block_time)


### PR DESCRIPTION
Similar to the previous refactor of `gnosis_protocol_v2.view_trades` into `gnosis_protocol_v2.trades` (here - #853) we do the same for `view_batches` which has become very large and whose update schedule is now about as long as the refresh rate. This PR creates a batches table which is being appended to instead of completely recreated as a view every 5 minutes. 

As a second step we would eliminate the view_batches and free up some resources on Dune servers. 

I've checked that:

* [ ] the query produces the intended results - This I can't actually check, but the query is quite similar to the `view_batches` which does produce intended results. 
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune (schema name will exist after the table is created - here)
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`

Additionally, with this merged, we should be more easily able to update `view_solvers` without conflict (cc #1013)
