### PR TITLE
[Ethereum] [Set Protocol] Price feed bug fix

### DIFF
--- a/ethereum/setprotocol_v2/insert_daily_component_prices.sql
+++ b/ethereum/setprotocol_v2/insert_daily_component_prices.sql
@@ -263,7 +263,7 @@ INSERT INTO cron.job (schedule, command)
 VALUES ('20 0,12 * * *', $$
     SELECT setprotocol_v2.insert_daily_component_prices(
         (SELECT date_trunc('day', now()) - interval '3 days'),
-        (SELECT date_trunc('day', now())));
+        (SELECT date_trunc('day', now()) + interval '1 day')); -- the insert function is noninclusive of the end date, so add a day
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
 


### PR DESCRIPTION
The cron job command doesn't update the current day. It turns out that this is because the insertion script is noninclusive of the end_date, so the cron job should pad an additional day to include the current date in the update.

I've checked that:

* [X] the query produces the intended results
* [X] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
