### PR TITLE
Create perpetuals.trades table on Optimism (OVM 2.0)

### DIFF
--- a/optimism2/perpetuals/README.md
+++ b/optimism2/perpetuals/README.md
@@ -1,0 +1,60 @@
+# Perpetuals Trades
+
+- **perpetuals.trades**: Builds a consolidated perpetual swaps table on Optimism. Patterned after the dex.trades table.
+ 
+### Current Projects
+- Kwenta/Synthetix
+- Perpetual Protocol (v2)
+- Pika Protcol (v1 and v2)
+
+### Insert Queries
+- **perpetuals.insert_sythetix.sql**: Inserts Kwenta/Synthetix data to the perpetuals.trades table.
+- **perpetuals.insert_perpetual.sql**: Inserts Perpetual data to the perpetuals.trades table.
+- **perpetuals.insert_pika_v1.sql**: Inserts Pika Protocol v1 data to the perpetuals.trades table.
+- **perpetuals.insert_pika_v2.sql**: Inserts Pika Protocol v2 data to the perpetuals.trades table.
+
+### Table Columns
+- block_time
+  - Time of the transaction
+- virtual_asset
+  - How the protocol represents the underlying asset
+- underlying_asset
+  - The real underlying asset that is represented in the swap 
+- market
+  - The futures market involved in the transaction
+- market_address
+  - Contract address of the market
+- volume_usd
+  - The size of the position taken for the swap in USD
+  - Already in absolute value and decimal normalized 
+    - 18 decimals for Synthetix and Perpetual
+    - 8 decimals for Pika
+- fee_usd
+  - The fees charged to the user for the swap in USD
+- margin_usd
+  - The amount of collateral/margin used in a trade in USD
+- trade
+  - Indicates a trade’s direction whether a short, long, or if a position is being closed
+- project
+  - The protocol/project where the swap took place
+- version
+  - The version of the protocol/project
+- trader
+  - The address which made the swap in the protocol
+- volume_raw
+  - The size of the position in raw form, based on the protocol’s specifications
+- tx_hash
+  - The hash of the transaction
+- tx_from
+  - The address that originated the transaction
+  - This is based on the optimism.transactions table
+- tx_to
+  - The address receiving the transaction
+  - This is based on the optimism.transactions table
+- evt_index
+  - Event index number
+- trade_id
+  - Unique trade id based on project, tx_hash, evt_index
+
+
+[OP DeFi Apps List](https://www.optimism.io/apps/defi)

--- a/optimism2/perpetuals/insert_perpetual_v2.sql
+++ b/optimism2/perpetuals/insert_perpetual_v2.sql
@@ -1,0 +1,198 @@
+CREATE OR REPLACE FUNCTION perpetuals.insert_perpetual_v2(start_ts timestamptz, end_ts timestamptz=now(), start_block numeric=0, end_block numeric=9e18) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH rows AS (
+    INSERT INTO perpetuals.trades (
+        block_time,
+        virtual_asset,
+        underlying_asset,
+        market,
+        market_address,
+        volume_usd,
+        fee_usd,
+        margin_usd,
+        trade,
+        project,
+        version,
+        trader,
+        volume_raw,
+        tx_hash,
+        tx_from,
+        tx_to,
+        evt_index,
+        trade_id
+    )
+    SELECT
+        perps."block_time",
+        COALESCE(e."symbol", CAST(perps."baseToken" AS TEXT)) AS virtual_asset,
+        SUBSTRING(e."symbol", '[A-Z].*') AS underlying_asset,
+        CONCAT(e."symbol", '-', 'USD') AS market,
+        market_address,
+        volume_usd,
+        fee_usd,
+        margin_usd,
+        trade,
+        project,
+        version,
+        trader,
+        volume_raw,
+        tx_hash,
+        tx."from" AS tx_from,
+        tx."to" AS tx_to,
+        evt_index,
+        row_number() OVER (PARTITION BY project, tx_hash, evt_index ORDER BY version) AS trade_id
+    FROM (
+        --Perpetual v2
+        SELECT
+            p."evt_block_time" AS block_time,
+            p."baseToken",
+            pp."pool" AS market_address,
+            (ABS(p."exchangedPositionNotional") / POW(10, 18)) AS volume_usd,
+            p."fee" / POW(10, 18) AS fee_usd,
+            co."output_0" / POW(10, 6) AS margin_usd,
+            
+            CASE
+            WHEN p."exchangedPositionSize" > 0 THEN 'long'
+            WHEN p."exchangedPositionSize" < 0 THEN 'short'
+            ELSE 'NA'
+            END AS trade,
+            
+            'Perpetual' AS project,
+            '2' AS version,
+            p."trader",
+            p."exchangedPositionNotional" AS volume_raw,
+            p."evt_tx_hash" AS tx_hash,
+            p."evt_index"
+        FROM perp_v2."ClearingHouse_evt_PositionChanged" AS p
+        LEFT JOIN perp_v2."Vault_call_getFreeCollateralByRatio" AS co
+            ON p."evt_tx_hash" = co."call_tx_hash"
+        LEFT JOIN perp_v2."MarketRegistry_evt_PoolAdded" AS pp
+            ON p."baseToken" = pp."baseToken"
+        WHERE co."call_success" = true
+    ) AS perps
+    LEFT JOIN erc20."tokens" AS e
+        ON perps."baseToken" = e."contract_address"
+    INNER JOIN optimism."transactions" AS tx
+        ON perps."tx_hash" = tx."hash"
+        AND tx.block_time >= start_ts
+        AND tx.block_time < end_ts
+        AND tx.block_number >= start_block
+        AND tx.block_number < end_block
+    
+    --update if we have updated info on old market addresses and erc20 table
+    ON CONFLICT (project, tx_hash, evt_index, trade_id)
+    DO UPDATE SET
+        virtual_asset = EXCLUDED.virtual_asset,
+        underlying_asset = EXCLUDED.underlying_asset,
+        market = EXCLUDED.market,
+        market_address = EXCLUDED.market_address,
+        trade = EXCLUDED.trade
+    RETURNING 1
+)
+
+SELECT COUNT(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+-- due to the high amount of transactions on Perpetual, this table must be filled a month at a time from the Optimism 2.0 Regenesis
+-- fill 2021-11-10 to 2021-12-10
+SELECT perpetuals.insert_perpetual_v2(
+    '2021-11-10',
+    '2021-12-10',
+    (SELECT MAX(number) FROM optimism.blocks WHERE time < '2021-11-10'),
+    (SELECT MAX(number) FROM optimism.blocks WHERE time <= '2021-12-10')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM perpetuals.trades
+    WHERE block_time > '2021-11-10'
+    AND block_time <= '2021-12-10'
+    AND project = 'Perpetual' AND version = '2'
+);
+
+-- fill 2021-12-10 to 2022-01-10
+SELECT perpetuals.insert_perpetual_v2(
+    '2021-12-10',
+    '2022-01-10',
+    (SELECT MAX(number) FROM optimism.blocks WHERE time < '2021-12-10'),
+    (SELECT MAX(number) FROM optimism.blocks WHERE time <= '2022-01-10')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM perpetuals.trades
+    WHERE block_time > '2021-12-10'
+    AND block_time <= '2022-01-10'
+    AND project = 'Perpetual' AND version = '2'
+);
+
+-- fill 2022-01-10 to 2022-02-10
+SELECT perpetuals.insert_perpetual_v2(
+    '2022-01-10',
+    '2022-02-10',
+    (SELECT MAX(number) FROM optimism.blocks WHERE time < '2022-01-10'),
+    (SELECT MAX(number) FROM optimism.blocks WHERE time <= '2022-02-10')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM perpetuals.trades
+    WHERE block_time > '2022-01-10'
+    AND block_time <= '2022-02-10'
+    AND project = 'Perpetual' AND version = '2'
+);
+
+-- fill 2022-02-10 to 2022-03-10
+SELECT perpetuals.insert_perpetual_v2(
+    '2022-02-10',
+    '2022-03-10',
+    (SELECT MAX(number) FROM optimism.blocks WHERE time < '2022-02-10'),
+    (SELECT MAX(number) FROM optimism.blocks WHERE time <= '2022-03-10')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM perpetuals.trades
+    WHERE block_time > '2022-02-10'
+    AND block_time <= '2022-03-10'
+    AND project = 'Perpetual' AND version = '2'
+);
+
+-- fill 2022-03-10 to 2022-04-10
+SELECT perpetuals.insert_perpetual_v2(
+    '2022-03-10',
+    '2022-04-10',
+    (SELECT MAX(number) FROM optimism.blocks WHERE time < '2022-03-10'),
+    (SELECT MAX(number) FROM optimism.blocks WHERE time <= '2022-04-10')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM perpetuals.trades
+    WHERE block_time > '2022-03-10'
+    AND block_time <= '2022-04-10'
+    AND project = 'Perpetual' AND version = '2'
+);
+
+-- fill 2022-04-10 onwards
+SELECT perpetuals.insert_perpetual_v2(
+    '2022-04-10',
+    now(),
+    (SELECT MAX(number) FROM optimism.blocks WHERE time < '2022-04-10'),
+    (SELECT MAX(number) FROM optimism.blocks WHERE time <= now() - interval '20 minutes')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM perpetuals.trades
+    WHERE block_time > '2022-04-10'
+    AND block_time <= now() - interval '20 minutes'
+    AND project = 'Perpetual' AND version = '2'
+);
+
+INSERT INTO cron.job (schedule, command)
+VALUES ('15,45 * * * *', $$
+    SELECT perpetuals.insert_perpetual_v2(
+        (SELECT MAX(block_time) - interval '1 days' FROM perpetuals.trades WHERE project = 'Perpetual' AND version = '2'),
+        (SELECT now() - interval '20 minutes'),
+        (SELECT MAX(number) FROM optimism.blocks WHERE time < (SELECT MAX(block_time) - interval '1 days' FROM perpetuals.trades WHERE project = 'Perpetual' AND version = '2')),
+        (SELECT MAX(number) FROM optimism.blocks where time < now() - interval '20 minutes'));
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/optimism2/perpetuals/insert_pika_v1.sql
+++ b/optimism2/perpetuals/insert_pika_v1.sql
@@ -1,0 +1,186 @@
+CREATE OR REPLACE FUNCTION perpetuals.insert_pika_v1(start_ts timestamptz, end_ts timestamptz=now(), perpetuals_version integer=0) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH rows AS (
+    INSERT INTO perpetuals.trades (
+        block_time,
+        virtual_asset,
+        underlying_asset,
+        market,
+        market_address,
+        volume_usd,
+        fee_usd,
+        margin_usd,
+        trade,
+        project,
+        version,
+        trader,
+        volume_raw,
+        tx_hash,
+        tx_from,
+        tx_to,
+        evt_index,
+        trade_id
+    )
+    SELECT
+        perps."block_time",
+        virtual_asset,
+        underlying_asset,
+        market,
+        market_address,
+        volume_usd,
+        fee_usd,
+        margin_usd,
+        trade,
+        project,
+        version,
+        trader,
+        volume_raw,
+        tx_hash,
+        tx."from" AS tx_from,
+        tx."to" AS tx_to,
+        evt_index,
+        row_number() OVER (PARTITION BY project, tx_hash, evt_index ORDER BY version) AS trade_id
+    FROM (
+        -- Pika Protocol v1
+        SELECT
+            p."evt_block_time" AS block_time,
+            
+            CASE
+            WHEN p."productId" = 1 THEN 'ETH'
+            WHEN p."productId" = 2 THEN 'BTC'
+            WHEN p."productId" = 3 THEN 'LINK'
+            WHEN p."productId" = 4 THEN 'SNX'
+            WHEN p."productId" = 5 THEN 'SOL'
+            WHEN p."productId" = 6 THEN 'AVAX'
+            WHEN p."productId" = 7 THEN 'MATIC'
+            WHEN p."productId" = 8 THEN 'LUNA'
+            WHEN p."productId" = 9 THEN 'AAVE'
+            ELSE CONCAT ('product_id_', p."productId") 
+            END AS virtual_asset,
+            
+            CASE
+            WHEN p."productId" = 1 THEN 'ETH'
+            WHEN p."productId" = 2 THEN 'BTC'
+            WHEN p."productId" = 3 THEN 'LINK'
+            WHEN p."productId" = 4 THEN 'SNX'
+            WHEN p."productId" = 5 THEN 'SOL'
+            WHEN p."productId" = 6 THEN 'AVAX'
+            WHEN p."productId" = 7 THEN 'MATIC'
+            WHEN p."productId" = 8 THEN 'LUNA'
+            WHEN p."productId" = 9 THEN 'AAVE'
+            ELSE CONCAT ('product_id_', p."productId") 
+            END AS underlying_asset,
+            
+            CASE
+            WHEN p."productId" = 1 THEN 'ETH-USD'
+            WHEN p."productId" = 2 THEN 'BTC-USD'
+            WHEN p."productId" = 3 THEN 'LINK-USD'
+            WHEN p."productId" = 4 THEN 'SNX-USD'
+            WHEN p."productId" = 5 THEN 'SOL-USD'
+            WHEN p."productId" = 6 THEN 'AVAX-USD'
+            WHEN p."productId" = 7 THEN 'MATIC-USD'
+            WHEN p."productId" = 8 THEN 'LUNA-USD'
+            WHEN p."productId" = 9 THEN 'AAVE-USD'
+            ELSE CONCAT ('product_id_', p."productId") 
+            END AS market,
+            
+            p."contract_address" AS market_address,
+            (p."margin"/POW(10, 8)) * (p."leverage"/POW(10, 8)) AS volume_usd,
+            p."fee"/POW(10, 8) AS fee_usd,
+            p."margin"/POW(10,8) AS margin_usd,
+            
+            CASE
+            WHEN p."isLong" = 'true' THEN 'long'
+            WHEN p."isLong" = 'false' THEN 'short'
+            ELSE p."isLong"
+            END AS trade,
+            
+            'Pika' AS project,
+            p."version",
+            p."user" AS trader,
+            p."margin" * p."leverage" AS volume_raw,
+            p."evt_tx_hash" AS tx_hash,
+            p."evt_index"
+        FROM (
+                SELECT
+                    "positionId",
+                    "user",
+                    "productId",
+                    CAST("isLong" AS TEXT),
+                    "price",
+                    "oraclePrice",
+                    "margin",
+                    "leverage",
+                    0 AS "fee",
+                    "contract_address",
+                    "evt_tx_hash",
+                    "evt_index",
+                    "evt_block_time",
+                    "evt_block_number",
+                    '1' AS version
+                FROM pika_perp."PikaPerpV2_evt_NewPosition"
+        
+                UNION ALL
+                --closing positions
+                SELECT
+                    "positionId",
+                    "user",
+                    "productId",
+                    'close' AS "action",
+                    "price",
+                    "entryPrice",
+                    "margin",
+                    "leverage",
+                    0 AS fee,
+                    "contract_address",
+                    "evt_tx_hash",
+                    "evt_index",
+                    "evt_block_time",
+                    "evt_block_number",
+                    '1' AS version
+                FROM pika_perp."PikaPerpV2_evt_ClosePosition"
+            ) AS p
+    ) AS perps
+    INNER JOIN optimism."transactions" AS tx
+        ON perps."tx_hash" = tx."hash"
+        AND tx.block_time >= start_ts
+        AND tx.block_time < end_ts
+        
+    --update if we have updated info on product_ids come in
+    ON CONFLICT (project, tx_hash, evt_index, trade_id)
+    DO UPDATE SET
+        virtual_asset = EXCLUDED.virtual_asset,
+        underlying_asset = EXCLUDED.underlying_asset,
+        market = EXCLUDED.market,
+        trade = EXCLUDED.trade
+    RETURNING 1
+)
+
+SELECT COUNT(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+SELECT perpetuals.insert_pika_v1(
+    '2021-11-10',
+    now(),
+    1
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM perpetuals.trades
+    WHERE block_time > '2021-11-10'
+    AND block_time <= now() - interval '20 minutes'
+    AND project = 'Pika' AND version = '1'
+);
+
+INSERT INTO cron.job (schedule, command)
+VALUES ('15,45 * * * *', $$
+    SELECT perpetuals.insert_pika_v1(
+        (SELECT MAX(block_time) - interval '1 days' FROM perpetuals.trades WHERE project='Pika' AND version = '1'),
+        now()
+    );
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/optimism2/perpetuals/insert_pika_v2.sql
+++ b/optimism2/perpetuals/insert_pika_v2.sql
@@ -1,0 +1,185 @@
+CREATE OR REPLACE FUNCTION perpetuals.insert_pika_v2(start_ts timestamptz, end_ts timestamptz=now(), perpetuals_version integer=0) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH rows AS (
+    INSERT INTO perpetuals.trades (
+        block_time,
+        virtual_asset,
+        underlying_asset,
+        market,
+        market_address,
+        volume_usd,
+        fee_usd,
+        margin_usd,
+        trade,
+        project,
+        version,
+        trader,
+        volume_raw,
+        tx_hash,
+        tx_from,
+        tx_to,
+        evt_index,
+        trade_id
+    )
+    SELECT
+        perps."block_time",
+        virtual_asset,
+        underlying_asset,
+        market,
+        market_address,
+        volume_usd,
+        fee_usd,
+        margin_usd,
+        trade,
+        project,
+        version,
+        trader,
+        volume_raw,
+        tx_hash,
+        tx."from" AS tx_from,
+        tx."to" AS tx_to,
+        evt_index,
+        row_number() OVER (PARTITION BY project, tx_hash, evt_index ORDER BY version) AS trade_id
+    FROM (
+        -- Pika Protocol v2
+        SELECT
+            p."evt_block_time" AS block_time,
+            
+            CASE
+            WHEN p."productId" = 1 THEN 'ETH'
+            WHEN p."productId" = 2 THEN 'BTC'
+            WHEN p."productId" = 3 THEN 'LINK'
+            WHEN p."productId" = 4 THEN 'SNX'
+            WHEN p."productId" = 5 THEN 'SOL'
+            WHEN p."productId" = 6 THEN 'AVAX'
+            WHEN p."productId" = 7 THEN 'MATIC'
+            WHEN p."productId" = 8 THEN 'LUNA'
+            WHEN p."productId" = 9 THEN 'AAVE'
+            ELSE CONCAT ('product_id_', p."productId") 
+            END AS virtual_asset,
+            
+            CASE
+            WHEN p."productId" = 1 THEN 'ETH'
+            WHEN p."productId" = 2 THEN 'BTC'
+            WHEN p."productId" = 3 THEN 'LINK'
+            WHEN p."productId" = 4 THEN 'SNX'
+            WHEN p."productId" = 5 THEN 'SOL'
+            WHEN p."productId" = 6 THEN 'AVAX'
+            WHEN p."productId" = 7 THEN 'MATIC'
+            WHEN p."productId" = 8 THEN 'LUNA'
+            WHEN p."productId" = 9 THEN 'AAVE'
+            ELSE CONCAT ('product_id_', p."productId") 
+            END AS underlying_asset,
+            
+            CASE
+            WHEN p."productId" = 1 THEN 'ETH-USD'
+            WHEN p."productId" = 2 THEN 'BTC-USD'
+            WHEN p."productId" = 3 THEN 'LINK-USD'
+            WHEN p."productId" = 4 THEN 'SNX-USD'
+            WHEN p."productId" = 5 THEN 'SOL-USD'
+            WHEN p."productId" = 6 THEN 'AVAX-USD'
+            WHEN p."productId" = 7 THEN 'MATIC-USD'
+            WHEN p."productId" = 8 THEN 'LUNA-USD'
+            WHEN p."productId" = 9 THEN 'AAVE-USD'
+            ELSE CONCAT ('product_id_', p."productId") 
+            END AS market,
+            
+            p."contract_address" AS market_address,
+            (p."margin"/POW(10, 8)) * (p."leverage"/POW(10, 8)) AS volume_usd,
+            p."fee"/POW(10, 8) AS fee_usd,
+            p."margin"/POW(10,8) AS margin_usd,
+            
+            CASE
+            WHEN p."isLong" = 'true' THEN 'long'
+            WHEN p."isLong" = 'false' THEN 'short'
+            ELSE p."isLong"
+            END AS trade,
+            
+            'Pika' AS project,
+            p."version",
+            p."user" AS trader,
+            p."margin" * p."leverage" AS volume_raw,
+            p."evt_tx_hash" AS tx_hash,
+            p."evt_index"
+        FROM (
+                SELECT 
+                    "positionId",
+                    "user",
+                    "productId",
+                    CAST("isLong" AS TEXT),
+                    "price",
+                    "oraclePrice",
+                    "margin",
+                    "leverage",
+                    "fee",
+                    "contract_address",
+                    "evt_tx_hash",
+                    "evt_index",
+                    "evt_block_time",
+                    "evt_block_number",
+                    '2' AS version
+                FROM pika_perp_v2."PikaPerpV2_evt_NewPosition"
+        
+                UNION ALL
+                --closing positions
+                SELECT
+                    "positionId",
+                    "user",
+                    "productId",
+                    'close' AS "action",
+                    "price",
+                    "entryPrice",
+                    "margin",
+                    "leverage",
+                    "fee",
+                    "contract_address",
+                    "evt_tx_hash",
+                    "evt_index",
+                    "evt_block_time",
+                    "evt_block_number",
+                    '2' AS version
+                FROM pika_perp_v2."PikaPerpV2_evt_ClosePosition"
+        ) AS p
+    ) AS perps
+    INNER JOIN optimism."transactions" AS tx
+        ON perps."tx_hash" = tx."hash"
+        AND tx.block_time >= start_ts
+        AND tx.block_time < end_ts
+        
+    ON CONFLICT (project, tx_hash, evt_index, trade_id)
+    DO UPDATE SET
+        virtual_asset = EXCLUDED.virtual_asset,
+        underlying_asset = EXCLUDED.underlying_asset,
+        market = EXCLUDED.market,
+        trade = EXCLUDED.trade
+    RETURNING 1
+)
+
+SELECT COUNT(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+SELECT perpetuals.insert_pika_v2(
+    '2021-11-10',
+    now(),
+    2
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM perpetuals.trades
+    WHERE block_time > '2021-11-10'
+    AND block_time <= now() - interval '20 minutes'
+    AND project = 'Pika' AND version = '2'
+);
+
+INSERT INTO cron.job (schedule, command)
+VALUES ('15,45 * * * *', $$
+    SELECT perpetuals.insert_pika_v2(
+        (SELECT MAX(block_time) - interval '1 days' FROM perpetuals.trades WHERE project='Pika' AND version = '2'),
+        now()
+    );
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/optimism2/perpetuals/insert_synthetix.sql
+++ b/optimism2/perpetuals/insert_synthetix.sql
@@ -1,0 +1,126 @@
+CREATE OR REPLACE FUNCTION perpetuals.insert_synthetix(start_ts timestamptz, end_ts timestamptz=now()) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH rows AS (
+    INSERT INTO perpetuals.trades (
+        block_time,
+        virtual_asset,
+        underlying_asset,
+        market,
+        market_address,
+        volume_usd,
+        fee_usd,
+        margin_usd,
+        trade,
+        project,
+        version,
+        trader,
+        volume_raw,
+        tx_hash,
+        tx_from,
+        tx_to,
+        evt_index,
+        trade_id
+    )
+    SELECT
+        perps."block_time",
+        virtual_asset,
+        underlying_asset,
+        market,
+        market_address,
+        volume_usd,
+        fee_usd,
+        margin_usd,
+        trade,
+        project,
+        version,
+        trader,
+        volume_raw,
+        tx_hash,
+        tx."from" AS tx_from,
+        tx."to" AS tx_to,
+        evt_index,
+        row_number() OVER (PARTITION BY project, tx_hash, evt_index ORDER BY version) AS trade_id
+    FROM (
+        --Kwenta/Synthetix
+        SELECT
+            s."evt_block_time" AS block_time,
+            REPLACE(ENCODE(sm."asset", 'ESCAPE'), '\000', '') AS virtual_asset,
+            SUBSTRING(REPLACE(ENCODE(sm."asset", 'ESCAPE'), '\000', ''), '[A-Z].*') AS underlying_asset,
+            REPLACE(ENCODE(sm."marketKey", 'ESCAPE'), '\000', '') AS market,
+            s."contract_address" AS market_address,
+            ABS(s."tradeSize")/POW(10, 18) * p.price AS volume_usd,
+            s."fee"/POW(10, 18) AS fee_usd,
+            s."margin"/POW(10, 18) AS margin_usd,
+            (ABS(s."tradeSize")/POW(10, 18) * p.price) / (s."margin"/POW(10, 18)) AS leverage_ratio,
+            
+            CASE
+            WHEN (s."margin" >= 0 AND s."size" = 0 AND s."tradeSize" < 0 AND s."size" != s."tradeSize") THEN 'close' --closing long positions
+            WHEN (s."margin" >= 0 AND s."size" = 0 AND s."tradeSize" > 0 AND s."size" != s."tradeSize") THEN 'close' --closing short positions
+            WHEN s."tradeSize" > 0 THEN 'long'
+            WHEN s."tradeSize" < 0 THEN 'short'
+            ELSE 'NA'
+            END AS "trade",
+            
+            'Synthetix' AS project,
+            1 AS version,
+            s."account" AS trader,
+            s."tradeSize" AS volume_raw,
+            s."evt_tx_hash" AS tx_hash,
+            s."evt_index"
+        FROM synthetix."FuturesMarket_evt_PositionModified" AS s
+        LEFT JOIN synthetix."FuturesMarketManager_evt_MarketAdded" AS sm
+            ON s."contract_address" = sm."market"
+        LEFT JOIN (
+            SELECT
+                s."contract_address" AS market_address,
+                REPLACE(ENCODE(sm."asset", 'ESCAPE'), '\000', '') AS asset,
+                s."evt_block_time",
+                AVG(s."lastPrice"/POW(10, 18)) AS price
+            FROM synthetix."FuturesMarket_evt_PositionModified" AS s
+            LEFT JOIN synthetix."FuturesMarketManager_evt_MarketAdded" AS sm
+                ON s."contract_address" = sm."market"
+            GROUP BY market_address, asset, s."evt_block_time"
+            ) AS p
+            ON s."contract_address" = p."market_address"
+            AND s."evt_block_time" = p."evt_block_time"
+        WHERE s."tradeSize" != 0
+    ) AS perps
+    INNER JOIN optimism."transactions" AS tx
+        ON perps."tx_hash" = tx."hash"
+        AND tx.block_time >= start_ts
+        AND tx.block_time < end_ts
+    
+    --update if changes to trade classifications are needed
+    ON CONFLICT (project, tx_hash, evt_index, trade_id)
+    DO UPDATE SET
+        trade = EXCLUDED.trade
+    RETURNING 1
+)
+
+SELECT COUNT(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+SELECT perpetuals.insert_synthetix(
+    '2021-11-10',
+    now()
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM perpetuals.trades
+    WHERE block_time > '2021-11-10'
+    AND block_time <= now() - interval '20 minutes'
+    AND project = 'Synthetix' AND version = '1'
+);
+
+INSERT INTO cron.job (schedule, command)
+VALUES ('15,45 * * * *', $$
+    SELECT perpetuals.insert_synthetix(
+        (SELECT MAX(block_time) - interval '1 days' FROM perpetuals.trades WHERE project='Synthetix' AND version = '1'),
+        now()
+    );
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/optimism2/perpetuals/trades.sql
+++ b/optimism2/perpetuals/trades.sql
@@ -1,0 +1,32 @@
+CREATE SCHEMA IF NOT EXISTS perpetuals;
+
+CREATE TABLE IF NOT EXISTS perpetuals.trades (
+    block_time timestamptz NOT NULL,
+    virtual_asset text,
+    underlying_asset text,
+    market text,
+    market_address bytea,
+    volume_usd numeric,
+    fee_usd numeric,
+    margin_usd numeric,
+    trade text,
+    project text NOT NULL,
+    version text,
+    trader bytea,
+    volume_raw numeric,
+    tx_hash bytea NOT NULL,
+    tx_from bytea NOT NULL,
+    tx_to bytea,
+    evt_index integer NOT NULL,
+    trade_id integer NOT NULL,
+    UNIQUE (project, tx_hash, evt_index, trade_id)
+);
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS perpetuals_trades_proj_evt_index_uniq_idx ON perpetuals.trades (project, tx_hash, evt_index, trade_id);
+CREATE INDEX IF NOT EXISTS perpetuals_trades_tx_from_idx ON perpetuals.trades (tx_from);
+CREATE INDEX IF NOT EXISTS perpetuals_trades_tx_to_idx ON perpetuals.trades (tx_to);
+CREATE INDEX IF NOT EXISTS perpetuals_trades_project_idx ON perpetuals.trades (project);
+CREATE INDEX IF NOT EXISTS perpetuals_trades_block_time_idx ON perpetuals.trades USING BRIN (block_time);
+CREATE INDEX IF NOT EXISTS perpetuals_trades_market_address_idx ON perpetuals.trades (market_address);
+CREATE INDEX IF NOT EXISTS perpetuals_trades_block_time_project_idx ON perpetuals.trades (block_time, project);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS perpetuals_trades_volume_usd_idx ON dex.trades (volume_usd);


### PR DESCRIPTION
This PR builds a `perpetuals.trades` table on Optimism which is patterned after the `dex.trades` table except for protocols that offer the trading of perpetuals. Protocols include Kwenta/Synthetix, Perpetual Protocol, and Pika Protocol. A new schema called `perpetuals` needs to be created which is handled by the `trades.sql` file. The `README` has more information on the table columns.

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`

Co-created with [MSilb7](https://dune.com/msilb7) and [drethereum](https://dune.com/drethereum)
