### PR TITLE
add tokens to coinpaprika yaml (BSC)

### DIFF
--- a/prices/bsc/coinpaprika.yaml
+++ b/prices/bsc/coinpaprika.yaml
@@ -519,3 +519,33 @@
   id: bund-bundles
   name: bund_bundles
   symbol: BUND
+- address: '0xfb6115445bff7b52feb98650c87f44907e58f802'
+  decimals: 18
+  id: aave-aave-token
+  name: Aave Token
+  symbol: AAVE
+- address: '0x250632378e573c6be1ac2f97fcdf00515d0aa91b'
+  decimals: 18
+  id: beth-binance-beacon-eth
+  name: Binance Beacon ETH
+  symbol: BETH
+- address: '0xcf6bb5389c92bdda8a3747ddb454cb7a64626c63'
+  decimals: 18
+  id: xvs-venus
+  name: Venus
+  symbol: XVS
+- address: '0x156ab3346823b651294766e23e6cf87254d68962'
+  decimals: 6
+  id: luna-luna-wormhole
+  name: LUNA (Wormhole)
+  symbol: LUNA
+- address: '0x3d4350cd54aef9f9b2c29435e0fa809957b3f30a'
+  decimals: 6
+  id: ust-ust-wormhole
+  name: UST (Wormhole)
+  symbol: UST
+- address: '0xcc42724c6683b7e57334c4e856f4c9965ed682bd'
+  decimals: 18
+  id: matic-polygon
+  name: Polygon
+  symbol: MATIC


### PR DESCRIPTION
Add some tokens to the coinpaprika yaml for BSC

Note: This does add a second token with symbol UST but it is wormhole UST

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
