### PR TITLE
[Ethereum] [Set protocol] Add cETH and cWBTC to component price feed

### DIFF
--- a/ethereum/setprotocol_v2/insert_daily_component_prices.sql
+++ b/ethereum/setprotocol_v2/insert_daily_component_prices.sql
@@ -256,7 +256,6 @@ with ceth_eth_exchange_rate as (
 , day_series as (
   select generate_series(start_time::date - interval '1 day' -- include an extra day for the anchor price
                         , end_time::date, '1 day') as day
-  from ceth_eth_exchange_rate
 )
 , anchor_prices as (
     select dcp.date as day

--- a/ethereum/setprotocol_v2/insert_daily_component_prices.sql
+++ b/ethereum/setprotocol_v2/insert_daily_component_prices.sql
@@ -254,7 +254,8 @@ with ceth_eth_exchange_rate as (
     and call_block_time < end_time
 )
 , day_series as (
-  select generate_series(start_time::date, end_time::date, '1 day') as day
+  select generate_series(start_time::date - interval '1 day' -- include an extra day for the anchor price
+                        , end_time::date, '1 day') as day
   from ceth_eth_exchange_rate
 )
 , anchor_prices as (
@@ -351,14 +352,15 @@ with cwbtc_wbtc_exchange_rate as (
     and call_block_time < end_time
 )
 , day_series as (
-  select generate_series(start_time::date, end_time::date, '1 day') as day
+  select generate_series(start_time::date - interval '1 day' -- include an extra day for the anchor price
+                        , end_time::date, '1 day') as day
 )
 , avg_daily_wbtc_price as (
     select minute::date as day
       , avg(price) as wbtc_price
     from prices.usd
     where contract_address = '\x2260fac5e5542a773aa44fbcfedf7c193bc2c599' -- WBTC contract address
-    and minute >= start_time
+    and minute >= start_time - interval '1 day' -- include one extra day for the anchor price
     and minute < end_time
     group by minute::date
 )

--- a/ethereum/setprotocol_v2/insert_daily_component_prices.sql
+++ b/ethereum/setprotocol_v2/insert_daily_component_prices.sql
@@ -254,7 +254,7 @@ with ceth_eth_exchange_rate as (
     and call_block_time < end_time
 )
 , day_series as (
-  select generate_series(min(call_block_time::date), end_time, '1 day') as day
+  select generate_series(start_time::date, end_time::date, '1 day') as day
   from ceth_eth_exchange_rate
 )
 , anchor_prices as (
@@ -351,7 +351,7 @@ with cwbtc_wbtc_exchange_rate as (
     and call_block_time < end_time
 )
 , day_series as (
-  select generate_series(min(call_block_time::date), now(), '1 day') as day
+  select generate_series(start_time::date, end_time::date, '1 day') as day
   from cwbtc_wbtc_exchange_rate
 )
 , avg_daily_wbtc_price as (

--- a/ethereum/setprotocol_v2/insert_daily_component_prices.sql
+++ b/ethereum/setprotocol_v2/insert_daily_component_prices.sql
@@ -95,7 +95,7 @@ with initial_components as (
   
 )
 SELECT count(*) INTO r from rows;
-
+-------------------------------------------------------------------------------------------------------------------------
 --Step 2: Grab components from dex trades
 with initial_components as (
   -- Get the initial components from the create function
@@ -238,6 +238,212 @@ with initial_components as (
     , avg_price_eth = EXCLUDED.avg_price_eth
   RETURNING 1
   
+)
+SELECT count(*) + r INTO r from rows;
+-------------------------------------------------------------------------------------------------------------------------
+-- Step 3: Update prices for cETH using Compound-specific query
+-- Compound Protocol V2: exhcangeRate (https://compound.finance/docs#protocol-math)
+-- one_ceth_in_eth is strictly increasing over time
+with ceth_eth_exchange_rate as (
+    select output_0 as exchange_rate_raw
+      , output_0 / (1.0 * 10 ^ (18 + 18 - 8)) as one_ceth_in_eth
+      , call_block_time
+    from compound_v2."cEther_call_exchangeRateCurrent"
+    where call_success
+    and call_block_time >= start_time
+    and call_block_time < end_time
+)
+, day_series as (
+  select generate_series(min(call_block_time::date), end_time, '1 day') as day
+  from ceth_eth_exchange_rate
+)
+, anchor_prices as (
+    select dcp.date as day
+    -- , dcp.component_address
+    -- , dcp.symbol
+    , dcp.avg_price_eth as one_ceth_in_eth
+  from setprotocol_v2.daily_component_prices dcp
+  -- from dune_user_generated.daily_component_prices dcp
+  where dcp.date = start_time::date - interval '1 day'
+    and dcp.component_address = '\x4ddc2d193948926d02f9b1fe9e1daa0718270ed5'::bytea -- cETH address
+)
+, avg_daily_ceth_eth_exchange_rate as (
+    select day
+        , one_ceth_in_eth
+    from anchor_prices
+    union
+    select call_block_time::date as day
+      , avg(one_ceth_in_eth) as one_ceth_in_eth
+    from ceth_eth_exchange_rate
+    group by call_block_time::date
+)
+-- Impute daily cETH to ETH exchange rate with the last known value
+-- Becuase the exchange rate is strictly increasing, this results in a slight price underestimate
+-- when cEther_call_exchangeRateCurrent data availability is low
+, avg_daily_ceth_eth_exchange_rate_imputed as (
+    select d.day
+      , max(r.one_ceth_in_eth) over (order by d.day) as one_ceth_in_eth -- this only works because the exchange rate is strictly increasing
+    from day_series d
+    left join avg_daily_ceth_eth_exchange_rate r on d.day = r.day
+)
+, avg_daily_eth_price as (
+    select minute::date as day
+      , avg(price) as eth_price
+    from prices.layer1_usd
+    where symbol = 'ETH'
+    and minute >= start_time
+    and minute < end_time
+    group by minute::date
+)
+, avg_daily_ceth_price as (
+    select '\x4ddc2d193948926d02f9b1fe9e1daa0718270ed5'::bytea as component_address -- cETH address
+        , 'cETH' as symbol
+        , r.day as date
+        , 'ceth_feed' as data_source
+      , r.one_ceth_in_eth * p.eth_price as avg_price_usd
+      , p.eth_price as eth_price
+      , r.one_ceth_in_eth as avg_price_eth
+      
+    from avg_daily_ceth_eth_exchange_rate_imputed r
+    inner join avg_daily_eth_price p on r.day = p.day
+)
+, rows as (
+  insert into setprotocol_v2.daily_component_prices (
+  -- insert into dune_user_generated.daily_component_prices (
+    component_address
+    , symbol
+    , date
+    , data_source
+    , avg_price_usd
+    , eth_price
+    , avg_price_eth
+  )
+  select
+    component_address
+    , symbol
+    , date
+    , data_source
+    , avg_price_usd
+    , eth_price
+    , avg_price_eth
+  from avg_daily_ceth_price
+
+  on CONFLICT(component_address, date) do update set 
+    data_source = EXCLUDED.data_source
+    , avg_price_usd = EXCLUDED.avg_price_usd
+    , eth_price = EXCLUDED.eth_price
+    , avg_price_eth = EXCLUDED.avg_price_eth
+  RETURNING 1
+)
+SELECT count(*) + r INTO r from rows;
+-------------------------------------------------------------------------------------------------------------------------
+-- Step 4: Update prices for cWBTC (and other cTokens in the future) using Compound-specific query
+-- exchangeRate (https://compound.finance/docs#protocol-math)
+-- one_cWBTC_in_WBTC is strictly increasing over time
+with cwbtc_wbtc_exchange_rate as (
+    select output_0 as exchange_rate_raw
+      , output_0 / (1.0 * 10 ^ (18 + 8 - 8)) as one_cwbtc_in_wbtc
+      , call_block_time
+    from compound_v2."cErc20_call_exchangeRateCurrent"
+    where call_success 
+    and contract_address = '\xc11b1268c1a384e55c48c2391d8d480264a3a7f4' -- cWBTC address
+    and call_block_time >= start_time
+    and call_block_time < end_time
+)
+, day_series as (
+  select generate_series(min(call_block_time::date), now(), '1 day') as day
+  from cwbtc_wbtc_exchange_rate
+)
+, avg_daily_wbtc_price as (
+    select minute::date as day
+      , avg(price) as wbtc_price
+    from prices.usd
+    where contract_address = '\x2260fac5e5542a773aa44fbcfedf7c193bc2c599' -- WBTC contract address
+    and minute >= start_time
+    and minute < end_time
+    group by minute::date
+)
+, avg_daily_eth_price as (
+    select minute::date as day
+      , avg(price) as eth_price
+    from prices.layer1_usd
+    where symbol = 'ETH'
+    and minute >= start_time
+    and minute < end_time
+    group by minute::date
+)
+, anchor_prices as (
+    select dcp.date as day
+    -- , dcp.component_address
+    -- , dcp.symbol
+    , dcp.avg_price_usd / pw.wbtc_price as one_cwbtc_in_wbtc
+  from setprotocol_v2.daily_component_prices dcp
+  -- from dune_user_generated.daily_component_prices dcp
+  inner join avg_daily_wbtc_price pw on dcp.date = pw.day
+  where dcp.date = start_time::date - interval '1 day'
+    and dcp.component_address = '\xc11b1268c1a384e55c48c2391d8d480264a3a7f4'::bytea -- cWBTC address
+)
+, avg_daily_cwbtc_wbtc_exchange_rate as (
+    select day
+        , one_cwbtc_in_wbtc
+    from anchor_prices
+    union
+    select call_block_time::date as day
+      , avg(one_cwbtc_in_wbtc) as one_cwbtc_in_wbtc
+    from cwbtc_wbtc_exchange_rate
+    group by call_block_time::date
+)
+-- Impute daily cWBTC to WBTC exchange rate with the last known value
+-- Becuase the exchange rate is strictly increasing, this results in a slight price underestimate
+-- when cErc20_call_exchangeRateCurrent data availability is low
+, avg_daily_cwbtc_wbtc_exchange_rate_imputed as (
+    select d.day
+      , max(r.one_cwbtc_in_wbtc) over (order by d.day) as one_cwbtc_in_wbtc -- this only works because the exchange rate is strictly increasing
+    from day_series d
+    left join avg_daily_cwbtc_wbtc_exchange_rate r on d.day = r.day
+)
+
+, avg_daily_cwbtc_price as (
+    select '\xc11b1268c1a384e55c48c2391d8d480264a3a7f4'::bytea as component_address -- cWBTC address
+        , 'cWBTC' as symbol
+        , r.day as date
+        , 'ctoken_feed' as data_source
+      -- , r.one_cwbtc_in_wbtc
+      -- , p.wbtc_price
+      , r.one_cwbtc_in_wbtc * pb.wbtc_price as avg_price_usd
+      , pe.eth_price
+      , r.one_cwbtc_in_wbtc * pb.wbtc_price / pe.eth_price as avg_price_eth
+    from avg_daily_cwbtc_wbtc_exchange_rate_imputed r
+    inner join avg_daily_wbtc_price pb on r.day = pb.day
+    inner join avg_daily_eth_price pe on r.day = pe.day
+)
+, rows as (
+  insert into setprotocol_v2.daily_component_prices (
+  -- insert into dune_user_generated.daily_component_prices (
+    component_address
+    , symbol
+    , date
+    , data_source
+    , avg_price_usd
+    , eth_price
+    , avg_price_eth
+  )
+  select
+    component_address
+    , symbol
+    , date
+    , data_source
+    , avg_price_usd
+    , eth_price
+    , avg_price_eth
+  from avg_daily_cwbtc_price
+
+  on CONFLICT(component_address, date) do update set 
+    data_source = EXCLUDED.data_source
+    , avg_price_usd = EXCLUDED.avg_price_usd
+    , eth_price = EXCLUDED.eth_price
+    , avg_price_eth = EXCLUDED.avg_price_eth
+  RETURNING 1
 )
 SELECT count(*) + r INTO r from rows;
 RETURN r;

--- a/ethereum/setprotocol_v2/insert_daily_component_prices.sql
+++ b/ethereum/setprotocol_v2/insert_daily_component_prices.sql
@@ -352,7 +352,6 @@ with cwbtc_wbtc_exchange_rate as (
 )
 , day_series as (
   select generate_series(start_time::date, end_time::date, '1 day') as day
-  from cwbtc_wbtc_exchange_rate
 )
 , avg_daily_wbtc_price as (
     select minute::date as day
@@ -416,6 +415,7 @@ with cwbtc_wbtc_exchange_rate as (
     from avg_daily_cwbtc_wbtc_exchange_rate_imputed r
     inner join avg_daily_wbtc_price pb on r.day = pb.day
     inner join avg_daily_eth_price pe on r.day = pe.day
+    where r.one_cwbtc_in_wbtc is not null
 )
 , rows as (
   insert into setprotocol_v2.daily_component_prices (


### PR DESCRIPTION
Added two extra steps to the insertion process. cETH and cWBTC aren't often traded, so their prices from dex data are either inaccurate or missing. To get their prices we pull directly from the Compound exchange rate events.

After making this change, we should truncate the table and re-run the backfill again.

I've checked that:

* [X] the query produces the intended results
* [X] the folder name matches the schema name
* [X] the schema name exists in Dune
* [X] views are prefixed with `view_`, functions with `fn_`.
* [X] the filename matches the defined view, table or function and ends with .sql
* [X] each file has only one view, table or function defined  
* [X] column names are `lowercase_snake_cased`
