### PR TITLE
add LOOT(lootex) price on ethereum and bsc

### DIFF
--- a/prices/bsc/coinpaprika.yaml
+++ b/prices/bsc/coinpaprika.yaml
@@ -549,3 +549,9 @@
   id: matic-polygon
   name: Polygon
   symbol: MATIC
+- name: LOOT Token
+  id: loot-lootex-token
+  symbol: LOOT
+  address: '0x14a9a94e555fdd54c21d7f7e328e61d7ebece54b'
+  decimals: 18
+  

--- a/prices/bsc/coinpaprika.yaml
+++ b/prices/bsc/coinpaprika.yaml
@@ -549,9 +549,8 @@
   id: matic-polygon
   name: Polygon
   symbol: MATIC
-- name: LOOT Token
-  id: loot-lootex-token
-  symbol: LOOT
-  address: '0x14a9a94e555fdd54c21d7f7e328e61d7ebece54b'
+- address: '0x14a9a94e555fdd54c21d7f7e328e61d7ebece54b'
   decimals: 18
-  
+  id: loot-lootex-token
+  name: LOOT Token
+  symbol: LOOT

--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -2084,5 +2084,5 @@
 - name: LOOT Token
   id: loot-lootex-token
   symbol: LOOT
-  address: 0x14a9a94e555fdd54c21d7f7e328e61d7ebece54b
+  address: 0x721A1B990699eE9D90b6327FaaD0A3E840aE8335
   decimals: 18

--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -2081,3 +2081,9 @@
   symbol: YOP
   address: 0xae1eaae3f627aaca434127644371b67b18444051
   decimals: 8
+- name: LOOT Token
+  id: loot-lootex-token
+  symbol: LOOT
+  address: '0x14a9a94e555fdd54c21d7f7e328e61d7ebece54b'
+  decimals: 18
+  

--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -2084,6 +2084,5 @@
 - name: LOOT Token
   id: loot-lootex-token
   symbol: LOOT
-  address: '0x14a9a94e555fdd54c21d7f7e328e61d7ebece54b'
+  address: 0x14a9a94e555fdd54c21d7f7e328e61d7ebece54b
   decimals: 18
-  


### PR DESCRIPTION
LOOT is a token launched by Lootex
Lootex is nft marketplace

website: https://lootex.io/
token info: https://coinmarketcap.com/currencies/lootex/
loot on coinpaprika: https://coinpaprika.com/coin/loot-lootex-token/

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
