### PR TITLE
add VAI to coinpaprika yaml

### DIFF
--- a/prices/bsc/coinpaprika.yaml
+++ b/prices/bsc/coinpaprika.yaml
@@ -554,3 +554,8 @@
   id: loot-lootex-token
   name: LOOT Token
   symbol: LOOT
+- address: '0x4bd17003473389a42daf6a0a729f6fdb328bbbd7'
+  decimals: 18
+  id: vai-vai
+  name: Vai
+  symbol: VAI


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
