### PR TITLE
Update coinpaprika.yaml to add OHM v2 token

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1540,10 +1540,15 @@
   symbol: WILD
   address: 0x08a75dbc7167714ceac1a8e43a8d643a4edd625a
   decimals: 18
-- name: ohm_olympus
-  id: ohm-olympus
+- name: ohm_olympus_v1
+  id: ohm-olympus-v1
   symbol: OHM
   address: 0x383518188c0c6d7730d91b2c03a03c837814a899
+  decimals: 9
+- name: ohm_olympus_v2
+  id: ohmv2-olympus-v2
+  symbol: OHM
+  address: 0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5
   decimals: 9
 - name: strong_strong
   id: strong-strong


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
