### PR TITLE
Add products to Pika protocol, namely APE, AXS, and UNI.

### DIFF
--- a/optimism2/perpetuals/insert_pika_v1.sql
+++ b/optimism2/perpetuals/insert_pika_v1.sql
@@ -57,6 +57,9 @@ WITH rows AS (
             WHEN p."productId" = 7 THEN 'MATIC'
             WHEN p."productId" = 8 THEN 'LUNA'
             WHEN p."productId" = 9 THEN 'AAVE'
+            WHEN p."productId" = 10 THEN 'APE'
+            WHEN p."productId" = 11 THEN 'AXS'
+            WHEN p."productId" = 12 THEN 'UNI'
             ELSE CONCAT ('product_id_', p."productId") 
             END AS virtual_asset,
             
@@ -70,6 +73,9 @@ WITH rows AS (
             WHEN p."productId" = 7 THEN 'MATIC'
             WHEN p."productId" = 8 THEN 'LUNA'
             WHEN p."productId" = 9 THEN 'AAVE'
+            WHEN p."productId" = 10 THEN 'APE'
+            WHEN p."productId" = 11 THEN 'AXS'
+            WHEN p."productId" = 12 THEN 'UNI'
             ELSE CONCAT ('product_id_', p."productId") 
             END AS underlying_asset,
             
@@ -83,6 +89,9 @@ WITH rows AS (
             WHEN p."productId" = 7 THEN 'MATIC-USD'
             WHEN p."productId" = 8 THEN 'LUNA-USD'
             WHEN p."productId" = 9 THEN 'AAVE-USD'
+            WHEN p."productId" = 10 THEN 'APE-USD'
+            WHEN p."productId" = 11 THEN 'AXS-USD'
+            WHEN p."productId" = 12 THEN 'UNI-USD'
             ELSE CONCAT ('product_id_', p."productId") 
             END AS market,
             

--- a/optimism2/perpetuals/insert_pika_v2.sql
+++ b/optimism2/perpetuals/insert_pika_v2.sql
@@ -57,6 +57,9 @@ WITH rows AS (
             WHEN p."productId" = 7 THEN 'MATIC'
             WHEN p."productId" = 8 THEN 'LUNA'
             WHEN p."productId" = 9 THEN 'AAVE'
+            WHEN p."productId" = 10 THEN 'APE'
+            WHEN p."productId" = 11 THEN 'AXS'
+            WHEN p."productId" = 12 THEN 'UNI'
             ELSE CONCAT ('product_id_', p."productId") 
             END AS virtual_asset,
             
@@ -70,6 +73,9 @@ WITH rows AS (
             WHEN p."productId" = 7 THEN 'MATIC'
             WHEN p."productId" = 8 THEN 'LUNA'
             WHEN p."productId" = 9 THEN 'AAVE'
+            WHEN p."productId" = 10 THEN 'APE'
+            WHEN p."productId" = 11 THEN 'AXS'
+            WHEN p."productId" = 12 THEN 'UNI'
             ELSE CONCAT ('product_id_', p."productId") 
             END AS underlying_asset,
             
@@ -83,6 +89,9 @@ WITH rows AS (
             WHEN p."productId" = 7 THEN 'MATIC-USD'
             WHEN p."productId" = 8 THEN 'LUNA-USD'
             WHEN p."productId" = 9 THEN 'AAVE-USD'
+            WHEN p."productId" = 10 THEN 'APE-USD'
+            WHEN p."productId" = 11 THEN 'AXS-USD'
+            WHEN p."productId" = 12 THEN 'UNI-USD'
             ELSE CONCAT ('product_id_', p."productId") 
             END AS market,
             


### PR DESCRIPTION
This PR adds $APE, $AXS, and $UNI as new underlying assets and markets under Pika Protocol. These new additions are specified in the `insert_pika_v1.sql` and `insert_pika_v2.sql` files.

I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
