### PR TITLE
add GCR token to coinpaprika.yaml

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -2096,3 +2096,8 @@
   symbol: VPAD
   address: 0x51FE2E572e97BFEB1D719809d743Ec2675924EDc
   decimals: 18
+- name: global-coin-research
+  id: gcr-global-coin-research
+  symbol: GCR
+  address: 0x6307B25A665Efc992EC1C1bC403c38F3dDd7c661
+  decimals: 4


### PR DESCRIPTION
I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
