### PR TITLE
Remove Curve from OP2 dex.trades

### DIFF
--- a/optimism2/dex/prices_and_trades_inserts.sql
+++ b/optimism2/dex/prices_and_trades_inserts.sql
@@ -17,7 +17,7 @@ VALUES ('15,30,45,59 * * * *', $$
 	SELECT dex.insert_oneinch( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='1inch'), now(), 0);
 	SELECT dex.insert_zeroex( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project IN ('0x API', 'Matcha')), now() );
 	SELECT dex.insert_zipswap( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Zipswap'), now() );
-	SELECT dex.insert_curve( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Curve'), now() );
+	--SELECT dex.insert_curve( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Curve'), now() );
 	SELECT dex.insert_clipper( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Clipper'), now() );
 	SELECT dex.insert_kwenta( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Kwenta'), now() );
 	SELECT dex.insert_wardenswap( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='WardenSwap' AND version = '2'), now() );


### PR DESCRIPTION
Something is off with the Curve insert & I think this is what's slowing down the table. It's inserting way more trades than actually exist.

Commenting out for now until i can resolve it.

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
