### PR TITLE
Remove all cronjobs for GPv1

### DIFF
--- a/ethereum/gnosis_protocol/view_balances.sql
+++ b/ethereum/gnosis_protocol/view_balances.sql
@@ -33,7 +33,7 @@ JOIN gnosis_protocol.view_movement movement
 CREATE UNIQUE INDEX IF NOT EXISTS view_balances_id ON gnosis_protocol.view_balances (trader, token) ;
 CREATE INDEX view_balances_1 ON gnosis_protocol.view_balances (token);
 
-INSERT INTO cron.job (schedule, command)
-VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_balances')
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
-COMMIT;
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_balances')
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- COMMIT;

--- a/ethereum/gnosis_protocol/view_daily_average_prices.sql
+++ b/ethereum/gnosis_protocol/view_daily_average_prices.sql
@@ -46,8 +46,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS view_daily_average_prices_id ON gnosis_protoco
 CREATE INDEX view_daily_average_prices_1 ON gnosis_protocol.view_daily_average_prices (day);
 CREATE INDEX view_daily_average_prices_2 ON gnosis_protocol.view_daily_average_prices (symbol);
 
-INSERT INTO cron.job (schedule, command)
--- Every 6 hours.
-VALUES ('0 */6 * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_daily_average_prices')
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
-COMMIT;
+-- INSERT INTO cron.job (schedule, command)
+-- -- Every 6 hours.
+-- VALUES ('0 */6 * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_daily_average_prices')
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- COMMIT;

--- a/ethereum/gnosis_protocol/view_movement.sql
+++ b/ethereum/gnosis_protocol/view_movement.sql
@@ -215,7 +215,7 @@ CREATE INDEX view_movement_1 ON gnosis_protocol.view_movement (token_symbol);
 CREATE INDEX view_movement_2 ON gnosis_protocol.view_movement (token);
 CREATE INDEX view_movement_3 ON gnosis_protocol.view_movement (batch_id);
 
-INSERT INTO cron.job (schedule, command)
-VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_movement')
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
-COMMIT;
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_movement')
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- COMMIT;

--- a/ethereum/gnosis_protocol/view_price_batch.sql
+++ b/ethereum/gnosis_protocol/view_price_batch.sql
@@ -188,7 +188,7 @@ CREATE INDEX view_price_batch_idx_1 ON gnosis_protocol.view_price_batch (token_i
 CREATE INDEX view_price_batch_idx_2 ON gnosis_protocol.view_price_batch (symbol);
 CREATE INDEX view_price_batch_idx_3 ON gnosis_protocol.view_price_batch (price_date);
 
-INSERT INTO cron.job (schedule, command)
-VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_price_batch')
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
-COMMIT;
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_price_batch')
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- COMMIT;

--- a/ethereum/gnosis_protocol/view_tokens.sql
+++ b/ethereum/gnosis_protocol/view_tokens.sql
@@ -44,7 +44,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS view_tokens_id ON gnosis_protocol.view_tokens 
 CREATE INDEX view_tokens_1 ON gnosis_protocol.view_tokens (symbol);
 CREATE INDEX view_tokens_2 ON gnosis_protocol.view_tokens (token);
 
-INSERT INTO cron.job (schedule, command)
-VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_tokens')
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
-COMMIT;
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_tokens')
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- COMMIT;

--- a/ethereum/gnosis_protocol/view_trade_stats.sql
+++ b/ethereum/gnosis_protocol/view_trade_stats.sql
@@ -73,7 +73,7 @@ CREATE INDEX view_trade_stats_idx_1 ON gnosis_protocol.view_trade_stats (app_id)
 CREATE INDEX view_trade_stats_idx_2 ON gnosis_protocol.view_trade_stats (trade_date);
 
 
-INSERT INTO cron.job (schedule, command)
-VALUES ('*/10 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_trades')
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
-COMMIT;
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('*/10 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_trades')
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- COMMIT;

--- a/ethereum/gnosis_protocol/view_trades.sql
+++ b/ethereum/gnosis_protocol/view_trades.sql
@@ -92,7 +92,7 @@ CREATE INDEX view_trades_idx_6 ON gnosis_protocol.view_trades (trader_hex, order
 
 
 
-INSERT INTO cron.job (schedule, command)
-VALUES ('*/1 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_trades')
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
-COMMIT;
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('*/1 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_trades')
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- COMMIT;

--- a/xdai/gnosis_protocol/view_balances.sql
+++ b/xdai/gnosis_protocol/view_balances.sql
@@ -33,7 +33,7 @@ JOIN gnosis_protocol.view_movement movement
 CREATE UNIQUE INDEX IF NOT EXISTS view_balances_id ON gnosis_protocol.view_balances (trader, token) ;
 CREATE INDEX view_balances_1 ON gnosis_protocol.view_balances (token);
 
-INSERT INTO cron.job (schedule, command)
-VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_balances')
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
-COMMIT;
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_balances')
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- COMMIT;

--- a/xdai/gnosis_protocol/view_daily_average_prices.sql
+++ b/xdai/gnosis_protocol/view_daily_average_prices.sql
@@ -46,8 +46,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS view_daily_average_prices_id ON gnosis_protoco
 CREATE INDEX view_daily_average_prices_1 ON gnosis_protocol.view_daily_average_prices (day);
 CREATE INDEX view_daily_average_prices_2 ON gnosis_protocol.view_daily_average_prices (symbol);
 
-INSERT INTO cron.job (schedule, command)
--- Every 6 hours.
-VALUES ('0 */6 * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_daily_average_prices')
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
-COMMIT;
+-- INSERT INTO cron.job (schedule, command)
+-- -- Every 6 hours.
+-- VALUES ('0 */6 * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_daily_average_prices')
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- COMMIT;

--- a/xdai/gnosis_protocol/view_movement.sql
+++ b/xdai/gnosis_protocol/view_movement.sql
@@ -215,7 +215,7 @@ CREATE INDEX view_movement_1 ON gnosis_protocol.view_movement (token_symbol);
 CREATE INDEX view_movement_2 ON gnosis_protocol.view_movement (token);
 CREATE INDEX view_movement_3 ON gnosis_protocol.view_movement (batch_id);
 
-INSERT INTO cron.job (schedule, command)
-VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_movement')
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
-COMMIT;
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_movement')
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- COMMIT;

--- a/xdai/gnosis_protocol/view_price_batch.sql
+++ b/xdai/gnosis_protocol/view_price_batch.sql
@@ -188,7 +188,7 @@ CREATE INDEX view_price_batch_idx_1 ON gnosis_protocol.view_price_batch (token_i
 CREATE INDEX view_price_batch_idx_2 ON gnosis_protocol.view_price_batch (symbol);
 CREATE INDEX view_price_batch_idx_3 ON gnosis_protocol.view_price_batch (price_date);
 
-INSERT INTO cron.job (schedule, command)
-VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_price_batch')
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
-COMMIT;
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_price_batch')
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- COMMIT;

--- a/xdai/gnosis_protocol/view_tokens.sql
+++ b/xdai/gnosis_protocol/view_tokens.sql
@@ -15,7 +15,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS view_tokens_id ON gnosis_protocol.view_tokens 
 CREATE INDEX view_tokens_1 ON gnosis_protocol.view_tokens (symbol);
 CREATE INDEX view_tokens_2 ON gnosis_protocol.view_tokens (token);
 
-INSERT INTO cron.job (schedule, command)
-VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_tokens')
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
-COMMIT;
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('*/5 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_tokens')
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- COMMIT;

--- a/xdai/gnosis_protocol/view_trade_stats.sql
+++ b/xdai/gnosis_protocol/view_trade_stats.sql
@@ -73,7 +73,7 @@ CREATE INDEX view_trade_stats_idx_1 ON gnosis_protocol.view_trade_stats (app_id)
 CREATE INDEX view_trade_stats_idx_2 ON gnosis_protocol.view_trade_stats (trade_date);
 
 
-INSERT INTO cron.job (schedule, command)
-VALUES ('*/10 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_trades')
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
-COMMIT;
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('*/10 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_trades')
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- COMMIT;

--- a/xdai/gnosis_protocol/view_trades.sql
+++ b/xdai/gnosis_protocol/view_trades.sql
@@ -92,7 +92,7 @@ CREATE INDEX view_trades_idx_6 ON gnosis_protocol.view_trades (trader_hex, order
 
 
 
-INSERT INTO cron.job (schedule, command)
-VALUES ('*/1 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_trades')
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
-COMMIT;
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('*/1 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_trades')
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- COMMIT;

--- a/xdai/gnosis_protocol/view_trades.sql
+++ b/xdai/gnosis_protocol/view_trades.sql
@@ -92,7 +92,7 @@ CREATE INDEX view_trades_idx_6 ON gnosis_protocol.view_trades (trader_hex, order
 
 
 
--- INSERT INTO cron.job (schedule, command)
--- VALUES ('*/1 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_trades')
--- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
--- COMMIT;
+INSERT INTO cron.job (schedule, command)
+VALUES ('*/1 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol.view_trades')
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+COMMIT;


### PR DESCRIPTION
This PR should free up some resources on your server and this protocol has been deprecated. Along with this code change, I suppose we may also want to execute the following deletion:

```sql
DELETE FROM cron.job WHERE command ILIKE 'gnosis_protocol.%';
```
BUT ONLY UNDER THE `ethereum` namespace!

Leaving in Draft State and awaiting approval from another team member (cc @fleupold and/or @anxolin)