### PR TITLE
ovm2 l1 gas price - add unique indices

### DIFF
--- a/optimism2/ovm2/l1_gas_price_oracle_updates.sql
+++ b/optimism2/ovm2/l1_gas_price_oracle_updates.sql
@@ -9,3 +9,6 @@ CREATE TABLE IF NOT EXISTS ovm2.l1_gas_price_oracle_updates (
 CREATE INDEX IF NOT EXISTS ovm2_l1_gas_prices_block_number_idx ON ovm2.l1_gas_price_oracle_updates (block_number);
 CREATE INDEX IF NOT EXISTS ovm2_l1_gas_prices_block_time_idx ON ovm2.l1_gas_price_oracle_updates (block_time);
 CREATE INDEX IF NOT EXISTS ovm2_l1_gas_prices_block_number_block_time_idx ON ovm2.l1_gas_price_oracle_updates (block_number, block_time);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ovm2_uniq)l1_gas_prices_block_number_idx ON ovm2.l1_gas_price_oracle_updates (block_number);
+CREATE UNIQUE INDEX IF NOT EXISTS ovm2_uniq)l1_gas_prices_block_number_time_idx ON ovm2.l1_gas_price_oracle_updates (block_number, block_time);

--- a/optimism2/ovm2/l1_gas_price_oracle_updates.sql
+++ b/optimism2/ovm2/l1_gas_price_oracle_updates.sql
@@ -10,5 +10,5 @@ CREATE INDEX IF NOT EXISTS ovm2_l1_gas_prices_block_number_idx ON ovm2.l1_gas_pr
 CREATE INDEX IF NOT EXISTS ovm2_l1_gas_prices_block_time_idx ON ovm2.l1_gas_price_oracle_updates (block_time);
 CREATE INDEX IF NOT EXISTS ovm2_l1_gas_prices_block_number_block_time_idx ON ovm2.l1_gas_price_oracle_updates (block_number, block_time);
 
-CREATE UNIQUE INDEX IF NOT EXISTS ovm2_uniq)l1_gas_prices_block_number_idx ON ovm2.l1_gas_price_oracle_updates (block_number);
-CREATE UNIQUE INDEX IF NOT EXISTS ovm2_uniq)l1_gas_prices_block_number_time_idx ON ovm2.l1_gas_price_oracle_updates (block_number, block_time);
+CREATE UNIQUE INDEX IF NOT EXISTS ovm2_uniq_l1_gas_prices_block_number_idx ON ovm2.l1_gas_price_oracle_updates (block_number);
+CREATE UNIQUE INDEX IF NOT EXISTS ovm2_uniq_l1_gas_prices_block_number_time_idx ON ovm2.l1_gas_price_oracle_updates (block_number, block_time);


### PR DESCRIPTION
Adding unique indices to try to make this table faster to query.

Let me know if there are other obvious-seeming ideas! Definitely not a pro at indices.

In short: Block Number is always unique, block time can be duplicated, but this table is often filtered by block time / joined on block number.

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
