### PR TITLE
Create op airdrop1_address_list.sql

### DIFF
--- a/optimism2/op/airdrop1_address_list.sql
+++ b/optimism2/op/airdrop1_address_list.sql
@@ -1,0 +1,28 @@
+CREATE SCHEMA IF NOT EXISTS op;
+
+CREATE TABLE IF NOT EXISTS op.airdrop1_address_list (
+	address bytea UNIQUE,
+	a_is_voter numeric,
+	b_is_multisig_signer numeric,
+	c_is_gitcoin numeric,
+	d_is_price_out numeric,
+	e_op_user numeric,
+	f_op_repeat numeric,
+	num_categories_if_op numeric,
+	g_overlap_bonus_op numeric,
+	total_amount_op numeric
+);
+
+BEGIN;
+DELETE FROM op.airdrop1_address_list *;
+
+
+COPY op.airdrop1_address_list (address, a_is_voter,b_is_multisig_signer,c_is_gitcoin,d_is_price_out,e_op_user,f_op_repeat,num_categories_if_op,g_overlap_bonus_op,total_amount_op) FROM stdin;
+
+
+\.
+
+
+COMMIT;
+
+CREATE INDEX IF NOT EXISTS op_address_idx ON erc20.tokens USING btree (address) INCLUDE (total_amount_op);


### PR DESCRIPTION
Creating a table for the eligible address list and associated eligibility amounts for Optimism Airdrop 1.

I've checked that:

* [ ] the query produces the intended results
* [ ] the folder name matches the schema name
* [ ] the schema name exists in Dune
* [ ] views are prefixed with `view_`, functions with `fn_`.
* [ ] the filename matches the defined view, table or function and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
