### PR TITLE
Update ovm contract project names

### DIFF
--- a/optimism2/ovm2/get_contracts/insert_project_name_mapping.sql
+++ b/optimism2/ovm2/get_contracts/insert_project_name_mapping.sql
@@ -14,11 +14,14 @@ DELETE FROM ovm2.project_name_mappings *;
 
 COPY ovm2.project_name_mappings (dune_name,mapped_name) FROM stdin;
 lyra_v1	Lyra
+Lyra V1	Lyra
 aave_v3	Aave
 perp_v2	Perpetual Protocol
 synthetix_futures	Kwenta
 zeroex	0x
-uniswap_v3	Uniswap
+uniswap_v3	Uniswap V3
+Uniswap V3	Uniswap V3
+OneInch	1inch
 \.
 COMMIT;
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS dune_name_mapped_name_uniq_idx ON ovm2.project_name_mappings (dune_name);

--- a/optimism2/ovm2/get_contracts/insert_updated_contract_info.sql
+++ b/optimism2/ovm2/get_contracts/insert_updated_contract_info.sql
@@ -8,6 +8,8 @@ SELECT gc.creator_address, MIN(created_time) AS min_created_time, MAX(created_ti
     FROM ovm2.get_contracts gc
     LEFT JOIN ovm2.contract_creator_address_list cc
         ON cc."creator_address" = gc.creator_address
+	LEFT JOIN ovm2.project_name_mappings pnm
+	ON pnm.dune_name = gc.contract_project
     
     WHERE
 	is_self_destruct = false
@@ -32,6 +34,7 @@ SELECT gc.creator_address, MIN(created_time) AS min_created_time, MAX(created_ti
 		    )
 	    )
 	    OR lower(cc.project) != lower(gc."contract_project")
+	    OR pnm.dune_name IS NOT NULL
 	)
     GROUP BY 1
 ;


### PR DESCRIPTION
Small updates to handle for name override edge cases, where we define a name in creator address mapping that we later override in project name mapping.

I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
