### PR TITLE
OP2 DEX Insert Velo, Beets, Sushi, Slingshot

### DIFF
--- a/optimism2/dex/insert_beethoven_x.sql
+++ b/optimism2/dex/insert_beethoven_x.sql
@@ -1,0 +1,138 @@
+CREATE OR REPLACE FUNCTION dex.insert_beethoven_x(start_ts timestamptz, end_ts timestamptz=now()) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH rows AS (
+    INSERT INTO dex.trades (
+        block_time,
+        token_a_symbol,
+        token_b_symbol,
+        token_a_amount,
+        token_b_amount,
+        project,
+        version,
+        category,
+        trader_a,
+        trader_b,
+        token_a_amount_raw,
+        token_b_amount_raw,
+        usd_amount,
+        token_a_address,
+        token_b_address,
+        exchange_contract_address,
+        tx_hash,
+        tx_from,
+        tx_to,
+        trace_address,
+        evt_index,
+        trade_id
+    )
+
+SELECT
+    dexs.block_time,
+    erc20a.symbol AS token_a_symbol,
+    erc20b.symbol AS token_b_symbol,
+    token_a_amount_raw / 10 ^ erc20a.decimals AS token_a_amount,
+    token_b_amount_raw / 10 ^ erc20b.decimals AS token_b_amount,
+    project,
+    version,
+    category,
+    coalesce(trader_a, tx."from") as trader_a, -- subqueries rely on this COALESCE to avoid redundant joins with the transactions table
+    trader_b,
+    token_a_amount_raw,
+    token_b_amount_raw,
+    coalesce(
+        usd_amount,
+        token_a_amount_raw / 10 ^ erc20a.decimals * pa.median_price,
+        token_b_amount_raw / 10 ^ erc20b.decimals * pb.median_price
+    ) as usd_amount,
+    token_a_address,
+    token_b_address,
+    exchange_contract_address,
+    tx_hash,
+    tx."from" as tx_from,
+    tx."to" as tx_to,
+    trace_address,
+    evt_index,
+    row_number() OVER (PARTITION BY project, tx_hash, evt_index, trace_address ORDER BY version, category) AS trade_id
+    FROM (
+    -- Beethoven X is executing the Balancer V2 deployment on Optimism (Contracts are labeled as balancer_v2 in Dune)
+    -- Insert based on: https://github.com/duneanalytics/abstractions/blob/master/ethereum/dex/trades/insert_balancer.sql
+	    SELECT
+            t.evt_block_time AS block_time,
+            'Beethoven X' AS project,
+            '2' AS version,
+            'DEX' AS category,
+            NULL::bytea AS trader_a, -- this relies on the outer query coalescing to tx."from"
+            NULL::bytea AS trader_b,
+            t."amountOut" AS token_a_amount_raw,
+            t."amountIn" AS token_b_amount_raw,
+            NULL::numeric AS usd_amount,
+            t."tokenOut" AS token_a_address,
+            t."tokenIn" AS token_b_address,
+            t."poolId" AS exchange_contract_address,
+            t.evt_tx_hash AS tx_hash,
+            NULL::integer[] AS trace_address,
+            t.evt_index
+        FROM
+            balancer_v2."Vault_evt_Swap" t
+        WHERE t."tokenIn" != SUBSTRING(t."poolId" FOR 20)
+        AND t."tokenOut" != SUBSTRING(t."poolId" FOR 20)
+
+	WHERE t.evt_block_time >= start_ts AND t.evt_block_time < end_ts
+    ) dexs
+    INNER JOIN optimism.transactions tx
+        ON dexs.tx_hash = tx.hash
+        AND tx.block_time >= start_ts
+        AND tx.block_time < end_ts
+
+    LEFT JOIN erc20.tokens erc20a ON erc20a.contract_address = dexs.token_a_address
+    LEFT JOIN erc20.tokens erc20b ON erc20b.contract_address = dexs.token_b_address
+    LEFT JOIN prices.approx_prices_from_dex_data pa
+      ON pa.hour = date_trunc('hour', dexs.block_time)
+        AND pa.contract_address = dexs.token_a_address
+        AND pa.hour >= start_ts
+        AND pa.hour < end_ts
+    LEFT JOIN prices.approx_prices_from_dex_data pb
+      ON pb.hour = date_trunc('hour', dexs.block_time)
+        AND pb.contract_address = dexs.token_b_address
+        AND pb.hour >= start_ts
+        AND pb.hour < end_ts
+
+    -- update if we have new info on prices or the erc20
+    ON CONFLICT (project, tx_hash, evt_index, trade_id)
+    DO UPDATE SET
+        usd_amount = EXCLUDED.usd_amount,
+        token_a_amount = EXCLUDED.token_a_amount,
+        token_b_amount = EXCLUDED.token_b_amount,
+        token_a_symbol = EXCLUDED.token_a_symbol,
+        token_b_symbol = EXCLUDED.token_b_symbol
+    RETURNING 1
+)
+SELECT count(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+-- launched may, 2022 - give a buffer for testing
+SELECT dex.insert_beethoven_x(
+    '2022-05-01',
+    now()
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM dex.trades
+    WHERE block_time > '2022-05-01'
+    AND block_time <= now()
+    AND project = 'Beethoven X'
+);
+/*
+INSERT INTO cron.job (schedule, command)
+VALUES ('15,45 * * * *', $$
+    SELECT dex.insert_beethoven_x(
+        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Beethoven X'),
+        now()
+    );
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+*/

--- a/optimism2/dex/insert_beethoven_x.sql
+++ b/optimism2/dex/insert_beethoven_x.sql
@@ -78,8 +78,8 @@ SELECT
             balancer_v2."Vault_evt_Swap" t
         WHERE t."tokenIn" != SUBSTRING(t."poolId" FOR 20)
         AND t."tokenOut" != SUBSTRING(t."poolId" FOR 20)
-
-	WHERE t.evt_block_time >= start_ts AND t.evt_block_time < end_ts
+	AND t.evt_block_time >= start_ts AND t.evt_block_time < end_ts
+	    
     ) dexs
     INNER JOIN optimism.transactions tx
         ON dexs.tx_hash = tx.hash

--- a/optimism2/dex/insert_slingshot.sql
+++ b/optimism2/dex/insert_slingshot.sql
@@ -1,0 +1,146 @@
+CREATE OR REPLACE FUNCTION dex.insert_slingshot(start_ts timestamptz, end_ts timestamptz=now()) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH rows AS (
+    INSERT INTO dex.trades (
+        block_time,
+        token_a_symbol,
+        token_b_symbol,
+        token_a_amount,
+        token_b_amount,
+        project,
+        version,
+        category,
+        trader_a,
+        trader_b,
+        token_a_amount_raw,
+        token_b_amount_raw,
+        usd_amount,
+        token_a_address,
+        token_b_address,
+        exchange_contract_address,
+        tx_hash,
+        tx_from,
+        tx_to,
+        trace_address,
+        evt_index,
+        trade_id
+    )
+
+SELECT
+    dexs.block_time,
+    erc20a.symbol AS token_a_symbol,
+    erc20b.symbol AS token_b_symbol,
+    token_a_amount_raw / 10 ^ erc20a.decimals AS token_a_amount,
+    token_b_amount_raw / 10 ^ erc20b.decimals AS token_b_amount,
+    project,
+    version,
+    category,
+    coalesce(trader_a, tx."from") as trader_a, -- subqueries rely on this COALESCE to avoid redundant joins with the transactions table
+    trader_b,
+    token_a_amount_raw,
+    token_b_amount_raw,
+    coalesce(
+        usd_amount,
+        token_a_amount_raw / 10 ^ erc20a.decimals * pa.median_price,
+        token_b_amount_raw / 10 ^ erc20b.decimals * pb.median_price
+    ) as usd_amount,
+    token_a_address,
+    token_b_address,
+    exchange_contract_address,
+    tx_hash,
+    tx."from" as tx_from,
+    tx."to" as tx_to,
+    trace_address,
+    evt_index,
+    row_number() OVER (PARTITION BY project, tx_hash, evt_index, trace_address ORDER BY version, category) AS trade_id
+    FROM (
+	    --Slingshot's contracts are not open & verified, so we have to piece together trades from logs
+	    SELECT
+            l.block_time AS block_time,
+            'Slingshot' AS project,
+            '1' AS version,
+            'Aggregator' AS category,
+            NULL::bytea AS trader_a, -- this relies on the outer query coalescing to tx."from"
+            NULL::bytea AS trader_b,
+            bytea2numeric(substring(data from 32*2+1 for 32)) AS token_a_amount_raw, --weird that this one behaves differently
+            bytea2numeric(substring(data from 32*3+1 for 33)) AS token_b_amount_raw,
+            NULL::numeric AS usd_amount,
+            
+            CASE WHEN substring(substring(data from 33*0 for 33) from 13 for 20) = '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' --Slingshot ETH Placeholder
+                THEN '\xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000' --L2 ETH Placeholder
+                ELSE substring(substring(data from 33*0 for 33) from 13 for 20)
+            END AS token_a_address,
+
+            CASE WHEN substring(substring(data from 33*1 for 33) from 13 for 20) = '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' --Slingshot ETH Placeholder
+                THEN '\xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000' --L2 ETH Placeholder
+                ELSE substring(substring(data from 33*1 for 33) from 13 for 20)
+            END AS token_b_address,
+	    
+            l."contract_address" AS exchange_contract_address,
+            l.tx_hash AS tx_hash,
+            NULL::integer[] AS trace_address,
+            l."tx_index" AS evt_index
+        FROM
+            optimism.logs l
+        WHERE contract_address = '\x00c0184c0b5d42fba6b7ca914b31239b419ab80b' --Slingshot Contract
+        AND topic1 = '\x899a8968d68f840cf01fdaf129bf72e96ca51b8ecad8c4f7566938e7a2ba6bcf' --swap
+
+	AND l.block_time >= start_ts AND l.block_time < end_ts
+    ) dexs
+    INNER JOIN optimism.transactions tx
+        ON dexs.tx_hash = tx.hash
+        AND tx.block_time >= start_ts
+        AND tx.block_time < end_ts
+
+    LEFT JOIN erc20.tokens erc20a ON erc20a.contract_address = dexs.token_a_address
+    LEFT JOIN erc20.tokens erc20b ON erc20b.contract_address = dexs.token_b_address
+    LEFT JOIN prices.approx_prices_from_dex_data pa
+      ON pa.hour = date_trunc('hour', dexs.block_time)
+        AND pa.contract_address = dexs.token_a_address
+        AND pa.hour >= start_ts
+        AND pa.hour < end_ts
+    LEFT JOIN prices.approx_prices_from_dex_data pb
+      ON pb.hour = date_trunc('hour', dexs.block_time)
+        AND pb.contract_address = dexs.token_b_address
+        AND pb.hour >= start_ts
+        AND pb.hour < end_ts
+
+    -- update if we have new info on prices or the erc20
+    ON CONFLICT (project, tx_hash, evt_index, trade_id)
+    DO UPDATE SET
+        usd_amount = EXCLUDED.usd_amount,
+        token_a_amount = EXCLUDED.token_a_amount,
+        token_b_amount = EXCLUDED.token_b_amount,
+        token_a_symbol = EXCLUDED.token_a_symbol,
+        token_b_symbol = EXCLUDED.token_b_symbol
+    RETURNING 1
+)
+SELECT count(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+-- get started
+SELECT dex.insert_slingshot(
+    '2021-11-11',
+    now()
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM dex.trades
+    WHERE block_time > '2021-11-11'
+    AND block_time <= now()
+    AND project = 'Slingshot'
+);
+/*
+INSERT INTO cron.job (schedule, command)
+VALUES ('15,45 * * * *', $$
+    SELECT dex.insert_slingshot(
+        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Slingshot'),
+        now()
+    );
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+*/

--- a/optimism2/dex/insert_sushiswap.sql
+++ b/optimism2/dex/insert_sushiswap.sql
@@ -1,0 +1,143 @@
+CREATE OR REPLACE FUNCTION dex.insert_sushiswap(start_ts timestamptz, end_ts timestamptz=now()) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH rows AS (
+    INSERT INTO dex.trades (
+        block_time,
+        token_a_symbol,
+        token_b_symbol,
+        token_a_amount,
+        token_b_amount,
+        project,
+        version,
+        category,
+        trader_a,
+        trader_b,
+        token_a_amount_raw,
+        token_b_amount_raw,
+        usd_amount,
+        token_a_address,
+        token_b_address,
+        exchange_contract_address,
+        tx_hash,
+        tx_from,
+        tx_to,
+        trace_address,
+        evt_index,
+        trade_id
+    )
+
+--Temporary solve until all of the Sushi pools get decoded.
+WITH sushi_pools AS (
+    SELECT output_pool FROM sushi."ConstantProductPoolFactory_call_deployPool"
+    WHERE call_success
+    GROUP BY 1
+    )
+
+SELECT
+    dexs.block_time,
+    erc20a.symbol AS token_a_symbol,
+    erc20b.symbol AS token_b_symbol,
+    token_a_amount_raw / 10 ^ erc20a.decimals AS token_a_amount,
+    token_b_amount_raw / 10 ^ erc20b.decimals AS token_b_amount,
+    project,
+    version,
+    category,
+    coalesce(trader_a, tx."from") as trader_a, -- subqueries rely on this COALESCE to avoid redundant joins with the transactions table
+    trader_b,
+    token_a_amount_raw,
+    token_b_amount_raw,
+    coalesce(
+        usd_amount,
+        token_a_amount_raw / 10 ^ erc20a.decimals * pa.median_price,
+        token_b_amount_raw / 10 ^ erc20b.decimals * pb.median_price
+    ) as usd_amount,
+    token_a_address,
+    token_b_address,
+    exchange_contract_address,
+    tx_hash,
+    tx."from" as tx_from,
+    tx."to" as tx_to,
+    trace_address,
+    evt_index,
+    row_number() OVER (PARTITION BY project, tx_hash, evt_index, trace_address ORDER BY version, category) AS trade_id
+    FROM (
+	    SELECT
+            l.block_time AS block_time,
+            'Sushiswap' AS project,
+            'Trident' AS version,
+            'DEX' AS category,
+            NULL::bytea AS trader_a, -- this relies on the outer query coalescing to tx."from"
+            NULL::bytea AS trader_b,
+            bytea2numeric(substring(data from 33 for 33)) AS token_a_amount_raw,
+            bytea2numeric(substring(data from 0 for 33)) AS token_b_amount_raw,
+            NULL::numeric AS usd_amount,
+            substring("topic4" from 13 for 33) AS token_a_address,
+            substring("topic3" from 13 for 33) AS token_b_address,
+            l."contract_address" AS exchange_contract_address,
+            l.tx_hash AS tx_hash,
+            NULL::integer[] AS trace_address,
+            l."tx_index" AS evt_index
+        FROM
+            optimism.logs l
+        WHERE contract_address IN (SELECT output_pool FROM sushi_pools)
+        AND topic1 = '\xcd3829a3813dc3cdd188fd3d01dcf3268c16be2fdd2dd21d0665418816e46062' --swap
+
+	AND l.block_time >= start_ts AND l.block_time < end_ts
+    ) dexs
+    INNER JOIN optimism.transactions tx
+        ON dexs.tx_hash = tx.hash
+        AND tx.block_time >= start_ts
+        AND tx.block_time < end_ts
+
+    LEFT JOIN erc20.tokens erc20a ON erc20a.contract_address = dexs.token_a_address
+    LEFT JOIN erc20.tokens erc20b ON erc20b.contract_address = dexs.token_b_address
+    LEFT JOIN prices.approx_prices_from_dex_data pa
+      ON pa.hour = date_trunc('hour', dexs.block_time)
+        AND pa.contract_address = dexs.token_a_address
+        AND pa.hour >= start_ts
+        AND pa.hour < end_ts
+    LEFT JOIN prices.approx_prices_from_dex_data pb
+      ON pb.hour = date_trunc('hour', dexs.block_time)
+        AND pb.contract_address = dexs.token_b_address
+        AND pb.hour >= start_ts
+        AND pb.hour < end_ts
+
+    -- update if we have new info on prices or the erc20
+    ON CONFLICT (project, tx_hash, evt_index, trade_id)
+    DO UPDATE SET
+        usd_amount = EXCLUDED.usd_amount,
+        token_a_amount = EXCLUDED.token_a_amount,
+        token_b_amount = EXCLUDED.token_b_amount,
+        token_a_symbol = EXCLUDED.token_a_symbol,
+        token_b_symbol = EXCLUDED.token_b_symbol
+    RETURNING 1
+)
+SELECT count(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+-- launched may 13, 2022 - give a buffer for testing
+SELECT dex.insert_sushiswap(
+    '2022-05-01',
+    now()
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM dex.trades
+    WHERE block_time > '2022-05-01'
+    AND block_time <= now()
+    AND project = 'Sushiswap'
+);
+/*
+INSERT INTO cron.job (schedule, command)
+VALUES ('15,45 * * * *', $$
+    SELECT dex.insert_sushiswap(
+        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Sushiswap'),
+        now()
+    );
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+*/

--- a/optimism2/dex/insert_velodrome.sql
+++ b/optimism2/dex/insert_velodrome.sql
@@ -73,7 +73,7 @@ SELECT
 	    t.evt_tx_hash AS tx_hash,
 	    NULL::integer[] AS trace_address,
 	    t.evt_index
-	    FROM velodrome."Router_evt_Swap" t
+	    FROM velodrome."Pair_evt_Swap" t
 		 INNER JOIN velodrome."PairFactory_evt_PairCreated" f ON f.pair = t.contract_address
 
 	WHERE t.evt_block_time >= start_ts AND t.evt_block_time < end_ts

--- a/optimism2/dex/insert_velodrome.sql
+++ b/optimism2/dex/insert_velodrome.sql
@@ -119,7 +119,7 @@ SELECT dex.insert_velodrome(
 WHERE NOT EXISTS (
     SELECT *
     FROM dex.trades
-    WHERE block_time > '2022-05-010'
+    WHERE block_time > '2022-05-01'
     AND block_time <= now()
     AND project = 'Velodrome'
 );

--- a/optimism2/dex/insert_velodrome.sql
+++ b/optimism2/dex/insert_velodrome.sql
@@ -1,0 +1,135 @@
+CREATE OR REPLACE FUNCTION dex.insert_velodrome(start_ts timestamptz, end_ts timestamptz=now()) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH rows AS (
+    INSERT INTO dex.trades (
+        block_time,
+        token_a_symbol,
+        token_b_symbol,
+        token_a_amount,
+        token_b_amount,
+        project,
+        version,
+        category,
+        trader_a,
+        trader_b,
+        token_a_amount_raw,
+        token_b_amount_raw,
+        usd_amount,
+        token_a_address,
+        token_b_address,
+        exchange_contract_address,
+        tx_hash,
+        tx_from,
+        tx_to,
+        trace_address,
+        evt_index,
+        trade_id
+    )
+
+SELECT
+    dexs.block_time,
+    erc20a.symbol AS token_a_symbol,
+    erc20b.symbol AS token_b_symbol,
+    token_a_amount_raw / 10 ^ erc20a.decimals AS token_a_amount,
+    token_b_amount_raw / 10 ^ erc20b.decimals AS token_b_amount,
+    project,
+    version,
+    category,
+    coalesce(trader_a, tx."from") as trader_a, -- subqueries rely on this COALESCE to avoid redundant joins with the transactions table
+    trader_b,
+    token_a_amount_raw,
+    token_b_amount_raw,
+    coalesce(
+        usd_amount,
+        token_a_amount_raw / 10 ^ erc20a.decimals * pa.median_price,
+        token_b_amount_raw / 10 ^ erc20b.decimals * pb.median_price
+    ) as usd_amount,
+    token_a_address,
+    token_b_address,
+    exchange_contract_address,
+    tx_hash,
+    tx."from" as tx_from,
+    tx."to" as tx_to,
+    trace_address,
+    evt_index,
+    row_number() OVER (PARTITION BY project, tx_hash, evt_index, trace_address ORDER BY version, category) AS trade_id
+    FROM (
+	    SELECT 
+	    t.evt_block_time AS block_time,
+	    'Velodrome' AS project,
+	    '1' AS version,
+	    'DEX' AS category,
+	    "to" AS trader_a,
+	    NULL::bytea AS trader_b,
+	    -- logic from ethereum/dex/trades/insert_uniswap_v2
+	    CASE WHEN "amount0Out" = 0 THEN "amount1Out" ELSE "amount0Out" END AS token_a_amount_raw,
+	    CASE WHEN "amount0In" = 0 OR "amount1Out" = 0 THEN "amount1In" ELSE "amount0In" END AS token_b_amount_raw,
+	    NULL::numeric AS usd_amount,
+	    CASE WHEN "amount0Out" = 0 THEN token1 ELSE token0 END AS token_a_address,
+	    CASE WHEN "amount0In" = 0 OR "amount1Out" = 0 THEN token1 ELSE token0 END AS token_b_address,
+	    t.contract_address as exchange_contract_address,
+	    t.evt_tx_hash AS tx_hash,
+	    NULL::integer[] AS trace_address,
+	    t.evt_index
+	    FROM velodrome."Router_evt_Swap" t
+		 INNER JOIN velodrome."PairFactory_evt_PairCreated" f ON f.pair = t.contract_address
+
+	WHERE t.evt_block_time >= start_ts AND t.evt_block_time < end_ts
+    ) dexs
+    INNER JOIN optimism.transactions tx
+        ON dexs.tx_hash = tx.hash
+        AND tx.block_time >= start_ts
+        AND tx.block_time < end_ts
+
+    LEFT JOIN erc20.tokens erc20a ON erc20a.contract_address = dexs.token_a_address
+    LEFT JOIN erc20.tokens erc20b ON erc20b.contract_address = dexs.token_b_address
+    LEFT JOIN prices.approx_prices_from_dex_data pa
+      ON pa.hour = date_trunc('hour', dexs.block_time)
+        AND pa.contract_address = dexs.token_a_address
+        AND pa.hour >= start_ts
+        AND pa.hour < end_ts
+    LEFT JOIN prices.approx_prices_from_dex_data pb
+      ON pb.hour = date_trunc('hour', dexs.block_time)
+        AND pb.contract_address = dexs.token_b_address
+        AND pb.hour >= start_ts
+        AND pb.hour < end_ts
+
+    -- update if we have new info on prices or the erc20
+    ON CONFLICT (project, tx_hash, evt_index, trade_id)
+    DO UPDATE SET
+        usd_amount = EXCLUDED.usd_amount,
+        token_a_amount = EXCLUDED.token_a_amount,
+        token_b_amount = EXCLUDED.token_b_amount,
+        token_a_symbol = EXCLUDED.token_a_symbol,
+        token_b_symbol = EXCLUDED.token_b_symbol
+    RETURNING 1
+)
+SELECT count(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+-- launched may 31, 2022 - give a buffer for testing
+SELECT dex.insert_velodrome(
+    '2022-05-01',
+    now()
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM dex.trades
+    WHERE block_time > '2022-05-010'
+    AND block_time <= now()
+    AND project = 'Velodrome'
+);
+/*
+INSERT INTO cron.job (schedule, command)
+VALUES ('15,45 * * * *', $$
+    SELECT dex.insert_velodrome(
+        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Velodrome'),
+        now()
+    );
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+*/

--- a/optimism2/dex/prices_and_trades_inserts.sql
+++ b/optimism2/dex/prices_and_trades_inserts.sql
@@ -23,6 +23,7 @@ VALUES ('15,30,45,59 * * * *', $$
 	SELECT dex.insert_wardenswap( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='WardenSwap' AND version = '2'), now() );
 	SELECT dex.insert_rubicon( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Rubicon'), now() );
 	SELECT dex.insert_velodrome( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Velodrome'), now() );
+	SELECT dex.insert_beethoven_x( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Beethoven X'), now() );
     );
 	--ADD REMAINING DEX INSERTS HERE
 --END DEX Inserts

--- a/optimism2/dex/prices_and_trades_inserts.sql
+++ b/optimism2/dex/prices_and_trades_inserts.sql
@@ -22,6 +22,7 @@ VALUES ('15,30,45,59 * * * *', $$
 	SELECT dex.insert_kwenta( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Kwenta'), now() );
 	SELECT dex.insert_wardenswap( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='WardenSwap' AND version = '2'), now() );
 	SELECT dex.insert_rubicon( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Rubicon'), now() );
+	SELECT dex.insert_velodrome( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Velodrome'), now() );
     );
 	--ADD REMAINING DEX INSERTS HERE
 --END DEX Inserts

--- a/optimism2/dex/prices_and_trades_inserts.sql
+++ b/optimism2/dex/prices_and_trades_inserts.sql
@@ -24,6 +24,7 @@ VALUES ('15,30,45,59 * * * *', $$
 	SELECT dex.insert_rubicon( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Rubicon'), now() );
 	SELECT dex.insert_velodrome( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Velodrome'), now() );
 	SELECT dex.insert_beethoven_x( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Beethoven X'), now() );
+	SELECT dex.insert_sushiswap( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Sushiswap'), now() );
     );
 	--ADD REMAINING DEX INSERTS HERE
 --END DEX Inserts

--- a/optimism2/dex/prices_and_trades_inserts.sql
+++ b/optimism2/dex/prices_and_trades_inserts.sql
@@ -25,6 +25,7 @@ VALUES ('15,30,45,59 * * * *', $$
 	SELECT dex.insert_velodrome( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Velodrome'), now() );
 	SELECT dex.insert_beethoven_x( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Beethoven X'), now() );
 	SELECT dex.insert_sushiswap( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Sushiswap'), now() );
+	SELECT dex.insert_slingshot( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Slingshot'), now() );
     );
 	--ADD REMAINING DEX INSERTS HERE
 --END DEX Inserts

--- a/optimism2/prices/insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/insert_approx_prices_from_dex_data.sql
@@ -29,7 +29,7 @@ chainlink_prices AS (
     AND token_a_amount_raw > 100 -- filter out small spam
     AND block_time >= start_time
     AND block_time < end_time
-AND project IN ('Uniswap','1inch','0x API','Matcha','Zipswap')
+AND project IN ('Uniswap','1inch','0x API','Matcha','Zipswap','Velodrome','Curve')
 	GROUP BY 1,2,3,4,5,6 --remove dupes
 
     UNION ALL
@@ -47,7 +47,7 @@ AND project IN ('Uniswap','1inch','0x API','Matcha','Zipswap')
     AND token_b_amount_raw > 100 -- filter out small spam
     AND block_time >= start_time
     AND block_time < end_time
-AND project IN ('Uniswap','1inch','0x API','Matcha','Zipswap')
+AND project IN ('Uniswap','1inch','0x API','Matcha','Zipswap','Velodrome','Curve')
 	
 	GROUP BY 1,2,3,4,5,6 --remove dupes
 ),

--- a/optimism2/prices/insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/insert_approx_prices_from_dex_data.sql
@@ -32,7 +32,7 @@ chainlink_prices AS (
 AND 1 =
 	(CASE
 	 -- For the following DEXs, grab tokens for all trades
-	 	WHEN project IN ('Uniswap','1inch','0x API','Matcha','Zipswap','Velodrome','Curve','Sushiswap') THEN 1
+	 	WHEN project IN ('Uniswap','1inch','0x API','Matcha','Zipswap','Velodrome','Curve','Sushiswap','Slingshot') THEN 1
 	 -- For Beethoven X, only grab BEETS and BAL for now.
 	 	WHEN project = 'Beethoven X'
 	 		AND
@@ -65,7 +65,7 @@ AND 1 =
 AND 1 =
 	(CASE
 	 -- For the following DEXs, grab tokens for all trades
-	 	WHEN project IN ('Uniswap','1inch','0x API','Matcha','Zipswap','Velodrome','Curve','Sushiswap') THEN 1
+	 	WHEN project IN ('Uniswap','1inch','0x API','Matcha','Zipswap','Velodrome','Curve','Sushiswap','Slingshot') THEN 1
 	 -- For Beethoven X, only grab BEETS and BAL for now.
 	 	WHEN project = 'Beethoven X'
 	 		AND

--- a/optimism2/prices/insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/insert_approx_prices_from_dex_data.sql
@@ -29,7 +29,22 @@ chainlink_prices AS (
     AND token_a_amount_raw > 100 -- filter out small spam
     AND block_time >= start_time
     AND block_time < end_time
-AND project IN ('Uniswap','1inch','0x API','Matcha','Zipswap','Velodrome','Curve')
+AND 1 =
+	(CASE
+	 -- For the following DEXs, grab tokens for all trades
+	 	WHEN project IN ('Uniswap','1inch','0x API','Matcha','Zipswap','Velodrome','Curve') THEN 1
+	 -- For Beethoven X, only grab BEETS and BAL for now.
+	 	WHEN project = 'Beethoven X'
+	 		AND
+	 		(
+				token_a_address IN ('\xFE8B128bA8C78aabC59d4c64cEE7fF28e9379921','\x97513e975a7fA9072c72C92d8000B0dB90b163c5')
+				OR
+				token_b_address IN ('\xFE8B128bA8C78aabC59d4c64cEE7fF28e9379921','\x97513e975a7fA9072c72C92d8000B0dB90b163c5')
+			) THEN 1
+	 ELSE 0
+	 END
+	 )
+	 
 	GROUP BY 1,2,3,4,5,6 --remove dupes
 
     UNION ALL
@@ -47,7 +62,21 @@ AND project IN ('Uniswap','1inch','0x API','Matcha','Zipswap','Velodrome','Curve
     AND token_b_amount_raw > 100 -- filter out small spam
     AND block_time >= start_time
     AND block_time < end_time
-AND project IN ('Uniswap','1inch','0x API','Matcha','Zipswap','Velodrome','Curve')
+AND 1 =
+	(CASE
+	 -- For the following DEXs, grab tokens for all trades
+	 	WHEN project IN ('Uniswap','1inch','0x API','Matcha','Zipswap','Velodrome','Curve') THEN 1
+	 -- For Beethoven X, only grab BEETS and BAL for now.
+	 	WHEN project = 'Beethoven X'
+	 		AND
+	 		(
+				token_a_address IN ('\xFE8B128bA8C78aabC59d4c64cEE7fF28e9379921','\x97513e975a7fA9072c72C92d8000B0dB90b163c5')
+				OR
+				token_b_address IN ('\xFE8B128bA8C78aabC59d4c64cEE7fF28e9379921','\x97513e975a7fA9072c72C92d8000B0dB90b163c5')
+			) THEN 1
+	 ELSE 0
+	 END
+	 )
 	
 	GROUP BY 1,2,3,4,5,6 --remove dupes
 ),

--- a/optimism2/prices/insert_approx_prices_from_dex_data.sql
+++ b/optimism2/prices/insert_approx_prices_from_dex_data.sql
@@ -32,7 +32,7 @@ chainlink_prices AS (
 AND 1 =
 	(CASE
 	 -- For the following DEXs, grab tokens for all trades
-	 	WHEN project IN ('Uniswap','1inch','0x API','Matcha','Zipswap','Velodrome','Curve') THEN 1
+	 	WHEN project IN ('Uniswap','1inch','0x API','Matcha','Zipswap','Velodrome','Curve','Sushiswap') THEN 1
 	 -- For Beethoven X, only grab BEETS and BAL for now.
 	 	WHEN project = 'Beethoven X'
 	 		AND
@@ -65,7 +65,7 @@ AND 1 =
 AND 1 =
 	(CASE
 	 -- For the following DEXs, grab tokens for all trades
-	 	WHEN project IN ('Uniswap','1inch','0x API','Matcha','Zipswap','Velodrome','Curve') THEN 1
+	 	WHEN project IN ('Uniswap','1inch','0x API','Matcha','Zipswap','Velodrome','Curve','Sushiswap') THEN 1
 	 -- For Beethoven X, only grab BEETS and BAL for now.
 	 	WHEN project = 'Beethoven X'
 	 		AND


### PR DESCRIPTION
Adds:
- Velodrome in dex.trades (Still waiting on 'PairFactory' data to come through, otherwise ready to go)
- Beethoven X (Balancer V2 deployment)
- Sushiswap (Trident deployment)
- Slingshot

Other:
- Add Velodrome, Sushiswap, Slingshot, and Curve as a token prices source
- Add Beethoven X as a token prices source for BEETS and BAL (will monitor for other tokens)

I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
