### PR TITLE
Add AUDIO price abstraction

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -2111,3 +2111,8 @@
   symbol: GCR
   address: 0x6307B25A665Efc992EC1C1bC403c38F3dDd7c661
   decimals: 4
+- name: audio_audius
+  id: audio-audius
+  symbol: AUDIO
+  address: 0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998
+  decimals: 18


### PR DESCRIPTION
Add AUDIO price abstraction to coinpaprika.yaml

I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
