### PR TITLE
import $Space token for thespace.game

### DIFF
--- a/polygon/erc20/tokens.sql
+++ b/polygon/erc20/tokens.sql
@@ -176,6 +176,7 @@ COPY erc20.tokens (contract_address, symbol, decimals) FROM stdin;
 \\x430ef9263e76dae63c84292c3409d61c598e9682	PYR	18
 \\x7c28f627ea3aec8b882b51eb1935f66e5b875714	PAINT	18
 \\x8d1566569d5b695d44a9a234540f68d393cdc40d	GAME	18
+\\x264808855b0a6a5a318d238c6ee9f299179f27fc	SPACE	18
 \.
 
 


### PR DESCRIPTION
from https://wiki.thespace.game/addresses

Inspired by r/place, The Space is the world’s NFT pixel art graffiti wall where players can own, color, and trade pixels under Harberger Tax and Universal Basic Income (UBI). Pixels are minted as ERC-721 tokens on Polygon, and are fractional NFTs under common ownership.

I've checked that:

* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`

please let me know what else can I do to be able query analysis for $Space token already traded on Uniswap and others

Thanks