### PR TITLE
change alter_table and optimize macros for erc721 balances/transfers

### DIFF
--- a/spellbook/macros/alter_table_properties.sql
+++ b/spellbook/macros/alter_table_properties.sql
@@ -28,6 +28,33 @@ ALTER VIEW balances_ethereum.erc20_latest SET TBLPROPERTIES('dune.public'='true'
                                                     'dune.data_explorer.contributors'='["soispoke","dot2dotseurat"]');
 {% endset %}
 
+{% set balances_ethereum_erc721_day %}
+ALTER VIEW balances_ethereum.erc721_day SET TBLPROPERTIES('dune.public'='true',
+                                                    'dune.data_explorer.blockchains'='["ethereum"]',
+                                                    'dune.data_explorer.category'='abstraction',
+                                                    'dune.data_explorer.abstraction.type'='sector',
+                                                    'dune.data_explorer.abstraction.name'='balances',
+                                                    'dune.data_explorer.contributors'='["soispoke","dot2dotseurat"]');
+{% endset %}
+
+{% set balances_ethereum_erc721_hour %}
+ALTER VIEW balances_ethereum.erc721_hour SET TBLPROPERTIES('dune.public'='true',
+                                                    'dune.data_explorer.blockchains'='["ethereum"]',
+                                                    'dune.data_explorer.category'='abstraction',
+                                                    'dune.data_explorer.abstraction.type'='sector',
+                                                    'dune.data_explorer.abstraction.name'='balances',
+                                                    'dune.data_explorer.contributors'='["soispoke","dot2dotseurat"]');
+{% endset %}
+
+{% set balances_ethereum_erc721_latest %}
+ALTER VIEW balances_ethereum.erc721_latest SET TBLPROPERTIES('dune.public'='true',
+                                                    'dune.data_explorer.blockchains'='["ethereum"]',
+                                                    'dune.data_explorer.category'='abstraction',
+                                                    'dune.data_explorer.abstraction.type'='sector',
+                                                    'dune.data_explorer.abstraction.name'='balances',
+                                                    'dune.data_explorer.contributors'='["soispoke","dot2dotseurat"]');
+{% endset %}
+
 {% set magiceden_trades %}
 ALTER VIEW magiceden.trades SET TBLPROPERTIES('dune.public'='true',
                                                     'dune.data_explorer.blockchains'='["solana"]',
@@ -118,8 +145,12 @@ ALTER VIEW uniswap_ethereum.trades SET TBLPROPERTIES('dune.public'='true',
                                                     'dune.data_explorer.contributors'='["soispoke"]');
 {% endset %}
 
+{% do run_query(balances_ethereum_erc20_day) %}
 {% do run_query(balances_ethereum_erc20_hour) %}
 {% do run_query(balances_ethereum_erc20_latest) %}
+{% do run_query(balances_ethereum_erc721_day) %}
+{% do run_query(balances_ethereum_erc721_hour) %}
+{% do run_query(balances_ethereum_erc721_latest) %}
 {% do run_query(magiceden_trades) %}
 {% do run_query(nft_trades) %}
 {% do run_query(opensea_active_traders_day) %}

--- a/spellbook/macros/optimize_tables.sql
+++ b/spellbook/macros/optimize_tables.sql
@@ -8,6 +8,14 @@ OPTIMIZE transfers_ethereum.erc20_agg_hour;
 OPTIMIZE transfers_ethereum.erc20_agg_day;
 {% endset %}
 
+{% set transfers_ethereum_erc721_agg_hour %}
+OPTIMIZE transfers_ethereum.erc721_agg_hour;
+{% endset %}
+
+{% set transfers_ethereum_erc721_agg_day %}
+OPTIMIZE transfers_ethereum.erc721_agg_day;
+{% endset %}
+
 {% set opensea_ethereum_trades %}
 OPTIMIZE opensea_ethereum.trades;
 {% endset %}
@@ -30,6 +38,8 @@ OPTIMIZE uniswap_v3_ethereum.trades;
 
 {% do run_query(transfers_ethereum_erc20_agg_hour) %}
 {% do run_query(transfers_ethereum_erc20_agg_day) %}
+{% do run_query(transfers_ethereum_erc721_agg_hour) %}
+{% do run_query(transfers_ethereum_erc721_agg_day) %}
 {% do run_query(opensea_ethereum_trades) %}
 {% do run_query(opensea_solana_trades) %}
 {% do run_query(magiceden_solana_trades) %}


### PR DESCRIPTION
This PR modifies:
- The macro alter_table_properties() to give metadata and expose the erc721 balances tables
- The macro optimize_tables() to run optimize on incremental erc721 transfers tables
Tagging @hildobby so you can see how we handle this :) 

I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
