### PR TITLE
update schema generation macro

### DIFF
--- a/spellbook/macros/generate_schema_name.sql
+++ b/spellbook/macros/generate_schema_name.sql
@@ -1,7 +1,7 @@
 {% macro generate_schema_name(custom_schema_name, node) -%}
 
     {%- set default_schema = target.schema -%}
-    {%- if target.name == 'prod' or target.name == 'wizard' and custom_schema_name is not none -%}
+    {%- if target.name == 'prod' or target.schema == 'wizard' and custom_schema_name is not none -%}
 
         {{ custom_schema_name | trim }}
 


### PR DESCRIPTION
Small change to the generate_schema_name macro. Wizard is the target.schema not target.name. This update should result in no pre-pended personal schemas for wizards. 

N/A below
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
