### PR TITLE
Change materialization for nft/uniswap trades

### DIFF
--- a/spellbook/models/magiceden/magiceden_trades.sql
+++ b/spellbook/models/magiceden/magiceden_trades.sql
@@ -1,10 +1,14 @@
 {{ config(
-        alias='trades'
+        alias='trades',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_id'
         )
 }}
 
-SELECT blockchain, 'magiceden' as project, '' as version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id FROM 
+SELECT blockchain, 'magiceden' as project, '' as version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id, unique_id FROM 
 (
-        SELECT blockchain, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id 
+        SELECT blockchain, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id, unique_id
         FROM {{ ref('magiceden_solana_trades') }}
 ) 

--- a/spellbook/models/magiceden/solana/magiceden_solana_trades.sql
+++ b/spellbook/models/magiceden/solana/magiceden_solana_trades.sql
@@ -1,10 +1,6 @@
  {{
   config(
-        alias='trades',
-        materialized ='incremental',
-        file_format ='delta',
-        incremental_strategy='merge',
-        unique_key='unique_id'
+        alias='trades'
   )
 }}
 

--- a/spellbook/models/nft/nft_trades.sql
+++ b/spellbook/models/nft/nft_trades.sql
@@ -1,12 +1,16 @@
 {{ config(
-        alias='trades'
+        alias='trades',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_id'
         )
 }}
 
-SELECT blockchain, project, version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address,trade_id FROM 
-(SELECT blockchain, project, version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id FROM {{ ref('opensea_trades') }} 
+SELECT blockchain, project, version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address,trade_id, unique_id FROM 
+(SELECT blockchain, project, version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id, unique_id FROM {{ ref('opensea_trades') }} 
 UNION ALL
-SELECT blockchain, project, version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id FROM {{ ref('magiceden_trades') }}) 
+SELECT blockchain, project, version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id, unique_id FROM {{ ref('magiceden_trades') }}) 
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
 where block_time > (select max(block_time) from {{ this }})

--- a/spellbook/models/opensea/ethereum/opensea_ethereum_trades.sql
+++ b/spellbook/models/opensea/ethereum/opensea_ethereum_trades.sql
@@ -1,10 +1,6 @@
  {{
   config(
-        alias='trades',
-        materialized ='incremental',
-        file_format ='delta',
-        incremental_strategy='merge',
-        unique_key='unique_id'
+        alias='trades'
   )
 }}
 

--- a/spellbook/models/opensea/opensea_trades.sql
+++ b/spellbook/models/opensea/opensea_trades.sql
@@ -1,9 +1,13 @@
 {{ config(
-        alias='trades'
+        alias='trades',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_id'
         )
 }}
 
-SELECT blockchain, 'opensea' as project, 'v1' as version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id FROM 
-(SELECT blockchain, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id FROM {{ ref('opensea_ethereum_trades') }} 
+SELECT blockchain, 'opensea' as project, 'v1' as version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id, unique_id FROM 
+(SELECT blockchain, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id, unique_id FROM {{ ref('opensea_ethereum_trades') }} 
 UNION ALL
-SELECT blockchain, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id FROM {{ ref('opensea_solana_trades') }}) 
+SELECT blockchain, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id, unique_id FROM {{ ref('opensea_solana_trades') }}) 

--- a/spellbook/models/opensea/solana/opensea_solana_trades.sql
+++ b/spellbook/models/opensea/solana/opensea_solana_trades.sql
@@ -1,10 +1,6 @@
  {{
   config(
-        alias='trades',
-        materialized ='incremental',
-        file_format ='delta',
-        incremental_strategy='merge',
-        unique_key='unique_id'
+        alias='trades'
   )
 }}
 

--- a/spellbook/models/uniswap/ethereum/uniswap_ethereum_trades.sql
+++ b/spellbook/models/uniswap/ethereum/uniswap_ethereum_trades.sql
@@ -1,12 +1,16 @@
  {{
   config(
-        alias='trades'
+        alias='trades',        
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_id'
   )
 }}
 
 SELECT blockchain, project, version, block_time, token_a_symbol, token_b_symbol, 
        token_a_amount, token_b_amount, trader_a, trader_b, usd_amount, token_a_address, 
-       token_b_address, exchange_contract_address, tx_hash, tx_from, tx_to, trade_id 
+       token_b_address, exchange_contract_address, tx_hash, tx_from, tx_to, trade_id, unique_id
 FROM (SELECT * FROM {{ ref('uniswap_v2_ethereum_trades') }} 
 UNION ALL
 SELECT * FROM {{ ref('uniswap_v3_ethereum_trades') }}) 

--- a/spellbook/models/uniswap/ethereum/uniswap_v2_ethereum_trades.sql
+++ b/spellbook/models/uniswap/ethereum/uniswap_v2_ethereum_trades.sql
@@ -1,11 +1,7 @@
  {{
   config(
         schema = 'uniswap_v2_ethereum', 
-        alias='trades',
-        materialized ='incremental',
-        file_format ='delta',
-        incremental_strategy='merge',
-        unique_key='unique_id'
+        alias='trades'
   )
 }}
 

--- a/spellbook/models/uniswap/ethereum/uniswap_v3_ethereum_trades.sql
+++ b/spellbook/models/uniswap/ethereum/uniswap_v3_ethereum_trades.sql
@@ -1,9 +1,5 @@
 {{config(schema = 'uniswap_v3_ethereum', 
-        alias='trades',
-        materialized ='incremental',
-        file_format ='delta',
-        incremental_strategy='merge',
-        unique_key='unique_id')
+        alias='trades')
 }}
         
 SELECT


### PR DESCRIPTION
This PR improves both create and query speed by changing the materialization strategy for nft and dex trades:
Here is an example for uniswap, but the same logic applies to nft trades (e.g., opensea_ethereum_trades and opensea_solana_trades UNIONed ALL to give opensea_trades)

Before:
uniswap_v2_trades                 uniswap_v3_trades
     Incr. Table                                   Incr. Table
                  
                          uniswap_trades
                                 View

Now:
uniswap_v2_trades                 uniswap_v3_trades
           View                                          View
                  
                          uniswap_trades
                                 Incr. Table


I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
