### PR TITLE
Revert "Change materialization for nft/uniswap trades (#1141)"

### DIFF
--- a/spellbook/dbt_project.yml
+++ b/spellbook/dbt_project.yml
@@ -99,7 +99,7 @@ seeds:
         +schema: test_data
         opensea_ethereum_trades_postgres:
           +column_types:
-            evt_block_times: timestamp
+            evt_block_time: timestamp
             evt_tx_hash: string
             price: string
       solana:

--- a/spellbook/models/magiceden/magiceden_trades.sql
+++ b/spellbook/models/magiceden/magiceden_trades.sql
@@ -1,14 +1,10 @@
 {{ config(
-        alias='trades',
-        materialized ='incremental',
-        file_format ='delta',
-        incremental_strategy='merge',
-        unique_key='unique_id'
+        alias='trades'
         )
 }}
 
-SELECT blockchain, 'magiceden' as project, '' as version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id, unique_id FROM 
+SELECT blockchain, 'magiceden' as project, '' as version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id FROM 
 (
-        SELECT blockchain, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id, unique_id
+        SELECT blockchain, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id 
         FROM {{ ref('magiceden_solana_trades') }}
 ) 

--- a/spellbook/models/magiceden/solana/magiceden_solana_trades.sql
+++ b/spellbook/models/magiceden/solana/magiceden_solana_trades.sql
@@ -1,6 +1,10 @@
  {{
   config(
-        alias='trades'
+        alias='trades',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_id'
   )
 }}
 

--- a/spellbook/models/nft/nft_trades.sql
+++ b/spellbook/models/nft/nft_trades.sql
@@ -1,16 +1,12 @@
 {{ config(
-        alias='trades',
-        materialized ='incremental',
-        file_format ='delta',
-        incremental_strategy='merge',
-        unique_key='unique_id'
+        alias='trades'
         )
 }}
 
-SELECT blockchain, project, version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address,trade_id, unique_id FROM 
-(SELECT blockchain, project, version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id, unique_id FROM {{ ref('opensea_trades') }} 
+SELECT blockchain, project, version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address,trade_id FROM 
+(SELECT blockchain, project, version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id FROM {{ ref('opensea_trades') }} 
 UNION ALL
-SELECT blockchain, project, version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id, unique_id FROM {{ ref('magiceden_trades') }}) 
+SELECT blockchain, project, version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id FROM {{ ref('magiceden_trades') }}) 
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
 where block_time > (select max(block_time) from {{ this }})

--- a/spellbook/models/opensea/ethereum/opensea_ethereum_trades.sql
+++ b/spellbook/models/opensea/ethereum/opensea_ethereum_trades.sql
@@ -1,6 +1,10 @@
  {{
   config(
-        alias='trades'
+        alias='trades',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_id'
   )
 }}
 

--- a/spellbook/models/opensea/opensea_trades.sql
+++ b/spellbook/models/opensea/opensea_trades.sql
@@ -1,13 +1,9 @@
 {{ config(
-        alias='trades',
-        materialized ='incremental',
-        file_format ='delta',
-        incremental_strategy='merge',
-        unique_key='unique_id'
+        alias='trades'
         )
 }}
 
-SELECT blockchain, 'opensea' as project, 'v1' as version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id, unique_id FROM 
-(SELECT blockchain, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id, unique_id FROM {{ ref('opensea_ethereum_trades') }} 
+SELECT blockchain, 'opensea' as project, 'v1' as version, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id FROM 
+(SELECT blockchain, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id FROM {{ ref('opensea_ethereum_trades') }} 
 UNION ALL
-SELECT blockchain, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id, unique_id FROM {{ ref('opensea_solana_trades') }}) 
+SELECT blockchain, tx_hash, block_time, amount_usd, amount, token_symbol, token_address, trade_id FROM {{ ref('opensea_solana_trades') }}) 

--- a/spellbook/models/opensea/solana/opensea_solana_trades.sql
+++ b/spellbook/models/opensea/solana/opensea_solana_trades.sql
@@ -1,6 +1,10 @@
  {{
   config(
-        alias='trades'
+        alias='trades',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_id'
   )
 }}
 

--- a/spellbook/models/uniswap/ethereum/uniswap_ethereum_trades.sql
+++ b/spellbook/models/uniswap/ethereum/uniswap_ethereum_trades.sql
@@ -1,16 +1,12 @@
  {{
   config(
-        alias='trades',        
-        materialized ='incremental',
-        file_format ='delta',
-        incremental_strategy='merge',
-        unique_key='unique_id'
+        alias='trades'
   )
 }}
 
 SELECT blockchain, project, version, block_time, token_a_symbol, token_b_symbol, 
        token_a_amount, token_b_amount, trader_a, trader_b, usd_amount, token_a_address, 
-       token_b_address, exchange_contract_address, tx_hash, tx_from, tx_to, trade_id, unique_id
+       token_b_address, exchange_contract_address, tx_hash, tx_from, tx_to, trade_id 
 FROM (SELECT * FROM {{ ref('uniswap_v2_ethereum_trades') }} 
 UNION ALL
 SELECT * FROM {{ ref('uniswap_v3_ethereum_trades') }}) 

--- a/spellbook/models/uniswap/ethereum/uniswap_v2_ethereum_trades.sql
+++ b/spellbook/models/uniswap/ethereum/uniswap_v2_ethereum_trades.sql
@@ -1,7 +1,11 @@
  {{
   config(
         schema = 'uniswap_v2_ethereum', 
-        alias='trades'
+        alias='trades',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_id'
   )
 }}
 

--- a/spellbook/models/uniswap/ethereum/uniswap_v3_ethereum_trades.sql
+++ b/spellbook/models/uniswap/ethereum/uniswap_v3_ethereum_trades.sql
@@ -1,5 +1,9 @@
 {{config(schema = 'uniswap_v3_ethereum', 
-        alias='trades')
+        alias='trades',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_id')
 }}
         
 SELECT


### PR DESCRIPTION
Ok so I thought the change of materialization, but for some (very obscure) reasons the magiceden trades take forever to create a table so it's probably best to revert this so we're back to normal (and running), and then investigate further why magiceden won't work properly

This reverts commit 0356bd532cb353af15c429af1e2355d1bb5dfa8b.

I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
