### PR TITLE
Update insert_1inch.sql

### DIFF
--- a/polygon/dex/trades/insert_1inch.sql
+++ b/polygon/dex/trades/insert_1inch.sql
@@ -27,12 +27,12 @@ WITH rows AS (
         evt_index,
         trade_id
     )
-    SELECT
+        SELECT
         dexs.block_time,
-        pa.symbol AS token_a_symbol,
-        pb.symbol AS token_b_symbol,
-        token_a_amount_raw / 10 ^ pa.decimals AS token_a_amount,
-        token_b_amount_raw / 10 ^ pb.decimals AS token_b_amount,
+        erc20a.symbol AS token_a_symbol,
+        erc20b.symbol AS token_b_symbol,
+        token_a_amount_raw / 10 ^ erc20a.decimals AS token_a_amount,
+        token_b_amount_raw / 10 ^ erc20b.decimals AS token_b_amount,
         project,
         version,
         category,
@@ -53,55 +53,276 @@ WITH rows AS (
         tx."to" as tx_to,
         trace_address,
         evt_index,
-        row_number() OVER (PARTITION BY project, tx_hash, trace_address  ORDER BY version, category) AS trade_id
+        row_number() OVER (PARTITION BY project, tx_hash, evt_index, trace_address ORDER BY version, category) AS trade_id
     FROM (
-        -- 1inch v3
+
         SELECT
-            evt_block_time AS block_time,
+            oi.block_time,
             '1inch' AS project,
-            '3' AS version,
+            version,
             'Aggregator' AS category,
-            sender AS trader_a,
+            tx."from" AS trader_a,
             NULL::bytea AS trader_b,
-            "returnAmount" AS token_a_amount_raw,
-            "spentAmount" AS token_b_amount_raw,
+            to_amount AS token_a_amount_raw,
+            from_amount AS token_b_amount_raw,
             NULL::numeric AS usd_amount,
-            (CASE WHEN "dstToken" = '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '\x0000000000000000000000000000000000001010' ELSE "dstToken" END) AS token_a_address,
-            (CASE WHEN "srcToken" = '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '\x0000000000000000000000000000000000001010' ELSE "srcToken" END) AS token_b_address,
+            (CASE WHEN to_token = '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '\x0000000000000000000000000000000000001010' ELSE to_token END) AS token_a_address,
+            (CASE WHEN from_token = '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '\x0000000000000000000000000000000000001010' ELSE from_token END) AS token_b_address,
             contract_address AS exchange_contract_address,
-            evt_tx_hash AS tx_hash,
-            evt_index,
-            NULL::integer[] AS trace_address
-        FROM oneinch."OneInchExchange_evt_Swapped"
+            tx_hash,
+            trace_address,
+            evt_index
+        FROM (
+            SELECT "srcToken" as from_token, "dstToken" as to_token, "spentAmount" as from_amount, "returnAmount" as to_amount, evt_tx_hash as tx_hash, evt_block_time as block_time, NULL::integer[] as trace_address, evt_index, contract_address, '3' as version FROM oneinch."OneInchExchange_evt_Swapped" WHERE evt_block_time >= start_ts AND evt_block_time < end_ts UNION ALL
+            SELECT decode(substring("desc"->>'srcToken' FROM 3), 'hex') as from_token, decode(substring("desc"->>'dstToken' FROM 3), 'hex') as to_token, ("desc"->>'amount')::numeric as from_amount, "output_returnAmount" as to_amount, call_tx_hash as tx_hash, call_block_time as block_time, call_trace_address, NULL::integer as evt_index, contract_address, '4' as version FROM oneinch_v4."AggregationRouterV4_call_swap" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts
+        ) oi
+        left join polygon.transactions tx on hash = tx_hash
+        WHERE tx.block_time >= start_ts
+        AND tx.block_time < end_ts
+
+        UNION ALL
+
+        -- 1inch Unoswap
+        SELECT
+            call_block_time as block_time,
+            '1inch' AS project,
+            'UNI v2' AS version,
+            'Aggregator' AS category,
+            tx."from" AS trader_a,
+            NULL::bytea AS trader_b,
+            "output_returnAmount" AS token_a_amount_raw,
+            "amount" AS token_b_amount_raw,
+            NULL::numeric AS usd_amount,
+            ll.to AS token_a_address,
+            (CASE WHEN "srcToken" = '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '\x0000000000000000000000000000000000001010' ELSE "srcToken" END) AS token_b_address,
+            us.contract_address AS exchange_contract_address,
+            call_tx_hash,
+            call_trace_address AS trace_address,
+            NULL::integer AS evt_index
+        FROM (
+            select "output_returnAmount", "amount", "srcToken", "_3" as pools, "call_tx_hash", "call_trace_address", "call_block_time", "contract_address" from oneinch."OneInchExchange_call_unoswap" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts union all
+            select "output_returnAmount", "amount", "srcToken", "pools", "call_tx_hash", "call_trace_address", "call_block_time", "contract_address" from oneinch."OneInchExchange_call_unoswapWithPermit" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts
+            UNION ALL
+            select "output_returnAmount", "amount", "srcToken", "pools", "call_tx_hash", "call_trace_address", "call_block_time", "contract_address" from oneinch_v4."AggregationRouterV4_call_unoswap"  where call_success AND call_block_time >= start_ts AND call_block_time < end_ts union all
+            select "output_returnAmount", "amount", "srcToken", "pools", "call_tx_hash", "call_trace_address", "call_block_time", "contract_address" from oneinch_v4."AggregationRouterV4_call_unoswapWithPermit"  where call_success AND call_block_time >= start_ts AND call_block_time < end_ts
+        ) us
+        LEFT JOIN polygon.transactions tx ON tx.hash = us.call_tx_hash
+        LEFT JOIN polygon.traces tr ON tr.tx_hash = us.call_tx_hash AND tr.trace_address = us.call_trace_address[:ARRAY_LENGTH(us.call_trace_address, 1)-1]
+        LEFT JOIN polygon.traces ll ON ll.tx_hash = us.call_tx_hash AND ll.trace_address = (us.call_trace_address || (ARRAY_LENGTH("pools", 1)*2 + CASE WHEN "srcToken" = '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN 1 ELSE 0 END) || 0)
+        WHERE tx.block_time >= start_ts
+        AND tx.block_time < end_ts
+        AND tr.block_time >= start_ts
+        AND tr.block_time < end_ts
+        AND ll.block_time >= start_ts
+        AND ll.block_time < end_ts
+        
         
         UNION ALL
 
-        -- 1inch v4
+        -- 1inch Uniswap V3 Router
         SELECT
-            evt_block_time AS block_time,
+            call_block_time as block_time,
             '1inch' AS project,
-            '4' AS version,
+            'UNI v3' AS version,
             'Aggregator' AS category,
-            sender AS trader_a,
+            tx."from" AS trader_a,
             NULL::bytea AS trader_b,
-            "returnAmount" AS token_a_amount_raw,
-            "spentAmount" AS token_b_amount_raw,
+            "output_returnAmount" AS token_a_amount_raw,
+            "amount" AS token_b_amount_raw,
             NULL::numeric AS usd_amount,
-            (CASE WHEN "dstToken" = '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '\x0000000000000000000000000000000000001010' ELSE "dstToken" END) AS token_a_address,
-            (CASE WHEN "srcToken" = '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '\x0000000000000000000000000000000000001010' ELSE "srcToken" END) AS token_b_address,
-            contract_address AS exchange_contract_address,
-            evt_tx_hash AS tx_hash,
-            evt_index,
-            NULL::integer[] AS trace_address
-        FROM oneinch_v4."AggregationRouterV4_evt_Swapped"
+            "dstToken" AS token_a_address,
+            "srcToken" AS token_b_address,
+            us.contract_address AS exchange_contract_address,
+            call_tx_hash,
+            call_trace_address AS trace_address,
+            NULL::integer AS evt_index
+        FROM (
+            select 
+                "output_returnAmount", "amount",
+                COALESCE((select tr1.to from
+                    polygon.traces tr1 where call_type = 'call' and tr1.tx_hash = call_tx_hash and substring(tr1.input from 1 for 4) = '\x23b872dd'
+                    and COALESCE(call_trace_address, array[]::int[]) = tr1.trace_address[:COALESCE(ARRAY_LENGTH(call_trace_address, 1), 0)]
+                    and COALESCE(ARRAY_LENGTH(call_trace_address, 1), 0) + 3 = COALESCE(ARRAY_LENGTH(tr1.trace_address, 1), 0)
+                    order by COALESCE(trace_address, array[]::int[])
+                    LIMIT 1
+                ), '\x0000000000000000000000000000000000001010') as "srcToken",
+                CASE WHEN ((pools[array_length(pools, 1)] / 2^252)::int & 2 <> 0) THEN '\x0000000000000000000000000000000000001010'
+                ELSE
+                    (select tr2.to from
+                        polygon.traces tr2 where call_type = 'call' and tr2.tx_hash = call_tx_hash and substring(tr2.input from 1 for 4) = '\xa9059cbb'
+                        and COALESCE(call_trace_address, array[]::int[]) = tr2.trace_address[:COALESCE(ARRAY_LENGTH(call_trace_address, 1), 0)]
+                        and COALESCE(ARRAY_LENGTH(call_trace_address, 1), 0) + 2 = COALESCE(ARRAY_LENGTH(tr2.trace_address, 1), 0)
+                        and tr2.from <> contract_address
+                        order by COALESCE(trace_address, array[]::int[]) desc
+                        LIMIT 1
+                    )
+                END as "dstToken",
+                "pools", "call_tx_hash", "call_trace_address", "call_block_time", "contract_address"
+            from (
+                select "output_returnAmount", "amount", "pools", "call_tx_hash", "call_trace_address", "call_block_time", "contract_address" from oneinch_v4."AggregationRouterV4_call_uniswapV3Swap" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts union all
+                select "output_returnAmount", "amount", "pools", "call_tx_hash", "call_trace_address", "call_block_time", "contract_address" from oneinch_v4."AggregationRouterV4_call_uniswapV3SwapTo" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts union all
+                select "output_returnAmount", "amount", "pools", "call_tx_hash", "call_trace_address", "call_block_time", "contract_address" from oneinch_v4."AggregationRouterV4_call_uniswapV3SwapToWithPermit" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts
+            ) sw
+        ) us
+        LEFT JOIN polygon.transactions tx ON tx.hash = us.call_tx_hash
+        WHERE tx.block_time >= start_ts
+        AND tx.block_time < end_ts
         
+        UNION ALL
+
+        -- 1inch Limit Order Protocol
+        SELECT
+            call_block_time as block_time,
+            '1inch Limit Order Protocol' AS project,
+            version,
+            'DEX' AS category,
+            "from"  AS trader_a,
+            maker AS trader_b,
+            "output_1" AS token_a_amount_raw,
+            "output_0" AS token_b_amount_raw,
+            NULL::numeric AS usd_amount,
+            decode(substring("order"::jsonb->>'takerAsset' from 3), 'hex') AS token_a_address,
+            decode(substring("order"::jsonb->>'makerAsset' from 3), 'hex') AS token_b_address,
+            contract_address AS exchange_contract_address,
+            call_tx_hash,
+            call_trace_address,
+            NULL AS evt_index
+        FROM (
+            select '1' as version, decode(substring("order"::jsonb->>'makerAssetData' from 35 for 40), 'hex') as maker, contract_address, "order", output_0, output_1, call_block_time, call_tx_hash, call_trace_address from oneinch_lop."LimitOrderProtocol_call_fillOrder" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts union all
+            select '2' as version, decode(substring("order"::jsonb->>'maker' from 3 for 40), 'hex') as maker, contract_address, "order", output_0, output_1, call_block_time, call_tx_hash, call_trace_address from oneinch_lop_v2."LimitOrderProtocol_V2_call_fillOrder" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts union all
+            select '2' as version, decode(substring("order"::jsonb->>'maker' from 3 for 40), 'hex') as maker, contract_address, "order", output_0, output_1, call_block_time, call_tx_hash, call_trace_address from oneinch_lop_v2."LimitOrderProtocol_V2_call_fillOrderTo" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts union all
+            select '2' as version, decode(substring("order"::jsonb->>'maker' from 3 for 40), 'hex') as maker, contract_address, "order", output_0, output_1, call_block_time, call_tx_hash, call_trace_address from oneinch_lop_v2."LimitOrderProtocol_V2_call_fillOrderToWithPermit" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts
+        ) call
+        LEFT JOIN polygon.traces ts ON call_tx_hash = ts.tx_hash AND call_trace_address = ts.trace_address
+        WHERE ts.block_time >= start_ts
+        AND ts.block_time < end_ts
+        
+        UNION ALL
+
+        -- 1inch Limit Order Protocol Embedded RFQ v1
+        SELECT
+            call_block_time as block_time,
+            '1inch Limit Order Protocol' AS project,
+            'eRFQ v1' AS version,
+            'DEX' AS category,
+            "from"  AS trader_a,
+            decode(substring("order"::jsonb->>'maker' from 3), 'hex') AS trader_b,
+            "output_1" AS token_a_amount_raw,
+            "output_0" AS token_b_amount_raw,
+            NULL::numeric AS usd_amount,
+            decode(substring("order"::jsonb->>'takerAsset' from 3), 'hex') AS token_a_address,
+            decode(substring("order"::jsonb->>'makerAsset' from 3), 'hex') AS token_b_address,
+            contract_address AS exchange_contract_address,
+            call_tx_hash,
+            trace_address,
+            NULL AS evt_index
+        FROM (
+            select "call_block_time", "order", "output_0", "output_1", "contract_address", "call_tx_hash", "call_trace_address" from oneinch_v4."AggregationRouterV4_call_fillOrderRFQ" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts union all
+            select "call_block_time", "order", "output_0", "output_1", "contract_address", "call_tx_hash", "call_trace_address" from oneinch_v4."AggregationRouterV4_call_fillOrderRFQTo" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts union all
+            select "call_block_time", "order", "output_0", "output_1", "contract_address", "call_tx_hash", "call_trace_address" from oneinch_v4."AggregationRouterV4_call_fillOrderRFQToWithPermit" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts
+        ) tt
+        LEFT JOIN polygon.traces ts ON call_tx_hash = ts.tx_hash AND call_trace_address = ts.trace_address
+        WHERE ts.block_time >= start_ts
+        AND ts.block_time < end_ts
+        
+        UNION ALL
+
+        -- 1inch Embedded RFQ v1
+        SELECT
+            call_block_time as block_time,
+            '1inch' AS project,
+            'eRFQ v1' AS version,
+            'Aggregator' AS category,
+            "from"  AS trader_a,
+            decode(substring("order"::jsonb->>'maker' from 3), 'hex') AS trader_b,
+            "output_1" AS token_a_amount_raw,
+            "output_0" AS token_b_amount_raw,
+            NULL::numeric AS usd_amount,
+            decode(substring("order"::jsonb->>'takerAsset' from 3), 'hex') AS token_a_address,
+            decode(substring("order"::jsonb->>'makerAsset' from 3), 'hex') AS token_b_address,
+            contract_address AS exchange_contract_address,
+            call_tx_hash,
+            trace_address,
+            NULL AS evt_index
+        FROM (
+            select "call_block_time", "order", "output_0", "output_1", "contract_address", "call_tx_hash", "call_trace_address" from oneinch_v4."AggregationRouterV4_call_fillOrderRFQ" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts union all
+            select "call_block_time", "order", "output_0", "output_1", "contract_address", "call_tx_hash", "call_trace_address" from oneinch_v4."AggregationRouterV4_call_fillOrderRFQTo" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts union all
+            select "call_block_time", "order", "output_0", "output_1", "contract_address", "call_tx_hash", "call_trace_address" from oneinch_v4."AggregationRouterV4_call_fillOrderRFQToWithPermit" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts
+        ) tt
+        LEFT JOIN polygon.traces ts ON call_tx_hash = ts.tx_hash AND call_trace_address = ts.trace_address
+        WHERE ts.block_time >= start_ts
+        AND ts.block_time < end_ts
+        
+        UNION ALL
+
+        -- 1inch Limit Order Protocol RFQ v1
+        SELECT
+            call_block_time as block_time,
+            '1inch Limit Order Protocol' AS project,
+            'RFQ v1' AS version,
+            'DEX' AS category,
+            ts."from"  AS trader_a,
+            decode(substring("order"::jsonb->>'makerAssetData' from 35 for 40), 'hex') AS trader_b,
+            bytea2numeric(substring(tf2.input from 69 for 32)) AS token_a_amount_raw,
+            bytea2numeric(substring(tf1.input from 69 for 32)) AS token_b_amount_raw,
+            NULL::numeric AS usd_amount,
+            decode(substring("order"::jsonb->>'takerAsset' from 3), 'hex') AS token_a_address,
+            decode(substring("order"::jsonb->>'makerAsset' from 3), 'hex') AS token_b_address,
+            contract_address AS exchange_contract_address,
+            call_tx_hash,
+            call_trace_address,
+            NULL AS evt_index
+        FROM oneinch_lop."LimitOrderProtocol_call_fillOrderRFQ" call 
+        LEFT JOIN polygon.traces ts ON call_tx_hash = ts.tx_hash AND ts.trace_address = call_trace_address
+        LEFT JOIN polygon.traces tf1 ON call_tx_hash = tf1.tx_hash AND tf1.trace_address = COALESCE(call_trace_address, '{}') || (ts.sub_traces-2)
+        LEFT JOIN polygon.traces tf2 ON call_tx_hash = tf2.tx_hash AND tf2.trace_address = COALESCE(call_trace_address, '{}') || (ts.sub_traces-1)
+        WHERE call_success 
+        AND call_block_time >= start_ts
+        AND call_block_time < end_ts
+        AND ts.block_time >= start_ts
+        AND ts.block_time < end_ts
+        AND tf1.block_time >= start_ts
+        AND tf1.block_time < end_ts
+        AND tf2.block_time >= start_ts
+        AND tf2.block_time < end_ts
+
+        UNION ALL
+        
+        -- 1inch Limit Order Protocol RFQ v2
+        SELECT
+            call_block_time as block_time,
+            '1inch Limit Order Protocol' AS project,
+            'RFQ v2' as version,
+            'DEX' AS category,
+            ts."from" AS trader_a,
+            decode(substring("order"::jsonb->>'maker' from 3 for 40), 'hex') AS trader_b,
+            "output_1" AS token_a_amount_raw,
+            "output_0" AS token_b_amount_raw,
+            NULL::numeric AS usd_amount,
+            decode(substring("order"::jsonb->>'takerAsset' from 3), 'hex') AS token_a_address,
+            decode(substring("order"::jsonb->>'makerAsset' from 3), 'hex') AS token_b_address,
+            contract_address AS exchange_contract_address,
+            call_tx_hash,
+            call_trace_address,
+            NULL AS evt_index
+        FROM (
+            select contract_address, "order", output_0, output_1, call_block_time, call_tx_hash, call_trace_address from oneinch_lop_v2."LimitOrderProtocol_V2_call_fillOrderRFQ" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts union all
+            select contract_address, "order", output_0, output_1, call_block_time, call_tx_hash, call_trace_address from oneinch_lop_v2."LimitOrderProtocol_V2_call_fillOrderRFQTo" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts union all
+            select contract_address, "order", output_0, output_1, call_block_time, call_tx_hash, call_trace_address from oneinch_lop_v2."LimitOrderProtocol_V2_call_fillOrderRFQToWithPermit" where call_success AND call_block_time >= start_ts AND call_block_time < end_ts
+        ) call
+        LEFT JOIN polygon.traces ts ON call_tx_hash = ts.tx_hash AND call_trace_address = ts.trace_address
+        WHERE ts.block_time >= start_ts
+        AND ts.block_time < end_ts
     ) dexs
+
     INNER JOIN polygon.transactions tx
         ON dexs.tx_hash = tx.hash
-        AND tx.block_time >= start_ts
+        AND tx.block_time >= start_ts 
         AND tx.block_time < end_ts
         AND tx.block_number >= start_block
         AND tx.block_number < end_block
+    LEFT JOIN erc20.tokens erc20a ON erc20a.contract_address = dexs.token_a_address
+    LEFT JOIN erc20.tokens erc20b ON erc20b.contract_address = dexs.token_b_address
     LEFT JOIN prices.usd pa ON pa.minute = date_trunc('minute', dexs.block_time)
         AND pa.contract_address = dexs.token_a_address
         AND pa.minute >= start_ts
@@ -110,8 +331,9 @@ WITH rows AS (
         AND pb.contract_address = dexs.token_b_address
         AND pb.minute >= start_ts
         AND pb.minute < end_ts
-    WHERE dexs.block_time >= start_ts
+    WHERE dexs.block_time >= start_ts 
     AND dexs.block_time < end_ts
+
     ON CONFLICT DO NOTHING
     RETURNING 1
 )
@@ -123,17 +345,31 @@ $function$;
 -- fill 2021
 SELECT dex.insert_1inch(
     '2021-01-01',
-    now(),
+    '2022-01-01',
     (SELECT max(number) FROM polygon.blocks WHERE time < '2021-01-01'),
-    (SELECT MAX(number) FROM polygon.blocks where time < now() - interval '20 minutes')
+    (SELECT MAX(number) FROM polygon.blocks where time < '2022-01-01')
 )
 WHERE NOT EXISTS (
     SELECT *
     FROM dex.trades
     WHERE block_time > '2021-01-01'
-    AND block_time <= now() - interval '20 minutes'
-    AND project = '1inch'
+    AND block_time <= '2022-01-01'
 );
+
+-- fill 2022
+SELECT dex.insert_1inch(
+    '2022-01-01',
+    now(),
+    (SELECT max(number) FROM polygon.blocks WHERE time < '2022-01-01'),
+    (SELECT MAX(number) FROM polygon.blocks where time < now() - interval '20 minutes')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM dex.trades
+    WHERE block_time > '2022-01-01'
+    AND block_time <= now() - interval '20 minutes'
+);
+
 
 INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$


### PR DESCRIPTION
Making 1inch on polygon similar to ethereum, including the Limit Order Protocol in the same insert.

A dune_user_generated.oneinch_dex_trades table was created to visualize all data although some double inclusions have been made to this table because I needed to break the insertions into many jobs.

Queries using this table, even though data is duplicated:
https://dune.com/queries/893408 : query that summarizes some of the most important stats on 1inch.
https://dune.com/queries/906627 : query that summarizes some of the most important stats on 1inch Limit order protocol.

View table simulating the insertion, but for limited time frames:
https://dune.com/queries/896051

I've checked that:

* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
