### PR TITLE
add new pool trade events for hashflow on all chains & init op tables

### DIFF
--- a/binance_smart_chain/hashflow/trades.sql
+++ b/binance_smart_chain/hashflow/trades.sql
@@ -93,7 +93,55 @@ with event_decoded as (
                                             then '\xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c' else ('\x' || substring(quote->>'quoteToken' from 3))::bytea end
                                             -- table has no BNB so using WBNB
     WHERE t.call_block_time >= start_ts AND t.call_block_time < end_ts
-), rows AS (
+), new_pool as (
+    -- subquery for including new pools created on 2022-04-09
+    -- same Trade event abi, effectively only from table hashflow.Pool_evt_Trade since 2022-04-09
+    select  l.evt_index as composite_index,
+            null as source, -- no join on call for this batch, refer to metabase for source info
+            tx.block_time as block_time,
+            tx.hash as tx_hash,
+            TRUE as fill_status, -- without call we are only logging successful fills
+            null as method_id, -- without call we dont have function call info
+            tx."to" as router_contract, -- taking top level contract called in tx as router, not necessarily HF contract
+            l."pool" as pool,
+            tx."from" as trader,
+            l."quoteToken" as maker_token,
+            l."baseToken" as taker_token,
+            case when l."quoteToken" = '\x0000000000000000000000000000000000000000'
+                                            then 'BNB' else mp.symbol end as maker_symbol,
+            case when l."baseToken" = '\x0000000000000000000000000000000000000000'
+                                            then 'BNB' else tp.symbol end as taker_symbol,
+            l."quoteTokenAmount"/power(10,mp.decimals) as maker_token_amount,
+            l."baseTokenAmount"/power(10,tp.decimals) as taker_token_amount,
+            coalesce(
+                    l."baseTokenAmount"/power(10, tp.decimals) * tp.price,
+                    l."quoteTokenAmount"/power(10, mp.decimals) * mp.price)
+                    as usd_amount
+
+    from hashflow."Pool_evt_Trade" l 
+    join bsc.transactions tx on tx.hash = l.evt_tx_hash
+    left join prices.usd tp on tp.minute = date_trunc('minute', tx.block_time)
+                                  and tp.contract_address = case when l."baseToken" = '\x0000000000000000000000000000000000000000'
+                                            then '\xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c' else l."baseToken" end
+                                  AND tp.minute >= start_ts
+                                  AND tp.minute < end_ts
+    left join prices.usd mp on mp.minute = date_trunc('minute', tx.block_time)
+                                  and mp.contract_address = case when l."quoteToken" = '\x0000000000000000000000000000000000000000'
+                                            then '\xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c' else l."quoteToken" end
+                                  AND tp.minute >= start_ts
+                                  AND tp.minute < end_ts
+    WHERE l.evt_block_time > '2022-04-08' -- necessary filter to only include new trades
+            AND l.evt_block_time >= start_ts 
+            AND l.evt_block_time < end_ts
+)
+, all_trades as (
+
+    select * from new_router
+    union all
+    select * from new_pool
+
+)
+, rows AS (
       INSERT INTO hashflow.trades (
           composite_index,
           source,
@@ -129,7 +177,7 @@ with event_decoded as (
           maker_token_amount,
           taker_token_amount,
           usd_amount
-      FROM new_router
+      FROM all_trades
       ON CONFLICT DO NOTHING
       RETURNING 1
     )

--- a/ethereum/hashflow/trades.sql
+++ b/ethereum/hashflow/trades.sql
@@ -320,17 +320,64 @@ with legacy_routers as (
                             (quote->'maxQuoteTokenAmount')::float/power(10, mp.decimals) * mp.price)
                     end as usd_amount
 
-    from hashflow."Router_call_tradeSingleHop" t
+    from hashflow."Router_call_tradeSingleHop" t 
+            -- 2022-01-10 to 2022-04-08
     join ethereum.transactions tx on tx.hash = t.call_tx_hash
     left join event_decoded l on l.tx_id = ('\x' || substring(quote->>'txid' from 3))::bytea -- join on tx_id 1:1, no dup
     left join prices.usd tp on tp.minute = date_trunc('minute', t.call_block_time)
                                   and tp.contract_address = case when quote->>'baseToken' = '0x0000000000000000000000000000000000000000'
                                             then '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' else ('\x' || substring(quote->>'baseToken' from 3))::bytea end
+                                  AND tp.minute >= start_ts
+                                  AND tp.minute < end_ts
     left join prices.usd mp on mp.minute = date_trunc('minute', t.call_block_time)
                                   and mp.contract_address = case when quote->>'quoteToken' = '0x0000000000000000000000000000000000000000'
                                             then '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' else ('\x' || substring(quote->>'quoteToken' from 3))::bytea end
-    AND t.call_block_time >= start_ts AND t.call_block_time < end_ts
-), all_trades as (
+                                  AND tp.minute >= start_ts
+                                  AND tp.minute < end_ts
+    WHERE t.call_block_time >= start_ts 
+            AND t.call_block_time < end_ts
+), new_pool as (
+    -- subquery for including new pools created on 2022-04-09
+    -- same Trade event abi, effectively only from table hashflow.Pool_evt_Trade since 2022-04-09
+    select  l.evt_index as composite_index,
+            null as source, -- no join on call for this batch, refer to metabase for source info
+            tx.block_time as block_time,
+            tx.hash as tx_hash,
+            TRUE as fill_status, -- without call we are only logging successful fills
+            null as method_id, -- without call we dont have function call info
+            tx."to" as router_contract, -- taking top level contract called in tx as router, not necessarily HF contract
+            l."pool" as pool,
+            tx."from" as trader,
+            l."quoteToken" as maker_token,
+            l."baseToken" as taker_token,
+            case when l."quoteToken" = '\x0000000000000000000000000000000000000000'
+                                            then 'ETH' else mp.symbol end as maker_symbol,
+            case when l."baseToken" = '\x0000000000000000000000000000000000000000'
+                                            then 'ETH' else tp.symbol end as taker_symbol,
+            l."quoteTokenAmount"/power(10,mp.decimals) as maker_token_amount,
+            l."baseTokenAmount"/power(10,tp.decimals) as taker_token_amount,
+            coalesce(
+                    l."baseTokenAmount"/power(10, tp.decimals) * tp.price,
+                    l."quoteTokenAmount"/power(10, mp.decimals) * mp.price)
+                    as usd_amount
+
+    from hashflow."Pool_evt_Trade" l 
+    join ethereum.transactions tx on tx.hash = l.evt_tx_hash
+    left join prices.usd tp on tp.minute = date_trunc('minute', tx.block_time)
+                                  and tp.contract_address = case when l."baseToken" = '\x0000000000000000000000000000000000000000'
+                                            then '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' else l."baseToken" end
+                                  AND tp.minute >= start_ts
+                                  AND tp.minute < end_ts
+    left join prices.usd mp on mp.minute = date_trunc('minute', tx.block_time)
+                                  and mp.contract_address = case when l."quoteToken" = '\x0000000000000000000000000000000000000000'
+                                            then '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' else l."quoteToken" end
+                                  AND tp.minute >= start_ts
+                                  AND tp.minute < end_ts
+    WHERE l.evt_block_time > '2022-04-08' -- necessary filter to only include new trades
+            AND l.evt_block_time >= start_ts 
+            AND l.evt_block_time < end_ts
+)
+, all_trades as (
     select
           -1::int as composite_index,
           -- was decoding from trace, no log_index, only single swap exist so works as PK
@@ -342,6 +389,8 @@ with legacy_routers as (
     select * from legacy_router_w_integration
     union all
     select * from new_router
+    union all
+    select * from new_pool
 
 ), rows AS (
       INSERT INTO hashflow.trades (

--- a/optimism2/dex/insert_hashflow.sql
+++ b/optimism2/dex/insert_hashflow.sql
@@ -1,0 +1,103 @@
+CREATE OR REPLACE FUNCTION dex.insert_hashflow(start_ts timestamptz, end_ts timestamptz=now()) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+WITH aux as (
+    SELECT
+        hf.block_time,
+        maker_symbol AS token_a_symbol,
+        taker_symbol AS token_b_symbol,
+        maker_token_amount AS token_a_amount,
+        taker_token_amount AS token_b_amount,
+        'hashflow' as project,
+        '1' as version,
+        'DEX' as category,
+        pool as trader_a,
+        trader as trader_b,
+        maker_token_amount * 10 ^ erc20a.decimals as token_a_amount_raw,
+        taker_token_amount * 10 ^ erc20b.decimals as token_b_amount_raw,
+        usd_amount,
+        maker_token as token_a_address,
+        taker_token as token_b_address,
+        router_contract as exchange_contract_address,
+        tx_hash,
+        trader as tx_from, -- already join on tx table with same logic in table creation
+        router_contract as tx_to, -- already join on tx table with same logic in table creation
+        NULL::integer[] as trace_address,
+        (case when hf.composite_index=-1 then NULL::integer else hf.composite_index end) as evt_index -- -1 means decoded from traces
+    FROM hashflow.trades hf
+
+    LEFT JOIN erc20.tokens erc20a ON erc20a.contract_address = hf.maker_token
+    LEFT JOIN erc20.tokens erc20b ON erc20b.contract_address = hf.taker_token
+    WHERE fill_status is true -- success trade
+          AND hf.block_time >= start_ts
+          AND hf.block_time < end_ts
+), rows AS (
+    INSERT INTO dex.trades (
+        block_time,
+        token_a_symbol,
+        token_b_symbol,
+        token_a_amount,
+        token_b_amount,
+        project,
+        version,
+        category,
+        trader_a,
+        trader_b,
+        token_a_amount_raw,
+        token_b_amount_raw,
+        usd_amount,
+        token_a_address,
+        token_b_address,
+        exchange_contract_address,
+        tx_hash,
+        tx_from,
+        tx_to,
+        trace_address,
+        evt_index,
+        trade_id
+    )
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY project, tx_hash, evt_index, trace_address ORDER BY version, category) AS trade_id
+    FROM aux
+    -- update if we have new info on prices or the erc20
+    ON CONFLICT (project, tx_hash, evt_index, trade_id)
+    DO UPDATE SET
+        usd_amount = EXCLUDED.usd_amount,
+        token_a_amount = EXCLUDED.token_a_amount,
+        token_b_amount = EXCLUDED.token_b_amount,
+        token_a_symbol = EXCLUDED.token_a_symbol,
+        token_b_symbol = EXCLUDED.token_b_symbol
+    RETURNING 1
+)
+SELECT count(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+/*
+-- fill 2022
+SELECT dex.insert_hashflow(
+    '2022-05-07',
+    now(),
+    0,
+    (SELECT MAX(number) FROM optimism.blocks where time < now() - interval '20 minutes')
+)
+WHERE NOT EXISTS (
+    SELECT *
+    FROM dex.trades
+    WHERE block_time > '2021-12-28'
+    AND block_time <= now() - interval '20 minutes'
+    AND project = 'hashflow'
+);
+
+INSERT INTO cron.job (schedule, command)
+VALUES ('15,45 * * * *', $$
+    SELECT dex.insert_hashflow(
+        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project = 'hashflow'),
+        now()
+        );
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+*/

--- a/optimism2/hashflow/trades.sql
+++ b/optimism2/hashflow/trades.sql
@@ -1,0 +1,125 @@
+CREATE TABLE IF NOT EXISTS hashflow.trades (
+	composite_index int4 NULL,
+	"source" text NULL,
+	block_time timestamptz NOT NULL,
+	tx_hash bytea NOT NULL,
+	fill_status bool NULL,
+	method_id text NULL,
+	router_contract bytea NULL,
+	pool bytea NULL,
+	trader bytea NULL,
+	maker_token bytea NULL,
+	taker_token bytea NULL,
+	maker_symbol text NULL,
+	taker_symbol text NULL,
+	maker_token_amount float8 NULL,
+	taker_token_amount float8 NULL,
+	usd_amount float8 NULL
+);
+
+CREATE OR REPLACE FUNCTION hashflow.insert_trades(start_ts timestamp with time zone, end_ts timestamp with time zone DEFAULT now())
+ RETURNS integer
+ LANGUAGE plpgsql
+AS $function$
+DECLARE r integer;
+BEGIN
+
+with new_pool as (
+    -- subquery for including new pools created on 2022-04-09
+    -- same Trade event abi, effectively only from table hashflow.Pool_evt_Trade since 2022-04-09
+    select  l.evt_index as composite_index,
+            null as source, -- no join on call for this batch, refer to metabase for source info
+            tx.block_time as block_time,
+            tx.hash as tx_hash,
+            TRUE as fill_status, -- without call we are only logging successful fills
+            null as method_id, -- without call we dont have function call info
+            tx."to" as router_contract, -- taking top level contract called in tx as router, not necessarily HF contract
+            l."pool" as pool,
+            tx."from" as trader,
+            l."quoteToken" as maker_token,
+            l."baseToken" as taker_token,
+            case when l."quoteToken" = '\x0000000000000000000000000000000000000000'
+                                            then 'ETH' else mp.symbol end as maker_symbol,
+            case when l."baseToken" = '\x0000000000000000000000000000000000000000'
+                                            then 'ETH' else tp.symbol end as taker_symbol,
+            l."quoteTokenAmount"/power(10,mp.decimals) as maker_token_amount,
+            l."baseTokenAmount"/power(10,tp.decimals) as taker_token_amount,
+            coalesce(
+                    l."baseTokenAmount"/power(10, tp.decimals) * tp.median_price,
+                    l."quoteTokenAmount"/power(10, mp.decimals) * mp.median_price)
+                    as usd_amount
+
+    from hashflow."Pool_evt_Trade" l 
+    join optimism.transactions tx on tx.hash = l.evt_tx_hash
+    left join prices.approx_prices_from_dex_data tp on tp.hour = date_trunc('hour', tx.block_time)
+                                  and tp.contract_address = case when l."baseToken" = '\x0000000000000000000000000000000000000000'
+                                            then '\xdeaddeaddeaddeaddeaddeaddeaddeaddead0000' else l."baseToken" end
+                                  AND tp.hour >= start_ts
+                                  AND tp.hour < end_ts
+    left join prices.approx_prices_from_dex_data mp on mp.hour = date_trunc('hour', tx.block_time)
+                                  and mp.contract_address = case when l."quoteToken" = '\x0000000000000000000000000000000000000000'
+                                            then '\xdeaddeaddeaddeaddeaddeaddeaddeaddead0000' else l."quoteToken" end
+                                  AND tp.hour >= start_ts
+                                  AND tp.hour < end_ts
+    WHERE l.evt_block_time >= start_ts 
+            AND l.evt_block_time < end_ts
+)
+, all_trades as (
+    
+    select * from new_pool
+
+), rows AS (
+      INSERT INTO hashflow.trades (
+          composite_index,
+          source,
+          block_time,
+          tx_hash,
+          fill_status,
+          method_id,
+          router_contract,
+          pool,
+          trader,
+          maker_token,
+          taker_token,
+          maker_symbol,
+          taker_symbol,
+          maker_token_amount,
+          taker_token_amount,
+          usd_amount
+      )
+      SELECT
+          composite_index,
+          source,
+          block_time,
+          tx_hash,
+          fill_status,
+          method_id,
+          router_contract,
+          pool,
+          trader,
+          maker_token,
+          taker_token,
+          maker_symbol,
+          taker_symbol,
+          maker_token_amount,
+          taker_token_amount,
+          usd_amount
+      FROM all_trades
+      ON CONFLICT DO NOTHING
+      RETURNING 1
+    )
+    SELECT count(*) INTO r from rows;
+    RETURN r;
+    END
+    $function$
+;
+
+CREATE INDEX IF NOT EXISTS hashflow_trades_time_index ON hashflow.trades USING btree (block_time);
+CREATE UNIQUE INDEX IF NOT EXISTS hashflow_trades_unique ON hashflow.trades USING btree (tx_hash, composite_index);
+
+--backfill
+SELECT hashflow.insert_trades('2022-05-07', (SELECT now() - interval '20 minutes')) WHERE NOT EXISTS (SELECT * FROM hashflow.trades LIMIT 1);
+
+INSERT INTO cron.job (schedule, command)
+VALUES ('15 * * * *', $$SELECT hashflow.insert_trades((SELECT max(block_time) - interval '2 days' FROM hashflow.trades), (SELECT now() - interval '20 minutes'));$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/polygon/hashflow/trades.sql
+++ b/polygon/hashflow/trades.sql
@@ -92,7 +92,56 @@ with event_decoded as (
                                   and mp.contract_address = case when quote->>'quoteToken' = '0x0000000000000000000000000000000000000000'
                                             then '\x0000000000000000000000000000000000001010' else ('\x' || substring(quote->>'quoteToken' from 3))::bytea end
     WHERE t.call_block_time >= start_ts AND t.call_block_time < end_ts
-), rows AS (
+), new_pool as (
+    -- subquery for including new pools created on 2022-04-09
+    -- same Trade event abi, effectively only from table hashflow.Pool_evt_Trade since 2022-04-09
+    select  l.evt_index as composite_index,
+            null as source, -- no join on call for this batch, refer to metabase for source info
+            tx.block_time as block_time,
+            tx.hash as tx_hash,
+            TRUE as fill_status, -- without call we are only logging successful fills
+            null as method_id, -- without call we dont have function call info
+            tx."to" as router_contract, -- taking top level contract called in tx as router, not necessarily HF contract
+            l."pool" as pool,
+            tx."from" as trader,
+            l."quoteToken" as maker_token,
+            l."baseToken" as taker_token,
+            case when l."quoteToken" = '\x0000000000000000000000000000000000000000'
+                                            then 'MATIC' else mp.symbol end as maker_symbol,
+            case when l."baseToken" = '\x0000000000000000000000000000000000000000'
+                                            then 'MATIC' else tp.symbol end as taker_symbol,
+            l."quoteTokenAmount"/power(10,mp.decimals) as maker_token_amount,
+            l."baseTokenAmount"/power(10,tp.decimals) as taker_token_amount,
+            coalesce(
+                    l."baseTokenAmount"/power(10, tp.decimals) * tp.price,
+                    l."quoteTokenAmount"/power(10, mp.decimals) * mp.price)
+                    as usd_amount
+
+    from hashflow."Pool_evt_Trade" l 
+    join polygon.transactions tx on tx.hash = l.evt_tx_hash
+    left join prices.usd tp on tp.minute = date_trunc('minute', tx.block_time)
+                                  and tp.contract_address = case when l."baseToken" = '\x0000000000000000000000000000000000000000'
+                                            then '\x0000000000000000000000000000000000001010' else l."baseToken" end
+                                  AND tp.minute >= start_ts
+                                  AND tp.minute < end_ts
+    left join prices.usd mp on mp.minute = date_trunc('minute', tx.block_time)
+                                  and mp.contract_address = case when l."quoteToken" = '\x0000000000000000000000000000000000000000'
+                                            then '\x0000000000000000000000000000000000001010' else l."quoteToken" end
+                                  AND tp.minute >= start_ts
+                                  AND tp.minute < end_ts
+    WHERE l.evt_block_time > '2022-04-08' -- necessary filter to only include new trades
+            AND l.evt_block_time >= start_ts 
+            AND l.evt_block_time < end_ts
+)
+, all_trades as (
+
+    select * from new_router
+    union all
+    select * from new_pool
+
+),
+
+ rows AS (
       INSERT INTO hashflow.trades (
           composite_index,
           source,
@@ -128,7 +177,7 @@ with event_decoded as (
           maker_token_amount,
           taker_token_amount,
           usd_amount
-      FROM new_router
+      FROM all_trades
       ON CONFLICT DO NOTHING
       RETURNING 1
     )


### PR DESCRIPTION
for the new trade events changes on ETH, Polygon, BSC -- here are the partial test of the new subqueries:

[Ethereum PR Test](https://dune.com/queries/907494)
[Polygon PR Test](https://dune.com/queries/907550)
[BSC PR Test](https://dune.com/queries/907573)

After this PR is merged, hashflow table will need a backfill from 2022-04-09.
There is no code change needed for inserting into dex.trades -- as it's a simple select from hashflow tables -- once the table's backfill is done, they will need a backfill from same dates (all chains start from 2022-04-09); and after that all data will flow automatically.



For the Optimism new hashflow tables, i tested the whole functions with dune_user_generated view:

[table function test](https://dune.com/queries/907557)
[function test result](https://dune.com/queries/907605) looks good.

They will need a backfill since 2022-05-07. Also added the insert_hashflow for dex.trades table on Optimism, which also need a backfill from same date.

cc our CTO @gxmxni

----
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
