### PR TITLE
Remove duplicates from `transfers_ethereum.erc20` originating in `erc20_ethereum.evt_transfer`

### DIFF
--- a/spellbook/models/transfers/ethereum/erc20/transfers_ethereum_erc20.sql
+++ b/spellbook/models/transfers/ethereum/erc20/transfers_ethereum_erc20.sql
@@ -3,8 +3,8 @@
 with
     sent_transfers as (
         select
-            evt_tx_hash || '-' || evt_index || '-' || to as unique_tx_id,
-            to as wallet_address,
+            'send' || '-' || evt_tx_hash || '-' || evt_index || '-' || `to` as unique_tx_id,
+            `to` as wallet_address,
             contract_address as token_address,
             evt_block_time,
             value as amount_raw
@@ -14,12 +14,12 @@ with
 
     ,
     received_transfers as (
-        select evt_tx_hash || '-' || evt_index || '-' || to as unique_tx_id,
-        from
-            as wallet_address,
-            contract_address as token_address,
-            evt_block_time, 
-            - value as amount_raw
+        select
+        'receive' || '-' || evt_tx_hash || '-' || evt_index || '-' || `from` as unique_tx_id,
+        `from` as wallet_address,
+        contract_address as token_address,
+        evt_block_time,
+        - value as amount_raw
         from
             {{ source('erc20_ethereum', 'evt_transfer') }}
     )
@@ -27,7 +27,7 @@ with
     ,
     deposited_weth as (
         select
-            evt_tx_hash || '-' || evt_index as unique_tx_id,
+            'deposit' || '-' || evt_tx_hash || '-' || evt_index || '-' || dst as unique_tx_id,
             dst as wallet_address,
             contract_address as token_address,
             evt_block_time,
@@ -39,7 +39,7 @@ with
     ,
     withdrawn_weth as (
         select
-            evt_tx_hash || '-' || evt_index as unique_tx_id,
+            'withdrawn' || '-' || evt_tx_hash || '-' || evt_index || '-' || src as unique_tx_id,
             src as wallet_address,
             contract_address as token_address,
             evt_block_time,
@@ -48,8 +48,14 @@ with
             {{ source('zeroex_ethereum', 'weth9_evt_withdrawal') }}
     )
     
-select 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
+select unique_tx_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
 from sent_transfers
-union all
-select 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
+union
+select unique_tx_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
 from received_transfers
+union
+select unique_tx_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
+from deposited_weth
+union
+select unique_tx_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
+from withdrawn_weth

--- a/spellbook/models/transfers/ethereum/transfers_ethereum_schema.yml
+++ b/spellbook/models/transfers/ethereum/transfers_ethereum_schema.yml
@@ -13,6 +13,8 @@ models:
     columns:
       - name: unique_tx_id
         description: "Unique tx ID (testing)"
+        tests:
+          - unique
       - &blockchain
         name: blockchain
         description: "Blockchain"


### PR DESCRIPTION
This PR addresses an issue raised by @MSilb7. https://github.com/duneanalytics/abstractions/issues/1120 

`erc20_ethereum.evt_transfer` has duplicated values keyed on `evt_tx_hash` and `evt_index`.  I will open an internal issue to identify the root cause. 

<img width="779" alt="Screen Shot 2022-06-14 at 4 38 53 PM" src="https://user-images.githubusercontent.com/9472574/173684560-d3cab91a-79b6-46d9-8f6a-1718efe2a05d.png">

<img width="1288" alt="Screen Shot 2022-06-14 at 4 39 00 PM" src="https://user-images.githubusercontent.com/9472574/173684571-2b2d59f2-a4eb-4fdc-b348-807e627bf108.png">

<img width="1096" alt="Screen Shot 2022-06-14 at 4 40 51 PM" src="https://user-images.githubusercontent.com/9472574/173684657-7efe26aa-2c32-4fca-ae22-9fe50c63a382.png">

In the meantime, `transfers_ethereum.erc20` is a slightly munged version of this table that we use to create token balances. I'm proposing using this view as a substitute until we fix the root cause. 

I've added a test on the a unique key coalesced from:
-  'send' || '-' || evt_tx_hash || '-' || evt_index || '-' || `to`  for sent transfers 
-  'receive' || '-' || evt_tx_hash || '-' || evt_index || '-' || `from` for received transfers 
-  'withdrawn' || '-' || evt_tx_hash || '-' || evt_index || '-' || src for withdrawn WETH
-  'deposit' || '-' || evt_tx_hash || '-' || evt_index || '-' || dst for deposited WETH

I added the tx type (send , receive etc) because I found there were transactions where the `to` and `from` addresses were the same address so the original unique key was insufficient. 
example: https://etherscan.io/tx/0xa3a30dc42d0276aca0ccc36aa3fb6644bee589afed121bae1c36c163e855d875

This PR also adds the WETH deposits and withdrawals into the transfers tables. Previously this was removed because those tables were not ready yet. 

I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
