### PR TITLE
standardize unique_trade_id

### DIFF
--- a/spellbook/models/magiceden/magiceden_schema.yml
+++ b/spellbook/models/magiceden/magiceden_schema.yml
@@ -30,5 +30,5 @@ models:
         description: "Value of the trade at time of execution in the original currency"
       - name: amount_usd
         description:  "USD value of the trade at time of execution"
-      - name: trade_id
-        description:  "Trade ID (derived from id in solana transactions)"
+      - name: unique_trade_id
+        description:  "Unique trade ID (derived from signatures[0] and id in solana transactions)"

--- a/spellbook/models/magiceden/solana/magiceden_solana_schema.yml
+++ b/spellbook/models/magiceden/solana/magiceden_solana_schema.yml
@@ -11,8 +11,8 @@ models:
     description: >
         MagicEden trades on Solana
     columns:
-      - name: unique_id
-        description:  "Unique id, combination of signatures[0] and id"
+      - name: unique_trade_id
+        description:  "Unique trade id, combination of signatures[0] and id"
         tests:
           - unique
       - &blockchain
@@ -32,5 +32,3 @@ models:
         description:  "USD value of the trade at time of execution"
       - name: traders
         description:  "Traders"
-      - name: trade_id
-        description:  "Trade ID (derived from id in solana transactions)"

--- a/spellbook/models/magiceden/solana/magiceden_solana_schema.yml
+++ b/spellbook/models/magiceden/solana/magiceden_solana_schema.yml
@@ -13,8 +13,6 @@ models:
     columns:
       - name: unique_trade_id
         description:  "Unique trade id, combination of signatures[0] and id"
-        tests:
-          - unique
       - &blockchain
         name: blockchain
         description: "Blockchain"

--- a/spellbook/models/magiceden/solana/magiceden_solana_schema.yml
+++ b/spellbook/models/magiceden/solana/magiceden_solana_schema.yml
@@ -13,6 +13,8 @@ models:
     columns:
       - name: unique_trade_id
         description:  "Unique trade id, combination of signatures[0] and id"
+        tests:
+          - unique
       - &blockchain
         name: blockchain
         description: "Blockchain"

--- a/spellbook/models/magiceden/solana/magiceden_solana_trades.sql
+++ b/spellbook/models/magiceden/solana/magiceden_solana_trades.sql
@@ -5,7 +5,7 @@
 }}
 
 SELECT 
-  signatures[0] || id as unique_trade_id,
+  signatures[0] || '-' || id as unique_trade_id,
   'solana' as blockchain,
   signatures[0] as tx_hash, 
   block_time,

--- a/spellbook/models/nft/nft_schema.yml
+++ b/spellbook/models/nft/nft_schema.yml
@@ -30,5 +30,5 @@ models:
         description: "Value of the trade at time of execution in the original currency"
       - name: amount_usd
         description:  "USD value of the trade at time of execution"
-      - name: trade_id
-        description:  "Trade ID"
+      - name: unique_trade_id
+        description:  "Unique trade ID"

--- a/spellbook/models/opensea/ethereum/opensea_ethereum_schema.yml
+++ b/spellbook/models/opensea/ethereum/opensea_ethereum_schema.yml
@@ -13,8 +13,6 @@ models:
     columns:
       - name: unique_trade_id
         description:  "Unique trade id, combination of tx_hash and trade_id"
-        tests:
-          - unique
       - &blockchain
         name: blockchain
         description: "Blockchain"

--- a/spellbook/models/opensea/ethereum/opensea_ethereum_schema.yml
+++ b/spellbook/models/opensea/ethereum/opensea_ethereum_schema.yml
@@ -11,8 +11,8 @@ models:
     description: >
         OpenSea trades on Ethereum
     columns:
-      - name: unique_id
-        description:  "Unique id, combination of tx_hash and trade_id"
+      - name: unique_trade_id
+        description:  "Unique trade id, combination of tx_hash and trade_id"
         tests:
           - unique
       - &blockchain
@@ -38,8 +38,6 @@ models:
         description:  "Maker"
       - name: taker
         description:  "Taker"
-      - name: trade_id
-        description:  "Trade id (derived from evt_index for ethereum nft trades)"
           
   - name: opensea_ethereum_volume_day
     meta:

--- a/spellbook/models/opensea/ethereum/opensea_ethereum_schema.yml
+++ b/spellbook/models/opensea/ethereum/opensea_ethereum_schema.yml
@@ -13,6 +13,8 @@ models:
     columns:
       - name: unique_trade_id
         description:  "Unique trade id, combination of tx_hash and trade_id"
+        tests:
+          - unique
       - &blockchain
         name: blockchain
         description: "Blockchain"

--- a/spellbook/models/opensea/ethereum/opensea_ethereum_trades.sql
+++ b/spellbook/models/opensea/ethereum/opensea_ethereum_trades.sql
@@ -5,7 +5,7 @@
 }}
 
 SELECT
-evt_tx_hash || evt_index::string as unique_trade_id,
+evt_tx_hash || '-' || evt_index::string as unique_trade_id,
 'ethereum' as blockchain,
 evt_tx_hash as tx_hash,
 evt_block_time as block_time,

--- a/spellbook/models/opensea/opensea_schema.yml
+++ b/spellbook/models/opensea/opensea_schema.yml
@@ -24,8 +24,8 @@ models:
         description: "Value of the trade at time of execution in the original currency"
       - name: amount_usd
         description:  "USD value of the trade at time of execution"
-      - name: trade_id
-        description:  "Trade ID"
+      - name: unique_trade_id
+        description:  "Unique trade ID"
 
   - name: opensea_volume_day
     meta:

--- a/spellbook/models/opensea/solana/opensea_solana_schema.yml
+++ b/spellbook/models/opensea/solana/opensea_solana_schema.yml
@@ -13,8 +13,6 @@ models:
     columns:
       - name: unique_trade_id
         description:  "Unique trade id, combination of signatures[0] and id"
-        tests:
-          - unique
       - &blockchain
         name: blockchain
         description: "Blockchain"

--- a/spellbook/models/opensea/solana/opensea_solana_schema.yml
+++ b/spellbook/models/opensea/solana/opensea_solana_schema.yml
@@ -11,8 +11,8 @@ models:
     description: >
         OpenSea trades on Solana
     columns:
-      - name: unique_id
-        description:  "Unique id, combination of signatures[0] and id"
+      - name: unique_trade_id
+        description:  "Unique trade id, combination of signatures[0] and id"
         tests:
           - unique
       - &blockchain
@@ -32,8 +32,6 @@ models:
         description:  "USD value of the trade at time of execution"
       - name: traders
         description:  "Traders"
-      - name: trade_id
-        description:  "Trade ID (derived from id in solana transactions)"
 
   - name: opensea_solana_volume_day
     meta:

--- a/spellbook/models/opensea/solana/opensea_solana_schema.yml
+++ b/spellbook/models/opensea/solana/opensea_solana_schema.yml
@@ -13,6 +13,8 @@ models:
     columns:
       - name: unique_trade_id
         description:  "Unique trade id, combination of signatures[0] and id"
+        tests:
+          - unique
       - &blockchain
         name: blockchain
         description: "Blockchain"

--- a/spellbook/models/opensea/solana/opensea_solana_trades.sql
+++ b/spellbook/models/opensea/solana/opensea_solana_trades.sql
@@ -5,7 +5,7 @@
 }}
 
 SELECT 
-  signatures[0] || id as unique_trade_id,
+  signatures[0] || '-' || id as unique_trade_id,
   'solana' as blockchain,
   signatures[0] as tx_hash, 
   block_time,

--- a/spellbook/models/uniswap/ethereum/uniswap_ethereum_schema.yml
+++ b/spellbook/models/uniswap/ethereum/uniswap_ethereum_schema.yml
@@ -62,9 +62,11 @@ models:
       - &tx_to
         name: tx_to
         description:  "Receive this transaction"   
-      - &trade_id
-        name: trade_id
-        description:  "Trade ID (derived from evt_index for ethereum dex trades)"      
+      - &unique_trade_id
+        name: unique_trade_id
+        description:  "Unique trade ID (derived from tx_hash and evt_index for ethereum dex trades)"      
+        tests:
+          - unique
 
   - name: uniswap_v2_ethereum_trades
     meta:
@@ -76,11 +78,7 @@ models:
     description: >
         Uniswap V2 trades on Ethereum
     columns:
-      - &unique_id
-        name: unique_id
-        description:  "Unique id, combination of tx_hash and trade_id"
-        tests:
-          - unique
+      - *unique_trade_id
       - *blockchain
       - *project
       - *version  
@@ -98,7 +96,6 @@ models:
       - *tx_hash
       - *tx_from
       - *tx_to
-      - *trade_id      
 
   - name: uniswap_v3_ethereum_trades
     meta:
@@ -110,7 +107,7 @@ models:
     description: >
         Uniswap V3 trades on Ethereum
     columns:
-      - *unique_id
+      - *unique_trade_id
       - *blockchain
       - *project
       - *version  
@@ -128,4 +125,3 @@ models:
       - *tx_hash
       - *tx_from
       - *tx_to
-      - *trade_id    

--- a/spellbook/models/uniswap/ethereum/uniswap_v2_ethereum_trades.sql
+++ b/spellbook/models/uniswap/ethereum/uniswap_v2_ethereum_trades.sql
@@ -6,7 +6,7 @@
 }}
 
 SELECT
-    tx_hash || evt_index::string as unique_trade_id,
+    tx_hash || '-' || evt_index::string as unique_trade_id,
     'ethereum' as blockchain,
     'uniswap' as project, 
     'v2' as version,

--- a/spellbook/models/uniswap/ethereum/uniswap_v3_ethereum_trades.sql
+++ b/spellbook/models/uniswap/ethereum/uniswap_v3_ethereum_trades.sql
@@ -3,7 +3,7 @@
 }}
         
 SELECT
-    tx_hash || evt_index::string as unique_trade_id,
+    tx_hash || '-' || evt_index::string as unique_trade_id,
     'ethereum' as blockchain,
     'uniswap' as project, 
     'v3' as version,


### PR DESCRIPTION
Standardize descriptions and unique_trade_id columns + its associated tests across existing abstractions

I've checked that:

* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
