### PR TITLE
Drop dbt cloud pr schemas macro

### DIFF
--- a/spellbook/macros/drop_dbt_cloud_pr_schemas.sql
+++ b/spellbook/macros/drop_dbt_cloud_pr_schemas.sql
@@ -1,4 +1,4 @@
-{% macro drop_old_tables() %}
+{% macro drop_dbt_cloud_pr_schemas() %}
     {%- set default_schema = target.schema -%}
     
     {%- set get_pr_schemas_sql -%}
@@ -14,7 +14,6 @@
                 DROP SCHEMA IF EXISTS {{ schema['databaseName'] }} CASCADE
                 {{ PRINT(schema['databaseName']) }}
             {%- endset -%}
-
             
             {{ drop_schema_sql }};
             {do run_query(drop_schema_sql)}

--- a/spellbook/macros/drop_old_tables.sql
+++ b/spellbook/macros/drop_old_tables.sql
@@ -1,0 +1,24 @@
+{% macro drop_old_tables() %}
+    {%- set default_schema = target.schema -%}
+    
+    {%- set get_pr_schemas_sql -%}
+        SHOW SCHEMAS LIKE 'dbt_cloud_pr_*'
+    {%- endset -%}
+
+    {%- set results = run_query(get_pr_schemas_sql) -%}
+
+    {%- if execute -%}
+        {%- for schema in results -%}
+
+            {%- set drop_schema_sql -%}
+                DROP SCHEMA IF EXISTS {{ schema['databaseName'] }} CASCADE
+                {{ PRINT(schema['databaseName']) }}
+            {%- endset -%}
+
+            
+            {{ drop_schema_sql }};
+            {do run_query(drop_schema_sql)}
+
+        {%- endfor -%}
+    {%- endif -%}
+{%- endmacro -%}


### PR DESCRIPTION
Current attempt at creating a macro to periodically delete dbt_cloud_pr schemas

I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
