### PR TITLE
add categories to erc721 balances

### DIFF
--- a/spellbook/models/balances/ethereum/balances_ethereum_schema.yml
+++ b/spellbook/models/balances/ethereum/balances_ethereum_schema.yml
@@ -128,6 +128,12 @@ models:
       - &tokenId
         name: tokenId
         description: "ID of this ERC721 token"
+      - &collection
+        name: collection
+        description: "Name of NFT collection"
+      - &category
+        name: category
+        description: "NFT category"
 
   - name: balances_ethereum_erc721_hour
     meta:
@@ -146,6 +152,8 @@ models:
       - *wallet_address_erc721
       - *token_address_erc721
       - *tokenId
+      - *collection
+      - *category
 
   - name: balances_ethereum_erc721_latest
     meta:
@@ -164,3 +172,5 @@ models:
       - *wallet_address
       - *token_address
       - *tokenId
+      - *collection
+      - *category

--- a/spellbook/models/balances/ethereum/erc721/balances_ethereum_erc721_day.sql
+++ b/spellbook/models/balances/ethereum/erc721/balances_ethereum_erc721_day.sql
@@ -28,7 +28,8 @@ SELECT
     b.wallet_address,
     b.token_address,
     b.tokenId,
-    nft_tokens.name as collection
+    nft_tokens.name as collection,
+    nft_tokens.category as category
 FROM daily_balances b
 INNER JOIN days d ON b.day <= d.day AND d.day < b.next_day
 LEFT JOIN {{ ref('tokens_ethereum_nft') }} nft_tokens ON nft_tokens.contract_address = b.token_address

--- a/spellbook/models/balances/ethereum/erc721/balances_ethereum_erc721_hour.sql
+++ b/spellbook/models/balances/ethereum/erc721/balances_ethereum_erc721_hour.sql
@@ -28,7 +28,8 @@ SELECT
     b.wallet_address,
     b.token_address,
     b.tokenId,
-    nft_tokens.name as collection
+    nft_tokens.name as collection,
+    nft_tokens.category as category
 FROM daily_balances b
 INNER JOIN hours d ON b.hour <= d.hour AND d.hour < b.next_hour
 LEFT JOIN {{ ref('tokens_ethereum_nft') }} nft_tokens ON nft_tokens.contract_address = b.token_address

--- a/spellbook/models/balances/ethereum/erc721/balances_ethereum_erc721_latest.sql
+++ b/spellbook/models/balances/ethereum/erc721/balances_ethereum_erc721_latest.sql
@@ -7,6 +7,7 @@ SELECT
     token_address,
     tokenId,
     nft_tokens.name as collection,
+    nft_tokens.category as category,
     updated_at
 FROM {{ ref('transfers_ethereum_erc721_rolling_hour') }}
 LEFT JOIN {{ ref('tokens_ethereum_nft') }} nft_tokens ON nft_tokens.contract_address = token_address


### PR DESCRIPTION
After having integrated the category column (PR by Hildobby), I think it makes sense to include it in erc721 balances 

I've checked that:

* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [ ] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
