### PR TITLE
run action on pull_request_review

### DIFF
--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -1,6 +1,9 @@
 # .github/workflows/app.yaml
 name: dbt slim ci
-on: workflow_dispatch
+on:
+  pull_request_review:
+    types: [submitted]
+
 
 jobs:
   test:


### PR DESCRIPTION
I think this on trigger will work for public forks 
```
For pull requests from a forked repository to the base repository, GitHub sends the pull_request, issue_comment, pull_request_review_comment, pull_request_review, and pull_request_target events to the base repository. No pull request events occur on the forked repository.

When a first-time contributor submits a pull request to a public repository, a maintainer with write access may need to approve running workflows on the pull request. For more information, see "[Approving workflow runs from public forks](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks)."
```

I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
