### PR TITLE
dbt core + cloud workflow

### DIFF
--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -1,23 +1,102 @@
 # .github/workflows/app.yaml
 name: dbt slim ci
 on:
-  pull_request_review:
-    types: [submitted]
-
+  push:
+    paths:
+      - 'spellbook/**'
 
 jobs:
-  test:
+  dbt-test:
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
 
-      - name: Add remote
-        run: git remote add ${{ github.repository_owner }} ${{ github.repositoryUrl }}
+      - name: Set up Python 3.8.12
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8.12
+          cache: 'pipenv'
 
-      - name: Fetch remote
-        run: git fetch ${{ github.repository_owner }}
+      - name: Cache pipenv virtualenv
+        id: cache-pipenv
+        uses: actions/cache@v1
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
 
-      - name: Check out code
-        run: git checkout -b ${{ github.ref_name }}_internal ${{ github.ref_name }}
+      - name: Install pipenv
+        run: pip install pipenv
+
+      - name: Install dependencies
+        if: steps.cache-pipenv.outputs.cache-hit != 'true'
+        run: |
+          pipenv install
+
+      - name: DBT configure
+        working-directory: ./spellbook
+        continue-on-error: true
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
+          DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
+          SCHEMA: "github_actions"
+        run: |
+          echo "2
+          $DATABRICKS_HOST
+          $DATABRICKS_HTTPS_PATH
+          $DATABRICKS_ACCESS_TOKEN
+          $SCHEMA
+          1" | pipenv run dbt init
+
+      - name: DBT configure take 2 (sometimes dbt init switches the order of db options)
+        continue-on-error: true
+        working-directory: ./spellbook
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
+          DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
+          SCHEMA: "github_actions"
+        run: |
+          echo "1
+          $DATABRICKS_HOST
+          $DATABRICKS_HTTPS_PATH
+          $DATABRICKS_ACCESS_TOKEN
+          $SCHEMA
+          1" | pipenv run dbt init
+
+      - name: Fetch latest run_id
+        uses: JamesIves/fetch-api-data-action@v2.1.0
+        with:
+          endpoint: https://cloud.getdbt.com/api/v2/accounts/58579/runs/?job_definition_id=81672&order_by=-finished_at&limit=2
+          configuration: '{ "method": "GET", 
+                            "headers": {"Authorization": "Token ${{ secrets.DBT_API_TOKEN }}"} }'
+          debug: true
+
+      - name: Set env, 2nd to last run_id (avoids fetching in progress runs)
+        run: echo "dbt_run_id=$(jq .data[1].id fetch-api-data-action/data.json)" >> $GITHUB_ENV
+
+      - name: Fetch latest manifest.json
+        run: |
+          curl  -o spellbook/manifest.json \
+            --request GET \
+            --url https://cloud.getdbt.com/api/v2/accounts/58579/runs/62469111/artifacts/manifest.json \
+            --header 'Content-Type: application/json' \
+            --header 'Authorization: Token ${{ secrets.DBT_API_TOKEN }}'
+
+      - name: dbt compile to create manifest to compare to
+        working-directory: ./spellbook
+        run: "pipenv run dbt compile"
+
+      - name: DBT seed
+        working-directory: ./spellbook
+        run: "pipenv run dbt seed --select state:modified --state ."
+
+      - name: DBT run
+        working-directory: ./spellbook
+        run: "pipenv run dbt run --select state:modified --state ."
+
+      - name: DBT test
+        working-directory: ./spellbook
+        run: "pipenv run dbt test --select state:new state:modified --state ."


### PR DESCRIPTION
This workflow does not work on forked PRs. It will only work for internal PRs due to the way github actions allows access to secrets. 

My proposal as an unblocker is that we ask wizards to tag the Data Experience team as reviewers when they are ready to test their code. If the code looks good, we use the [shell script ](https://github.com/duneanalytics/abstractions/pull/1144) I wrote a while ago to open an internal PR. This will trigger the tests to run and the wizard will be able to read the output. (This is currently not possible with the dbt cloud integration). 

The downsides of this approach are it will be hard to rerun tests on additional commits but this is a temporary solution. 

Note:
This workflow will not work until we add the service principal tokens. 

I will update the PR template in a separate branch to reflect this workflow change. 

I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
