### PR TITLE
fix incremental strategy for erc721 and erc20 tables

### DIFF
--- a/spellbook/models/transfers/ethereum/erc20/transfers_ethereum_erc20.sql
+++ b/spellbook/models/transfers/ethereum/erc20/transfers_ethereum_erc20.sql
@@ -3,7 +3,7 @@
 with
     sent_transfers as (
         select
-            'send' || '-' || evt_tx_hash || '-' || evt_index || '-' || `to` as unique_transfer_id,
+            'send' || '-' || evt_tx_hash || '-' || evt_index || '-' || `to` as unique_tx_id,
             `to` as wallet_address,
             contract_address as token_address,
             evt_block_time,
@@ -15,7 +15,7 @@ with
     ,
     received_transfers as (
         select
-        'receive' || '-' || evt_tx_hash || '-' || evt_index || '-' || `from` as unique_transfer_id,
+        'receive' || '-' || evt_tx_hash || '-' || evt_index || '-' || `from` as unique_tx_id,
         `from` as wallet_address,
         contract_address as token_address,
         evt_block_time,
@@ -27,7 +27,7 @@ with
     ,
     deposited_weth as (
         select
-            'deposit' || '-' || evt_tx_hash || '-' || evt_index || '-' || dst as unique_transfer_id,
+            'deposit' || '-' || evt_tx_hash || '-' || evt_index || '-' || dst as unique_tx_id,
             dst as wallet_address,
             contract_address as token_address,
             evt_block_time,
@@ -39,7 +39,7 @@ with
     ,
     withdrawn_weth as (
         select
-            'withdrawn' || '-' || evt_tx_hash || '-' || evt_index || '-' || src as unique_transfer_id,
+            'withdrawn' || '-' || evt_tx_hash || '-' || evt_index || '-' || src as unique_tx_id,
             src as wallet_address,
             contract_address as token_address,
             evt_block_time,
@@ -48,14 +48,14 @@ with
             {{ source('zeroex_ethereum', 'weth9_evt_withdrawal') }}
     )
     
-select unique_transfer_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
+select unique_tx_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
 from sent_transfers
 union
-select unique_transfer_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
+select unique_tx_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
 from received_transfers
 union
-select unique_transfer_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
+select unique_tx_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
 from deposited_weth
 union
-select unique_transfer_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
+select unique_tx_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
 from withdrawn_weth

--- a/spellbook/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_day.sql
+++ b/spellbook/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_day.sql
@@ -2,7 +2,8 @@
         alias ='erc20_agg_day',
         materialized ='incremental',
         file_format ='delta',
-        incremental_strategy='merge'
+        incremental_strategy='merge',
+        unique_key='unique_transfer_id'
         )
 }}
 
@@ -13,7 +14,8 @@ select
     tr.token_address,
     t.symbol,
     sum(tr.amount_raw) as amount_raw,
-    sum(tr.amount_raw / power(10, t.decimals)) as amount
+    sum(tr.amount_raw / power(10, t.decimals)) as amount,
+    unique_tx_id || '-' || wallet_address || '-' || token_address || '-' || sum(tr.amount_raw)::string as unique_transfer_id
 from {{ ref('transfers_ethereum_erc20') }} tr
 left join {{ ref('tokens_ethereum_erc20') }} t on t.contract_address = tr.token_address
 {% if is_incremental() %}
@@ -21,4 +23,4 @@ left join {{ ref('tokens_ethereum_erc20') }} t on t.contract_address = tr.token_
 where tr.evt_block_time > now() - interval 2 days
 {% endif %}
 group by
-    date_trunc('day', tr.evt_block_time), tr.wallet_address, tr.token_address, t.symbol
+    date_trunc('day', tr.evt_block_time), tr.wallet_address, tr.token_address, t.symbol,unique_tx_id

--- a/spellbook/models/transfers/ethereum/erc721/transfers_ethereum_erc721.sql
+++ b/spellbook/models/transfers/ethereum/erc721/transfers_ethereum_erc721.sql
@@ -24,8 +24,8 @@ with
             {{ source('erc721_ethereum', 'evt_transfer') }}
     )
     
-select 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, tokenId, amount
+select 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, tokenId, amount, unique_tx_id
 from sent_transfers
 union all
-select 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, tokenId, amount
+select 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, tokenId, amount, unique_tx_id
 from received_transfers

--- a/spellbook/models/transfers/ethereum/erc721/transfers_ethereum_erc721_agg_day.sql
+++ b/spellbook/models/transfers/ethereum/erc721/transfers_ethereum_erc721_agg_day.sql
@@ -2,7 +2,8 @@
         alias ='erc721_agg_day',
         materialized ='incremental',
         file_format ='delta',
-        incremental_strategy='merge'
+        incremental_strategy='merge',
+        unique_key='unique_transfer_id'
         )
 }}
 
@@ -11,12 +12,13 @@ select
     date_trunc('day', evt_block_time) as day,
     wallet_address,
     token_address,
-    tokenId
+    tokenId,
+    unique_tx_id || '-' || wallet_address || '-' || token_address || tokenId as unique_transfer_id
 from {{ ref('transfers_ethereum_erc721') }}
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
 where evt_block_time > now() - interval 2 days
 {% endif %}
 group by
-    date_trunc('day', evt_block_time), wallet_address, token_address, tokenId
+    date_trunc('day', evt_block_time), wallet_address, token_address, tokenId,unique_tx_id
 having sum(amount) = 1

--- a/spellbook/models/transfers/ethereum/erc721/transfers_ethereum_erc721_agg_hour.sql
+++ b/spellbook/models/transfers/ethereum/erc721/transfers_ethereum_erc721_agg_hour.sql
@@ -2,7 +2,8 @@
         alias ='erc721_agg_hour',
         materialized ='incremental',
         file_format ='delta',
-        incremental_strategy='merge'
+        incremental_strategy='merge',
+        unique_key='unique_transfer_id'
         )
 }}
 
@@ -11,12 +12,13 @@ select
     date_trunc('hour', evt_block_time) as hour,
     wallet_address,
     token_address,
-    tokenId
+    tokenId,
+    unique_tx_id || '-' || wallet_address || '-' || token_address || tokenId as unique_transfer_id
 from {{ ref('transfers_ethereum_erc721') }}
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
 where evt_block_time > now() - interval 2 days
 {% endif %}
 group by
-    date_trunc('hour', evt_block_time), wallet_address, token_address, tokenId
+    date_trunc('hour', evt_block_time), wallet_address, token_address, tokenId,unique_tx_id
 having sum(amount) = 1


### PR DESCRIPTION
The fact that we found out very late about duplicates in erc20/721 transfers + transfers tables took quite a long time to build got me investigating the incremental strategy we used.

Turns out we didn't include the unique_key parameter while using the merge strategy, which basically means the table was rebuilt everytime, without checking for uniqueness.

This PR adresses this issue, and improves both build time and compute costs

I've checked that:

* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [ ] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
