### PR TITLE
fix incremental strategy from append to merge into

### DIFF
--- a/spellbook/models/magiceden/magiceden_trades.sql
+++ b/spellbook/models/magiceden/magiceden_trades.sql
@@ -1,7 +1,9 @@
 {{ config(
         alias ='trades',
         materialized ='incremental',
-        file_format ='delta'
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_trade_id'
         )
 }}
 

--- a/spellbook/models/nft/nft_trades.sql
+++ b/spellbook/models/nft/nft_trades.sql
@@ -1,7 +1,9 @@
 {{ config(
         alias ='trades',
         materialized ='incremental',
-        file_format ='delta'
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_trade_id'
         )
 }}
 

--- a/spellbook/models/opensea/opensea_trades.sql
+++ b/spellbook/models/opensea/opensea_trades.sql
@@ -1,7 +1,9 @@
 {{ config(
         alias ='trades',
         materialized ='incremental',
-        file_format ='delta'
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_trade_id'
         )
 }}
 

--- a/spellbook/models/transfers/ethereum/erc1155/transfers_ethereum_erc1155_agg_day.sql
+++ b/spellbook/models/transfers/ethereum/erc1155/transfers_ethereum_erc1155_agg_day.sql
@@ -1,7 +1,9 @@
 {{ config(
         alias ='erc1155_agg_day',
         materialized ='incremental',
-        file_format ='delta'
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_transfer_id'
         )
 }}
 

--- a/spellbook/models/transfers/ethereum/erc1155/transfers_ethereum_erc1155_agg_hour.sql
+++ b/spellbook/models/transfers/ethereum/erc1155/transfers_ethereum_erc1155_agg_hour.sql
@@ -1,7 +1,9 @@
 {{ config(
         alias ='erc1155_agg_hour',
         materialized ='incremental',
-        file_format ='delta'
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_transfer_id'
         )
 }}
 

--- a/spellbook/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_day.sql
+++ b/spellbook/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_day.sql
@@ -1,7 +1,9 @@
 {{ config(
         alias ='erc20_agg_day',
         materialized ='incremental',
-        file_format ='delta'
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_transfer_id'
         )
 }}
 

--- a/spellbook/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_hour.sql
+++ b/spellbook/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_hour.sql
@@ -1,7 +1,9 @@
 {{ config(
         alias ='erc20_agg_hour', 
         materialized ='incremental',
-        file_format ='delta'
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_transfer_id'
         )
 }}
 

--- a/spellbook/models/transfers/ethereum/erc721/transfers_ethereum_erc721_agg_day.sql
+++ b/spellbook/models/transfers/ethereum/erc721/transfers_ethereum_erc721_agg_day.sql
@@ -1,7 +1,9 @@
 {{ config(
         alias ='erc721_agg_day', 
         materialized ='incremental',
-        file_format ='delta'
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_transfer_id'
         )
 }}
 

--- a/spellbook/models/transfers/ethereum/erc721/transfers_ethereum_erc721_agg_hour.sql
+++ b/spellbook/models/transfers/ethereum/erc721/transfers_ethereum_erc721_agg_hour.sql
@@ -1,7 +1,9 @@
 {{ config(
         alias ='erc721_agg_hour', 
         materialized ='incremental',
-        file_format ='delta'
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_transfer_id'
         )
 }}
 

--- a/spellbook/models/uniswap/uniswap_trades.sql
+++ b/spellbook/models/uniswap/uniswap_trades.sql
@@ -1,7 +1,9 @@
 {{ config(
         alias ='trades',
         materialized ='incremental',
-        file_format ='delta'
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_trade_id'
         )
 }}
 


### PR DESCRIPTION
After trying a new incremental strategy with a simple append instead of merge into, I realized this conflicts with our trick to append for the last two days (and not based on the max timestamp). This results in data being duplicated for the last 2 days every 15 minutes...so I want to reverse these changes and switch back to a merge into strategy until we figure out a new/faster way of updating our incremental tables.

I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] the directory tree matches the pattern /sector/blockchain/ e.g. /tokens/ethereum
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each file has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
