### PR TITLE
Update list of coingecko API IDs for Polygon assets

### DIFF
--- a/prices/polygon/coingecko.yaml
+++ b/prices/polygon/coingecko.yaml
@@ -432,3 +432,17 @@
 - id: sphere-finance
 - id: yam-2
 - id: meshswap-protocol
+- id: amp-token
+- id: band-protocol
+- id: binance-usd
+- id: bancor
+- id: gyen
+- id: gnosis
+- id: ethereum-name-service
+- id: adbank
+- id: tower
+- id: biconomy
+- id: storj
+- id: avalanche-2
+- id: cosmos
+- id: near


### PR DESCRIPTION
Brief comments on the purpose of your changes:
Add price listings for 14 most-traded tokens on Clipper Coves Polygon as a separate PR.

Requested by @jeff-dude as part of https://github.com/duneanalytics/abstractions/pull/1202#issuecomment-1167646524

