### PR TITLE
replace unique_tx_id by unique_transfer_id to match schema

### DIFF
--- a/spellbook/models/transfers/ethereum/erc20/transfers_ethereum_erc20.sql
+++ b/spellbook/models/transfers/ethereum/erc20/transfers_ethereum_erc20.sql
@@ -3,7 +3,7 @@
 with
     sent_transfers as (
         select
-            'send' || '-' || evt_tx_hash || '-' || evt_index || '-' || `to` as unique_tx_id,
+            'send' || '-' || evt_tx_hash || '-' || evt_index || '-' || `to` as unique_transfer_id,
             `to` as wallet_address,
             contract_address as token_address,
             evt_block_time,
@@ -15,7 +15,7 @@ with
     ,
     received_transfers as (
         select
-        'receive' || '-' || evt_tx_hash || '-' || evt_index || '-' || `from` as unique_tx_id,
+        'receive' || '-' || evt_tx_hash || '-' || evt_index || '-' || `from` as unique_transfer_id,
         `from` as wallet_address,
         contract_address as token_address,
         evt_block_time,
@@ -27,7 +27,7 @@ with
     ,
     deposited_weth as (
         select
-            'deposit' || '-' || evt_tx_hash || '-' || evt_index || '-' || dst as unique_tx_id,
+            'deposit' || '-' || evt_tx_hash || '-' || evt_index || '-' || dst as unique_transfer_id,
             dst as wallet_address,
             contract_address as token_address,
             evt_block_time,
@@ -39,7 +39,7 @@ with
     ,
     withdrawn_weth as (
         select
-            'withdrawn' || '-' || evt_tx_hash || '-' || evt_index || '-' || src as unique_tx_id,
+            'withdrawn' || '-' || evt_tx_hash || '-' || evt_index || '-' || src as unique_transfer_id,
             src as wallet_address,
             contract_address as token_address,
             evt_block_time,
@@ -48,14 +48,14 @@ with
             {{ source('zeroex_ethereum', 'weth9_evt_withdrawal') }}
     )
     
-select unique_tx_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
+select unique_transfer_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
 from sent_transfers
 union
-select unique_tx_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
+select unique_transfer_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
 from received_transfers
 union
-select unique_tx_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
+select unique_transfer_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
 from deposited_weth
 union
-select unique_tx_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
+select unique_transfer_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
 from withdrawn_weth


### PR DESCRIPTION
This was causing the erc20 transfers uniqueness test to fail

Brief comments on the purpose of your changes:


*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
