### PR TITLE
GH Action name schema by branch

### DIFF
--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Set schema var
-      run: echo "pr_schema=$(echo ${{ github.ref_name}} | tr - _)" >> $PR_SCHEMA
+        run: echo "pr_schema=$(echo ${{ github.ref_name}} | tr - _)" >> $PR_SCHEMA
 
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -44,7 +44,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: $PR_SCHEMA
+          SCHEMA: echo $PR_SCHEMA
         run: |
           echo "2
           $DATABRICKS_HOST
@@ -60,7 +60,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: $PR_SCHEMA
+          SCHEMA: echo $PR_SCHEMA
         run: |
           echo "1
           $DATABRICKS_HOST
@@ -84,7 +84,7 @@ jobs:
         run: |
           curl  -o spellbook/manifest.json \
             --request GET \
-            --url https://cloud.getdbt.com/api/v2/accounts/58579/runs/$DBT_RUN_ID/artifacts/manifest.json \
+            --url https://cloud.getdbt.com/api/v2/accounts/58579/runs/echo $DBT_RUN_ID/artifacts/manifest.json \
             --header 'Content-Type: application/json' \
             --header 'Authorization: Token ${{ secrets.DBT_API_TOKEN }}'
 

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -11,7 +11,10 @@ jobs:
 
     steps:
       - name: test
-        run: ${${{ github.ref_name}} | sed 's/ /-/_'
+        run: echo "${{ github.ref_name}}" | tr - _
+
+      - name: test var
+        run: echo "${{ github.ref_name}}" | tr - _ >> $PR_SCHEMA
 
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -44,7 +47,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: ${${{ github.ref_name}}//[0-9]/X}
+          SCHEMA: $PR_SCHEMA
         run: |
           echo "2
           $DATABRICKS_HOST
@@ -60,7 +63,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: ${${{ github.ref_name}}//[0-9]/X}
+          SCHEMA: $PR_SCHEMA
         run: |
           echo "1
           $DATABRICKS_HOST

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Set DBT schema
-        run: echo "PR_SCHEMA=$(${{ github.ref_name}} | tr - _)" >> $GITHUB_ENV
+        run: echo "PR_SCHEMA=$(echo ${{ github.ref_name}} | tr - _)" >> $GITHUB_ENV
 
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -35,7 +35,7 @@ jobs:
           pipenv install
 
       - name: test
-        run: echo "${{ env.GITHUB_REF_NAME }}"
+        run: echo "$GITHUB_REF_NAME"
 
       - name: DBT configure
         working-directory: ./spellbook
@@ -44,7 +44,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: ${{ env.GITHUB_REF_NAME }}
+          SCHEMA: $GITHUB_REF_NAME
         run: |
           echo "2
           $DATABRICKS_HOST
@@ -60,7 +60,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: ${{ env.GITHUB_REF_NAME }}
+          SCHEMA: $GITHUB_REF_NAME
         run: |
           echo "1
           $DATABRICKS_HOST

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: test
+        run: echo "${{ github.ref_name}}//-/_ "
+
       - name: Check out repository code
         uses: actions/checkout@v2
 
@@ -34,9 +37,6 @@ jobs:
         run: |
           pipenv install
 
-      - name: test
-        run: echo "${{ github.ref_name }}"
-
       - name: DBT configure
         working-directory: ./spellbook
         continue-on-error: true
@@ -44,7 +44,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: ${{ github.ref_name }}
+          SCHEMA: ${{ github.ref_name}}//-/_
         run: |
           echo "2
           $DATABRICKS_HOST
@@ -60,7 +60,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: ${{ github.ref_name }}
+          SCHEMA: ${{ github.ref_name}}//-/_
         run: |
           echo "1
           $DATABRICKS_HOST

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -41,7 +41,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: "github_actions"
+          SCHEMA: ${{ env.GITHUB_REF_NAME }}
         run: |
           echo "2
           $DATABRICKS_HOST
@@ -57,7 +57,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: "github_actions"
+          SCHEMA: ${{ env.GITHUB_REF_NAME }}
         run: |
           echo "1
           $DATABRICKS_HOST

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -10,11 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: test
-        run: echo "${{ github.ref_name}}" | tr - _
-
-      - name: test var
-        run: echo "pr_schema=$(${{ github.ref_name}}" | tr - _)" >> $PR_SCHEMA
+      - name: Set schema var
+      run: echo "pr_schema=$(echo ${{ github.ref_name}} | tr - _)" >> $PR_SCHEMA
 
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -2,8 +2,8 @@
 name: dbt slim ci
 on:
   push:
-    paths:
-      - 'spellbook/**'
+#    paths:
+#      - 'spellbook/**'
 
 jobs:
   dbt-test:

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -44,13 +44,12 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: echo $PR_SCHEMA
         run: |
           echo "2
           $DATABRICKS_HOST
           $DATABRICKS_HTTPS_PATH
           $DATABRICKS_ACCESS_TOKEN
-          $SCHEMA
+          $PR_SCHEMA
           1" | pipenv run dbt init
 
       - name: DBT configure take 2 (sometimes dbt init switches the order of db options)
@@ -60,13 +59,12 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: echo $PR_SCHEMA
         run: |
           echo "1
           $DATABRICKS_HOST
           $DATABRICKS_HTTPS_PATH
           $DATABRICKS_ACCESS_TOKEN
-          $SCHEMA
+          $PR_SCHEMA
           1" | pipenv run dbt init
 
       - name: Fetch latest run_id
@@ -84,7 +82,7 @@ jobs:
         run: |
           curl  -o spellbook/manifest.json \
             --request GET \
-            --url https://cloud.getdbt.com/api/v2/accounts/58579/runs/echo $DBT_RUN_ID/artifacts/manifest.json \
+            --url https://cloud.getdbt.com/api/v2/accounts/58579/runs/$DBT_RUN_ID/artifacts/manifest.json \
             --header 'Content-Type: application/json' \
             --header 'Authorization: Token ${{ secrets.DBT_API_TOKEN }}'
 

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -2,8 +2,8 @@
 name: dbt slim ci
 on:
   push:
-#    paths:
-#      - 'spellbook/**'
+    paths:
+      - 'spellbook/**'
 
 jobs:
   dbt-test:

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -2,14 +2,17 @@
 name: dbt slim ci
 on:
   push:
-#    paths:
-#      - 'spellbook/**'
+    paths:
+      - 'spellbook/**'
 
 jobs:
   dbt-test:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set DBT schema
+        run: echo "PR_SCHEMA=$(${{ github.ref_name}} | tr - _)" >> $GITHUB_ENV
+
       - name: Check out repository code
         uses: actions/checkout@v2
 
@@ -41,7 +44,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: ${{ github.ref_name}} | tr - _
+          SCHEMA: $PR_SCHEMA
         run: |
           echo "2
           $DATABRICKS_HOST
@@ -57,7 +60,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: ${{ github.ref_name}} | tr - _
+          SCHEMA: $PR_SCHEMA
         run: |
           echo "1
           $DATABRICKS_HOST
@@ -75,13 +78,13 @@ jobs:
           debug: true
 
       - name: Set env, 2nd to last run_id (avoids fetching in progress runs)
-        run: echo "dbt_run_id=$(jq .data[1].id fetch-api-data-action/data.json)" >> $GITHUB_ENV
+        run: echo "DBT_RUN_ID=$(jq .data[1].id fetch-api-data-action/data.json)" >> $GITHUB_ENV
 
       - name: Fetch latest manifest.json
         run: |
           curl  -o spellbook/manifest.json \
             --request GET \
-            --url https://cloud.getdbt.com/api/v2/accounts/58579/runs/62469111/artifacts/manifest.json \
+            --url https://cloud.getdbt.com/api/v2/accounts/58579/runs/$DBT_RUN_ID/artifacts/manifest.json \
             --header 'Content-Type: application/json' \
             --header 'Authorization: Token ${{ secrets.DBT_API_TOKEN }}'
 

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: test
-        run: echo "${${{ github.ref_name}}//-/_}"
+        run: ${${{ github.ref_name}} | sed 's/ /-/_'
 
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -10,9 +10,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set schema var
-        run: echo "pr_schema=$(echo ${{ github.ref_name}} | tr - _)" >> $PR_SCHEMA
-
       - name: Check out repository code
         uses: actions/checkout@v2
 
@@ -44,7 +41,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: $PR_SCHEMA
+          SCHEMA: ${{ github.ref_name}} | tr - _
         run: |
           echo "2
           $DATABRICKS_HOST
@@ -60,7 +57,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: $PR_SCHEMA
+          SCHEMA: ${{ github.ref_name}} | tr - _
         run: |
           echo "1
           $DATABRICKS_HOST

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -2,8 +2,8 @@
 name: dbt slim ci
 on:
   push:
-    paths:
-      - 'spellbook/**'
+#    paths:
+#      - 'spellbook/**'
 
 jobs:
   dbt-test:
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: test
-        run: echo   "${${{ github.ref_name}}//[0-9]/X}"
+        run: echo "${${{ github.ref_name}}//-/_}"
 
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: test
-        run: echo "${{ github.ref_name}}//-/_ "
+        run: echo   "${${{ github.ref_name}}//[0-9]/X}"
 
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: ${{ github.ref_name}}//-/_
+          SCHEMA: ${${{ github.ref_name}}//[0-9]/X}
         run: |
           echo "2
           $DATABRICKS_HOST
@@ -60,7 +60,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: ${{ github.ref_name}}//-/_
+          SCHEMA: ${${{ github.ref_name}}//[0-9]/X}
         run: |
           echo "1
           $DATABRICKS_HOST

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -35,7 +35,7 @@ jobs:
           pipenv install
 
       - name: test
-        run: echo "$GITHUB_REF_NAME"
+        run: echo "${{ github.ref_name }}"
 
       - name: DBT configure
         working-directory: ./spellbook
@@ -44,7 +44,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: $GITHUB_REF_NAME
+          SCHEMA: ${{ github.ref_name }}
         run: |
           echo "2
           $DATABRICKS_HOST
@@ -60,7 +60,7 @@ jobs:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTPS_PATH: ${{ secrets.DATABRICKS_HTTPS_PATH }}
           DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
-          SCHEMA: $GITHUB_REF_NAME
+          SCHEMA: ${{ github.ref_name }}
         run: |
           echo "1
           $DATABRICKS_HOST

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -14,7 +14,7 @@ jobs:
         run: echo "${{ github.ref_name}}" | tr - _
 
       - name: test var
-        run: echo "${{ github.ref_name}}" | tr - _ >> $PR_SCHEMA
+        run: echo "pr_schema=$(${{ github.ref_name}}" | tr - _)" >> $PR_SCHEMA
 
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/dbt_slim_CI.yml
+++ b/.github/workflows/dbt_slim_CI.yml
@@ -34,6 +34,9 @@ jobs:
         run: |
           pipenv install
 
+      - name: test
+        run: echo "${{ env.GITHUB_REF_NAME }}"
+
       - name: DBT configure
         working-directory: ./spellbook
         continue-on-error: true

--- a/spellbook/models/balances/ethereum/balances_ethereum_schema.yml
+++ b/spellbook/models/balances/ethereum/balances_ethereum_schema.yml
@@ -11,7 +11,7 @@ models:
       tags: ['balances', 'ethereum', 'erc20', 'hour', 'soispoke', 'dot2dotseurat']
     description: >
         Hourly token balances of ERC20 Ethereum tokens per wallet and contract address pair.
-        Depends on erc20_ethereum_transfers.
+        Depends on erc20_ethereum_transfers
     columns:
       - &blockchain
         name: blockchain

--- a/spellbook/models/balances/ethereum/balances_ethereum_schema.yml
+++ b/spellbook/models/balances/ethereum/balances_ethereum_schema.yml
@@ -145,7 +145,7 @@ models:
       tags: ['balances', 'ethereum', 'erc721', 'hour', 'soispoke', 'dot2dotseurat', 'hildobby']
     description: >
         Hourly token balances of ERC721 Ethereum tokens per wallet and contract address pair.
-        Depends on erc721_ethereum_transfers.
+        Depends on erc721_ethereum_transfers..
     columns:
       - *blockchain
       - *hour

--- a/spellbook/models/balances/ethereum/balances_ethereum_schema.yml
+++ b/spellbook/models/balances/ethereum/balances_ethereum_schema.yml
@@ -145,7 +145,7 @@ models:
       tags: ['balances', 'ethereum', 'erc721', 'hour', 'soispoke', 'dot2dotseurat', 'hildobby']
     description: >
         Hourly token balances of ERC721 Ethereum tokens per wallet and contract address pair.
-        Depends on erc721_ethereum_transfers.
+        Depends on erc721_ethereum_transfers
     columns:
       - *blockchain
       - *hour

--- a/spellbook/models/balances/ethereum/balances_ethereum_schema.yml
+++ b/spellbook/models/balances/ethereum/balances_ethereum_schema.yml
@@ -145,7 +145,7 @@ models:
       tags: ['balances', 'ethereum', 'erc721', 'hour', 'soispoke', 'dot2dotseurat', 'hildobby']
     description: >
         Hourly token balances of ERC721 Ethereum tokens per wallet and contract address pair.
-        Depends on erc721_ethereum_transfers
+        Depends on erc721_ethereum_transfers.
     columns:
       - *blockchain
       - *hour

--- a/spellbook/models/balances/ethereum/balances_ethereum_schema.yml
+++ b/spellbook/models/balances/ethereum/balances_ethereum_schema.yml
@@ -145,7 +145,7 @@ models:
       tags: ['balances', 'ethereum', 'erc721', 'hour', 'soispoke', 'dot2dotseurat', 'hildobby']
     description: >
         Hourly token balances of ERC721 Ethereum tokens per wallet and contract address pair.
-        Depends on erc721_ethereum_transfers..
+        Depends on erc721_ethereum_transfers.
     columns:
       - *blockchain
       - *hour


### PR DESCRIPTION
Brief comments on the purpose of your changes:
Currently, the GH Action Slim sets all workflow runs to the schema SCHEMA: "github_actions"

In the dbt cloud PR job, each job is name spaced by its own PR. This update uses the github action environment variables to name the schema based on the PR branch/fork.

n/a below
*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
