### PR TITLE
Add $CFTI to coinpaprika.yaml

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -2159,3 +2159,8 @@
   symbol: NOTE
   address: 0xCFEAead4947f0705A14ec42aC3D44129E1Ef3eD5
   decimals: 8
+- name: Confetti
+  id: cfti-confetti
+  symbol: CFTI
+  address: 0xCfef8857E9C80e3440A823971420F7Fa5F62f020
+  decimals: 18


### PR DESCRIPTION
Brief comments on the purpose of your changes:

I added the Confetti coin that's primarily used by the Raid Party, an on-chain idle game (https://raid.party).
Useful links:
- https://raid.party
- https://etherscan.io/address/0xcfef8857e9c80e3440a823971420f7fa5f62f020 ($CFTI)
- https://coinpaprika.com/coin/cfti-confetti
- https://dune.xyz/mariopaolo/raidparty (Most popular Dune dashboard for the game)
- https://dune.com/mariopaolo/raidpartycost

cc @mariopaolo, who created those dashboards
