### PR TITLE
[WIP] T 13857 write read schema to delta

### DIFF
--- a/spellbook/macros/generate_schema_name.sql
+++ b/spellbook/macros/generate_schema_name.sql
@@ -1,9 +1,13 @@
 {% macro generate_schema_name(custom_schema_name, node) -%}
 
     {%- set default_schema = target.schema -%}
-    {%- if target.name == 'prod' or target.schema == 'wizard' and custom_schema_name is not none -%}
+    {%- if target.name == 'prod' and custom_schema_name is not none -%}
 
         {{ custom_schema_name | trim }}
+
+    {%- elif 'dbt_meghan' in target.schema and custom_schema_name is not none -%}
+
+        delta
 
     {%- elif custom_schema_name is none -%}
 

--- a/spellbook/macros/get_alias_name.sql
+++ b/spellbook/macros/get_alias_name.sql
@@ -1,0 +1,45 @@
+{#
+    Renders a alias name given a custom alias name. If the custom
+    alias name is none, then the resulting alias is just the filename of the
+    model. If an alias override is specified, then that is used.
+
+    This macro can be overriden in projects to define different semantics
+    for rendering a alias name.
+
+    Arguments:
+    custom_alias_name: The custom alias name specified for a model, or none
+    node: The available node that an alias is being generated for, or none
+
+#}
+
+{% macro generate_alias_name(custom_alias_name=none, node=none) -%}
+    {% do return(adapter.dispatch('generate_alias_name', 'dbt')(custom_alias_name, node)) %}
+{%- endmacro %}
+
+{% macro default__generate_alias_name(custom_alias_name=none, node=none) -%}
+
+    {%- if 'dbt_meghan' not in target.schema -%}
+        {%- if custom_alias_name is none -%}
+
+            {{ node.name }}
+
+        {%- else -%}
+
+            {{ custom_alias_name | trim }}
+
+        {%- endif -%}
+
+    {%- else -%}
+        {%- if custom_alias_name is none -%}
+
+            {{ "s3a://meghan-sandbox/" + target.schema + '/' + node.name }}
+
+        {%- else -%}
+
+            {{ "s3a://meghan-sandbox/" + target.schema + '/' + node.name + '_' + custom_alias_name | trim }}
+
+        {%- endif -%}
+
+    {%- endif -%}
+
+{%- endmacro %}


### PR DESCRIPTION
Brief comments on the purpose of your changes:
This work is a work in progress. I'm creating this PR just to share what's possible so far; I don't intend to merge. 

We can alter the alias and schemas generated by DBT to read from delta s3 files. But there's a lot more work needed to write to s3. 

The macros in this PR compile table/view names to unique s3 file names. `dbt_meghan` is my personal schema but we could trivially make this unique to each forked PR by setting the schema name to the github_ref_name in the Github Action.

```
 (SELECT
    wallet_address,
    ... 
    lead(hour, 1, now()) OVER (PARTITION BY token_address, wallet_address ORDER BY hour) AS next_hour
    FROM delta.s3a://meghan-sandbox/dbt_meghan/transfers_ethereum_erc20_rolling_hour_erc20_rolling_hour)

```

HOWEVER, we also need to write to the same location. DBT compiles the materialization for us, the view creation would compile to something like:
```
20:48:35    == SQL ==
20:48:35    /* {"app": "dbt", "dbt_version": "1.1.1", "profile_name": "spellbook", "target_name": "dev", "node_id": "model.spellbook.transfers_ethereum_erc20"} */
20:48:35    create or replace view delta.s3a://meghan-sandbox/dbt_meghan/transfers_ethereum_erc20_erc20
20:48:35    --------------------------------^^^
```
This obviously doesn't work. 


We might be able to rewrite the way the materialization work. 

A more expedient path would be use separate metastores like metastore1.pr_110_dex.trades. Then we would only need to edit the same files in this PR. We wouldn't need to mess around with the DBT materialization strategies. 

*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
