### PR TITLE
Update OP Kwenta DEX Insert

### DIFF
--- a/optimism2/dex/insert_kwenta.sql
+++ b/optimism2/dex/insert_kwenta.sql
@@ -76,9 +76,9 @@ WITH rows AS (
 	--Synthetix event uses hash keys for tokens, so we pull ERC20 transfers instead
     FROM synthetix."MintableSynthetix_evt_SynthExchange" se
 -- to-do: Find a way to validate that this is the Synthetix token and not a token with the same symbol
-    INNER JOIN erc20.tokens send
+    LEFT JOIN erc20.tokens send
         ON send."symbol" = split_part(encode("fromCurrencyKey", 'escape'),'\',1)
-    INNER JOIN erc20.tokens rec
+    LEFT JOIN erc20.tokens rec
         ON rec."symbol" = split_part(encode("toCurrencyKey", 'escape'),'\',1)
 
 	WHERE se.evt_block_time >= start_ts AND se.evt_block_time < end_ts

--- a/optimism2/dex/insert_kwenta.sql
+++ b/optimism2/dex/insert_kwenta.sql
@@ -63,8 +63,8 @@ WITH rows AS (
             'DEX' AS category,
             se."toAddress" AS trader_a,
             NULL::bytea AS trader_b,
-	    -- Receive token_a, Send token_b
-	    se."toAmount" AS token_a_amount_raw,
+            -- Receive token_a, Send token_b
+            se."toAmount" AS token_a_amount_raw,
             se."fromAmount" AS token_b_amount_raw,
             NULL::numeric AS usd_amount,
             rec.contract_address AS token_a_address,
@@ -73,23 +73,23 @@ WITH rows AS (
             se.evt_tx_hash AS tx_hash,
             NULL::integer[] AS trace_address,
             se.evt_index
-	--Synthetix event uses hash keys for tokens, so we pull ERC20 transfers instead
-    FROM synthetix."MintableSynthetix_evt_SynthExchange" se
--- to-do: Find a way to validate that this is the Synthetix token and not a token with the same symbol
-    LEFT JOIN erc20.tokens send
-        ON send."symbol" = split_part(encode("fromCurrencyKey", 'escape'),'\',1)
-    LEFT JOIN erc20.tokens rec
-        ON rec."symbol" = split_part(encode("toCurrencyKey", 'escape'),'\',1)
+        --Synthetix event uses hash keys for tokens, so we pull ERC20 transfers instead
+        FROM synthetix."MintableSynthetix_evt_SynthExchange" se
+        -- to-do: Find a way to validate that this is the Synthetix token and not a token with the same symbol
+        LEFT JOIN erc20.tokens send
+            ON send."symbol" = split_part(encode("fromCurrencyKey", 'escape'),'\',1)
+        LEFT JOIN erc20.tokens rec
+            ON rec."symbol" = split_part(encode("toCurrencyKey", 'escape'),'\',1)
 
-	WHERE se.evt_block_time >= start_ts AND se.evt_block_time < end_ts
+        WHERE se.evt_block_time >= start_ts AND se.evt_block_time < end_ts
 
     ) dexs
     INNER JOIN optimism.transactions tx
         ON dexs.tx_hash = tx.hash
         AND tx.block_time >= start_ts
         AND tx.block_time < end_ts
---        AND tx.block_number >= start_block
---        AND tx.block_number < end_block
+        -- AND tx.block_number >= start_block
+        -- AND tx.block_number < end_block
     LEFT JOIN erc20.tokens erc20a ON erc20a.contract_address = dexs.token_a_address
     LEFT JOIN erc20.tokens erc20b ON erc20b.contract_address = dexs.token_b_address
     LEFT JOIN prices.approx_prices_from_dex_data pa
@@ -119,6 +119,7 @@ END
 $function$;
 
 -- fill 2021 (post-regenesis 11-11)
+delete FROM dex.trades WHERE project='Kwenta';
 SELECT dex.insert_kwenta(
     '2021-11-10',
     now()


### PR DESCRIPTION
Brief comments on the purpose of your changes:
Updating the Optimism DEX Trades insert for Kwenta to better pick the tokens traded.

Would we be able to wipe and re-insert the Kwenta trades? Some more recent trades are showing sETH for sETH because of multi-hops causing an issue with the prior construction.

Eventually we'd need to figure out some verification that we're picking the synth token contract addresses and not another token with the same symbol (maybe add a 'project name' field to erc20 tokens?)


*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
