### PR TITLE
T 13944 fix uniswap unique trade

### DIFF
--- a/spellbook/models/uniswap/ethereum/uniswap_v2_ethereum_trades.sql
+++ b/spellbook/models/uniswap/ethereum/uniswap_v2_ethereum_trades.sql
@@ -6,7 +6,6 @@
 }}
 
 SELECT
-    'v2' || '-' ||  tx_hash || '-' || evt_index::string as unique_trade_id,
     'ethereum' as blockchain,
     'uniswap' as project, 
     'v2' as version,
@@ -27,7 +26,8 @@ SELECT
     exchange_contract_address,
     tx_hash,
     tx.from as tx_from,
-    tx.to as tx_to
+    tx.to as tx_to,
+    tx_hash || '-' || evt_index::string || '-' || token_a_address || '-' || token_a_amount_raw::string as unique_trade_id
 FROM (
     --Uniswap v2
     SELECT

--- a/spellbook/models/uniswap/ethereum/uniswap_v3_ethereum_trades.sql
+++ b/spellbook/models/uniswap/ethereum/uniswap_v3_ethereum_trades.sql
@@ -2,8 +2,7 @@
         alias='trades')
 }}
         
-SELECT
-    'v3' || '-' || tx_hash || '-' || evt_index::string as unique_trade_id,
+SELECT DISTINCT
     'ethereum' as blockchain,
     'uniswap' as project, 
     'v3' as version,
@@ -24,7 +23,8 @@ SELECT
     exchange_contract_address,
     tx_hash,
     tx.from as tx_from,
-    tx.to as tx_to
+    tx.to as tx_to,
+    tx_hash || '-' || evt_index::string || '-' || token_a_amount_raw::string as unique_trade_id
     FROM (--Uniswap v3
     SELECT
     t.evt_block_time AS block_time,


### PR DESCRIPTION
Quick fix of the uniswap v3 unique_trade_id so it's actually unique and the merge into incremental strategy doesn't fail

Brief comments on the purpose of your changes:


*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
