### PR TITLE
added version to unique_trade_id again and distinct to uniswap trades…

### DIFF
--- a/spellbook/models/uniswap/ethereum/uniswap_ethereum_trades.sql
+++ b/spellbook/models/uniswap/ethereum/uniswap_ethereum_trades.sql
@@ -3,7 +3,7 @@
         alias='trades')
 }}
 
-SELECT blockchain, project, version, block_time, token_a_symbol, token_b_symbol, 
+SELECT DISTINCT blockchain, project, version, block_time, token_a_symbol, token_b_symbol, 
        token_a_amount, token_b_amount, trader_a, trader_b, usd_amount, token_a_address, 
        token_b_address, exchange_contract_address, tx_hash, tx_from, tx_to, unique_trade_id
 FROM (SELECT * FROM {{ ref('uniswap_v2_ethereum_trades') }} 

--- a/spellbook/models/uniswap/ethereum/uniswap_v2_ethereum_trades.sql
+++ b/spellbook/models/uniswap/ethereum/uniswap_v2_ethereum_trades.sql
@@ -5,7 +5,7 @@
   )
 }}
 
-SELECT
+SELECT DISTINCT
     'ethereum' as blockchain,
     'uniswap' as project, 
     'v2' as version,
@@ -27,7 +27,7 @@ SELECT
     tx_hash,
     tx.from as tx_from,
     tx.to as tx_to,
-    tx_hash || '-' || evt_index::string || '-' || token_a_address || '-' || token_a_amount_raw::string as unique_trade_id
+    'v2' || '-' || tx_hash || '-' || evt_index::string || '-' || token_a_address || '-' || token_a_amount_raw::string as unique_trade_id
 FROM (
     --Uniswap v2
     SELECT

--- a/spellbook/models/uniswap/ethereum/uniswap_v3_ethereum_trades.sql
+++ b/spellbook/models/uniswap/ethereum/uniswap_v3_ethereum_trades.sql
@@ -2,7 +2,7 @@
         alias='trades')
 }}
         
-SELECT DISTINCT
+SELECT
     'ethereum' as blockchain,
     'uniswap' as project, 
     'v3' as version,
@@ -24,7 +24,7 @@ SELECT DISTINCT
     tx_hash,
     tx.from as tx_from,
     tx.to as tx_to,
-    tx_hash || '-' || evt_index::string || '-' || token_a_amount_raw::string as unique_trade_id
+    'v3' || '-' ||  tx_hash || '-' || evt_index::string || '-' || token_a_amount_raw::string as unique_trade_id
     FROM (--Uniswap v3
     SELECT
     t.evt_block_time AS block_time,

--- a/spellbook/models/uniswap/uniswap_trades.yml
+++ b/spellbook/models/uniswap/uniswap_trades.yml
@@ -9,7 +9,7 @@ models:
     config:
       tags: ['ethereum','uniswap','trades']
     description: >
-        Uniswap V1 trades
+        Uniswap trades
     columns:
       - &blockchain
         name: blockchain


### PR DESCRIPTION
… to make sure we have no dupes

Some duplicates were actually cause by txs like this one: https://etherscan.io/tx/0x956dd8bded921b16b93fd0a89d5ae1db53c5ed5fc06d1f548a8c438c17492338
where both uniswap v3 and v2 contracts were used in the same tx

Brief comments on the purpose of your changes:


*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
