### PR TITLE
add backfill jobs for seaport abstractions

### DIFF
--- a/ethereum/seaport/backfill_transactions.sql
+++ b/ethereum/seaport/backfill_transactions.sql
@@ -1,0 +1,36 @@
+CREATE OR REPLACE FUNCTION seaport.backfill_transactions() RETURNS boolean
+LANGUAGE plpgsql AS $function$
+BEGIN
+
+-- backfill usd_price, fee_usd_price, royalty_usd_amount
+update seaport.transactions
+   set usd_amount = new.new_usd_amount
+      ,fee_usd_amount = new.new_fee_usd_amount
+      ,royalty_usd_amount = new.new_royalty_usd_amount
+  from (select a.tx_hash
+              ,a.original_amount_raw / 10^t.decimals * p.price as new_usd_amount
+              ,a.fee_amount_raw / 10^t.decimals * p.price as new_fee_usd_amount
+              ,a.royalty_amount_raw / 10^t.decimals * p.price as new_royalty_usd_amount
+          from seaport.transactions a
+               inner join prices.usd p on p.contract_address = a.currency_contract
+                            		   and date_trunc('minute', a.block_time) = p."minute"
+                                       and p.minute >= '2022-05-15'
+               inner join erc20.tokens t on t.contract_address = a.currency_contract
+         where a.usd_amount is null
+        ) as new
+  where transactions.tx_hash = new.tx_hash
+;
+
+RETURN TRUE;
+END
+$function$;
+
+-- historical fill
+SELECT seaport.backfill_transactions();
+
+-- insert into cronjob
+INSERT INTO cron.job (schedule, command)
+VALUES ('*/35 * * * *', $$
+    SELECT seaport.backfill_transactions();
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/seaport/backfill_transfers.sql
+++ b/ethereum/seaport/backfill_transfers.sql
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION seaport.backfill_transfers() RETURNS boolean
+LANGUAGE plpgsql AS $function$
+BEGIN
+
+-- backfill usd_price, fee_usd_price, royalty_usd_amount
+update seaport.transfers
+   set usd_amount = new.new_usd_amount
+      ,fee_usd_amount = new.new_fee_usd_amount
+      ,royalty_usd_amount = new.new_royalty_usd_amount
+  from (select a.tx_hash
+              ,a.trade_id
+              ,a.original_amount_raw / 10^t.decimals * p.price as new_usd_amount
+              ,a.fee_amount_raw / 10^t.decimals * p.price as new_fee_usd_amount
+              ,a.royalty_amount_raw / 10^t.decimals * p.price as new_royalty_usd_amount
+          from seaport.transfers a
+               inner join prices.usd p on p.contract_address = a.currency_contract
+                            		   and date_trunc('minute', a.block_time) = p."minute"
+                                       and p.minute >= '2022-05-15'
+               inner join erc20.tokens t on t.contract_address = a.currency_contract
+         where a.usd_amount is null
+        ) as new
+  where transfers.tx_hash = new.tx_hash
+    and transfers.trade_id = new.trade_id
+;
+
+RETURN TRUE;
+END
+$function$;
+
+-- historical fill
+SELECT seaport.backfill_transfers();
+
+-- insert into cronjob
+INSERT INTO cron.job (schedule, command)
+VALUES ('*/35 * * * *', $$
+    SELECT seaport.backfill_transfers();
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;


### PR DESCRIPTION
Brief comments on the purpose of your changes:
- add backfill jobs for seaport abstractions


*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
