### PR TITLE
Balances patch: remove filter on prices

### DIFF
--- a/spellbook/models/balances/ethereum/erc20/balances_ethereum_erc20_latest.sql
+++ b/spellbook/models/balances/ethereum/erc20/balances_ethereum_erc20_latest.sql
@@ -22,6 +22,5 @@ LEFT JOIN {{ ref('tokens_ethereum_rebase') }}  as r
 LEFT JOIN {{ ref('balances_ethereum_erc20_noncompliant') }}  as nc
     ON rh.token_address = nc.token_address
 where rh.recency_index = 1
-and p.minute is not null
 and r.contract_address is null
 and nc.token_address is null


### PR DESCRIPTION
Brief comments on the purpose of your changes:
In balances_ethereum.erc20_latest, we are joining on a prices.usd by the minute.  Where we don't have a price for that token, we filter all the rows out for that token. This is too strict. In the PR, we remove that filter and provide latest token balances even if the usd price wasn't available. 

*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
