### PR TITLE
Basic aztec connect parsing and views

### DIFF
--- a/ethereum/aztec_v2/README.md
+++ b/ethereum/aztec_v2/README.md
@@ -1,0 +1,31 @@
+# Aztec Connect
+
+These are a series of views and functions to parse and interpret Aztec Connect data. They're broadly separated into a few categories:
+* Helper labels
+  * contract_labels - Identifies and describes Aztec Connect ecosystem contracts, i.e. rollup processors and bridge contracts. This needs to be updated manually as new bridge contracts are deployed.
+  * view_deposit_assets - List of asset by asset ID that the Aztec Rollup Processor interacts with
+* Parsing and processing Aztec Connect rollup data
+  * fn_process_block - byte data parsing function and struct definitions
+  * insert_parsed_rollups - insertion logic and cron job for the rollup parsing function
+  * rollups_parsed - table definition for the parsed rollups. More specific data is wrapped up into arrays of structs that are unwrapped in subsequent views.
+  * view_rollup_defi_deposits - Unwrapped struct array that describes deposits made into defi protocols from the RollupProcessor
+  * view_rollup_inner_proofs - Unwrapped struct array that describes the more specific inner proof data
+  * view_rollup_txn_fees - Unwrapped struct array that describes transaction fees collected by the RollupProcessor
+* Categorizing and measuring ERC-20 token flows between the Aztec Connect Rollup Processor, bridge contracts, and defi protocols
+  * daily_token_prices - table definition for cached daily token price feed
+  * insert_daily_token_prices - collates price feed data for any erc20 tokens that are used in the Aztec Connect ecosystem. Preferentially uses `prices.usd`, then prices from dex data with some minimum DQ standards applied
+  * view_daily_bridge_activity - Connects each ERC-20 token transfer in the Aztec Connect ecosystem and connects it to the price of those tokens
+  * view_daily_deposits - Assumes all non-bridge ERC-20 transfers into the rollup contract are deposits
+  * view_daily_estimated_rollup_tvl - Estimates the Rollup Processor's TVL by the value of the balance of ERC20 tokens it holds. This is not strictly accurate, as the rollup can hold positions via the bridge contracts
+  * view_rollup_bridge_transfers - Categorizes all ERC-20 token transfers in the Aztec Connect ecosystem
+
+Conceptually, the Aztec Connect bridge boils down defi interactions into transfers of erc-20 token transfers. In general, the flow of tokens is as follows:
+
+**Users** --user deposit--> **Rollup Processor** --defi deposit--> **Bridge Contracts** --defi interactions--> **Defi Protocol**
+
+And then, in reverse:
+
+**Defi Protocol** --defi interactions--> **Bridge Contracts** --defi withdrawal--> **Rollup Processor** --user withdrawal--> **Users**
+
+To track these flows, we can either look at the overtly visible ERC-20 tokens that are being transferred on L1, or we can look at the proof data that Aztec Connect's rollup provides. All defi interactions are obfuscated, but obviously, any user deposits or withdrawals leave L1 traces and are not anonymous.
+

--- a/ethereum/aztec_v2/contract_labels.sql
+++ b/ethereum/aztec_v2/contract_labels.sql
@@ -1,0 +1,36 @@
+-- https://dune.com/queries/874721
+-- prototype alias table for Aztec V2
+drop table if exists aztec_v2.contract_labels cascade;
+
+create table if not exists aztec_v2.contract_labels
+(
+  protocol varchar,
+  contract_type varchar,               
+  version varchar,
+  description text,
+  contract_address bytea                       
+);
+
+create index on aztec_v2.contract_labels(contract_address);
+create index on aztec_v2.contract_labels(protocol);
+
+truncate table aztec_v2.contract_labels;
+
+insert into aztec_v2.contract_labels 
+(protocol,               contract_type,      version,   description,                   contract_address) values
+-- ('Element',              'Bridge',           '0.1',     'Test - Beta bridge',           '\xb5e0Ab45C2c48a6F7032Ee0db749c3c9C5c58A32'::bytea), -- v 0.1 is pre-deployment beta
+-- ('Aztec RollupProcessor','Rollup',           '0.1',     'Test - Beta rollup',           '\xff6bed1e4d28491b89a02dc56b34a4b273eb9e0d'::bytea),
+-- ('Lido',                 'Bridge',           '0.1',     'Test - Beta bridge',           '\xFDb2f2E720436972644bf824dEBea47F07C5041D'::bytea),
+('Aztec RollupProcessor','Rollup',           '1.0',     'Prod Aztec Rollup',            '\xFF1F2B4ADb9dF6FC8eAFecDcbF96A2B351680455'::bytea),
+('Element',              'Bridge',           '1.0',     'Prod Element Bridge',          '\xaeD181779A8AAbD8Ce996949853FEA442C2CDB47'::bytea),
+('Lido',                 'Bridge',           '1.0',     'Prod Lido Bridge',             '\x381abF150B53cc699f0dBBBEF3C5c0D1fA4B3Efd'::bytea),
+('AceOfZK',              'Bridge',           '1.0',     'Ace Of ZK NFT - nonfunctional','\x0eb7f9464060289fe4fddfde2258f518c6347a70'::bytea)
+;
+
+alter table aztec_v2.contract_labels add contract_creator bytea;
+
+update aztec_v2.contract_labels
+set contract_creator = t."from"
+from ethereum.traces t
+where t.type = 'create'
+and aztec_v2_contract_labels.contract_address = t.address;

--- a/ethereum/aztec_v2/daily_token_prices.sql
+++ b/ethereum/aztec_v2/daily_token_prices.sql
@@ -1,0 +1,23 @@
+select p.token_address
+    , p.symbol
+    , p.date
+    , 'prices.prices_from_dex_data' as data_source
+    , p.avg_price_usd
+    , e.eth_price
+    , p.avg_price_usd / e.eth_price as avg_price_eth
+
+-- CREATE TABLE IF NOT EXISTS dune_user_generated.aztec_v2_daily_token_prices(
+CREATE TABLE IF NOT EXISTS aztec_v2.daily_token_prices ( 
+  token_address bytea
+  , symbol varchar
+  , date date
+  , data_source varchar
+  , avg_price_usd numeric
+  , eth_price numeric
+  , avg_price_eth numeric
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS aztec_v2_daily_token_prices_uniq_idx on aztec_v2.daily_token_prices (date, token_address);
+CREATE UNIQUE INDEX IF NOT EXISTS aztec_v2_daily_token_prices_address_idx on aztec_v2.daily_token_prices (token_address);
+CREATE UNIQUE INDEX IF NOT EXISTS aztec_v2_daily_token_prices_symbol_idx on aztec_v2.daily_token_prices (symbol);
+CREATE UNIQUE INDEX IF NOT EXISTS aztec_v2_daily_token_prices_date_idx on aztec_v2.daily_token_prices (date);

--- a/ethereum/aztec_v2/fn_process_block.sql
+++ b/ethereum/aztec_v2/fn_process_block.sql
@@ -1,0 +1,487 @@
+-- taken from https://github.com/simplestreet/bytea_bitwise_operation
+CREATE OR REPLACE FUNCTION aztec_v2.f_bytea_to_bit(
+    IN i_bytea BYTEA
+)
+RETURNS BIT VARYING
+AS
+$BODY$
+DECLARE
+    w_bit BIT VARYING := b'';
+BEGIN
+    w_bit := ('x' || ltrim(i_bytea::text, '\x'))::bit varying;
+RETURN w_bit;
+END;
+$BODY$
+LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION aztec_v2.f_bit_to_bytea(
+    IN i_bit BIT VARYING
+)
+RETURNS bytea
+AS
+$BODY$
+DECLARE
+    w_panel_data_len INTEGER;
+    w_str_bit TEXT := '';
+    w_bytea BYTEA := NULL::BYTEA;
+BEGIN
+    /* Get number of bytes */
+    w_panel_data_len := octet_length(i_bit);
+
+    IF length(i_bit) % 8 != 0 THEN
+        RAISE 'Can not convert to bytea. The passed argument is % bits', length(i_bit);
+    END IF;
+
+    FOR i IN 0 .. w_panel_data_len - 1 LOOP
+        w_str_bit := w_str_bit || lpad(to_hex(substring(i_bit from (i * 8) + 1  for 8)::int), 2, '0');
+    END LOOP;
+
+    w_bytea := decode(w_str_bit, 'hex');
+
+RETURN w_bytea;
+END;
+$BODY$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION aztec_v2.f_bytea_rshift(
+    IN i_bytea BYTEA,
+    IN i_num INTEGER
+)
+RETURNS BYTEA
+AS
+$BODY$
+DECLARE
+    w_bit BIT VARYING := b'';
+    w_bytea BYTEA := null::BYTEA;
+BEGIN
+    w_bit := aztec_v2.f_bytea_to_bit(i_bytea);
+    w_bytea := aztec_v2.f_bit_to_bytea(w_bit >> i_num);
+RETURN w_bytea;
+END;
+$BODY$
+LANGUAGE plpgsql;
+
+
+drop type if exists aztec_v2.inner_proof_data_struct cascade;
+
+drop type if exists aztec_v2.proof_data_struct cascade;
+
+drop type if exists aztec_v2.proof_bridge_data_struct cascade;
+
+-- Infomation for bridge usage in a rollup. inputs can have up to 2 different assets of equal value; same for output assets
+create type aztec_v2.proof_bridge_data_struct as (
+  -- 1-based bridge id. values can be mapped with contract method getSupportedBridges or getSupportedBridge(id)
+  addressId numeric,
+  -- bridge name, currently hardcoded
+  name text,
+  -- first input asset ID
+  inputAssetIdA numeric,
+  -- first input asset
+  outputAssetIdA numeric,
+  -- first output asset (optional)
+  inputAssetIdB numeric,
+  -- second output asset (optional)
+  outputAssetIdB numeric,
+  -- auxData used as input by each specific bridge
+  auxData numeric,
+  -- true/false flag for second input being present
+  secondInputInUse boolean,
+  -- true/false flag for second output being present
+  secondOutputInUse boolean
+);
+
+-- Transaction data
+create type aztec_v2.inner_proof_data_struct as (
+  proofType text,
+  noteCommitment1 bytea,
+  noteCommitment2 bytea,
+  nullifier1 bytea,
+  nullifier2 bytea,
+  publicValue numeric,
+  publicOwner bytea,
+  assetId numeric
+);
+
+create type aztec_v2.proof_data_struct as (
+  rollupId numeric,
+  rollupSize numeric,
+  dataStartIndex numeric,
+  oldDataRoot bytea,
+  newDataRoot bytea,
+  oldNullRoot bytea,
+  newNullRoot bytea,
+  oldDataRootsRoot bytea,
+  newDataRootsRoot bytea,
+  oldDefiRoot bytea,
+  newDefiRoot bytea,
+  -- array of data for bridges used in rollup. Length will always be 32, bridge with address = 0 is empty data
+  bridges aztec_v2.proof_bridge_data_struct [],
+  -- sum of deposits made to a bridge. total value is denominated in inputAssetIdA. Mapping is 1-1 with bridges list
+  defiDepositSums numeric [],
+  -- asset IDs that fees were paid into
+  assetIds numeric [],
+  -- transaction fees paid with each asset. Mapping 1-1 with assetIds. Denominated in specific asset
+  totalTxFees numeric [],
+  defiInteractionNotes bytea [],
+  prevDefiInteractionHash bytea,
+  rollupBeneficiary bytea,
+  numRollupTxs numeric,
+  innerProofs aztec_v2.inner_proof_data_struct []
+);
+
+create
+or replace function aztec_v2.fn_process_aztec_block(data bytea) returns aztec_v2.proof_data_struct as 
+$$
+declare 
+
+proofData aztec_v2.proof_data_struct;
+
+-- placeholders
+bridgeId bytea;
+defiDepositSums numeric [];
+assetIds numeric [];
+totalTxFees numeric [];
+defiInteractionNotes bytea [];
+innerProofs aztec_v2.inner_proof_data_struct [];
+innerProof aztec_v2.inner_proof_data_struct;
+bridge aztec_v2.proof_bridge_data_struct;
+bridges aztec_v2.proof_bridge_data_struct [];
+bridgeName text;
+bridgeNum numeric;
+assetId numeric;
+proofType text;
+
+-- bridge decoding byte holders
+inputAssetIdA bytea;
+outputAssetIdA bytea;
+inputAssetIdB bytea;
+outputAssetIdB bytea;
+auxData bytea;
+bitConfig bytea;
+secondInputInUse boolean;
+secondOutputInUse boolean;
+
+-- counter variables
+startIndex integer = 11 * 32;
+innerProofStartIndex integer;
+innerProofDataLength integer;
+innerProofByteData bytea;
+proofId integer;
+rollupSize integer;
+innerOffset integer;
+
+-- fixed constants
+NUM_BRIDGE_CALLS_PER_BLOCK integer = 32;
+NUMBER_OF_ASSETS integer = 16;
+LENGTH_ROLLUP_HEADER_INPUTS integer = 4544;
+INNER_PROOF_ENCODED_LENGTH integer = 1;
+EMPTY_BYTES_12 bytea = '\x000000000000000000000000';
+EMPTY_BYTES_28 bytea = '\x00000000000000000000000000000000000000000000000000000000';
+EMPTY_BYTES_32 bytea = '\x0000000000000000000000000000000000000000000000000000000000000000';
+
+begin
+
+rollupSize = bytea2numeric(substring(data, 61, 4), false);
+
+for i in 0..NUM_BRIDGE_CALLS_PER_BLOCK - 1 
+loop 
+  bridgeId = substring(data, startIndex + 1, 32);
+  bridgeNum = bytea2numeric(substring(bridgeId, length(bridgeId) - 3, 4), false)::bigint & ((1::bigint << 32) - 1);
+  
+ -- currently hardcoded here but should be able to fetch dynamically from aztec_v2.RollupProcessor_call_getSupportedBridge
+ case bridgeNum
+   when 1
+   then 
+     bridgeName = 'ElementBridge';
+   when 2, 3
+   then
+     bridgeName = 'LidoBridge';
+   when 4
+   then 
+     bridgeName = 'AceOfZkBridge';
+  when 5
+  then
+     bridgeName = 'CurveStEthBridge';
+  else
+     bridgeName = 'N/A';
+ end case;
+  
+  inputAssetIdA = aztec_v2.f_bytea_rshift(bridgeId, 32);
+  outputAssetIdA = aztec_v2.f_bytea_rshift(bridgeId, 92);
+  inputAssetIdB = aztec_v2.f_bytea_rshift(bridgeId, 62);
+  outputAssetIdB = aztec_v2.f_bytea_rshift(bridgeId, 122);
+  auxData = aztec_v2.f_bytea_rshift(bridgeId, 184);
+  bitConfig = aztec_v2.f_bytea_rshift(bridgeId, 152);
+  
+  if (get_bit(bitConfig, 0) = 1) then
+    secondInputInUse = true;
+  else
+    secondInputInUse = false;
+  end if;
+  
+  if (get_bit(bitConfig, 1) = 1) then
+    secondOutputInUse = true;
+  else
+    secondOutputInUse = false;
+  end if;
+ 
+  select
+  --   addressId: numeric
+    bridgeNum,
+  -- bridgeName: text
+    bridgeName,
+  --   inputAssetIdA: numeric
+    bytea2numeric(substring(inputAssetIdA, length(inputAssetIdA) - 7, 8), false)::bigint & (((1::bigint << 30) - 1)),
+  --   outputAssetIdA: numeric
+    bytea2numeric(substring(outputAssetIdA, length(outputAssetIdA) - 7, 8), false)::bigint & (((1::bigint << 30) - 1)),
+  --   inputAssetIdB: numeric,
+    bytea2numeric(substring(inputAssetIdB, length(inputAssetIdB) - 7, 8), false)::bigint & (((1::bigint << 30) - 1)),
+  --   outputAssetIdB: numeric,
+    bytea2numeric(substring(outputAssetIdB, length(outputAssetIdB) - 7, 8), false)::bigint & (((1::bigint << 30) - 1)),
+  --   auxData: numeric    
+    bytea2numeric(substring(auxData, length(auxData) - 7, 8), false)::bigint & (((1::bigint << 62) - 1)),
+  --  secondInputInUse: boolean
+    secondInputInUse,
+  --  secondOutputInUse: boolean
+    secondOutputInUse
+  into bridge;
+
+  bridges = array_append(bridges, bridge);
+  startIndex = startIndex + 32;
+end loop;
+
+for i in 0..NUM_BRIDGE_CALLS_PER_BLOCK - 1 loop defiDepositSums = array_append(
+  defiDepositSums,
+  bytea2numeric(substring(data, startIndex + 1, 32), false)
+);
+
+startIndex = startIndex + 32;
+
+end loop;
+
+for i in 0..NUMBER_OF_ASSETS - 1 
+loop 
+
+assetIds = array_append(
+  assetIds,
+  bytea2numeric(substring(data, startIndex + 28 + 1, 4), false)
+);
+startIndex = startIndex + 32;
+
+end loop;
+
+for i in 0..NUMBER_OF_ASSETS - 1 
+loop
+
+totalTxFees = array_append(
+  totalTxFees,
+  bytea2numeric(substring(data, startIndex + 1, 32), false)
+);
+startIndex = startIndex + 32;
+
+end loop;
+
+for i in 0..NUM_BRIDGE_CALLS_PER_BLOCK - 1 
+loop 
+
+defiInteractionNotes = array_append(
+  defiInteractionNotes,
+  substring(data, startIndex + 1, 32)
+);
+startIndex = startIndex + 32;
+
+end loop;
+
+innerProofStartIndex = LENGTH_ROLLUP_HEADER_INPUTS;
+
+-- skip over numRealtxs
+innerProofStartIndex = innerProofStartIndex + 4;
+innerProofDataLength = bytea2numeric(substring(data, innerProofStartIndex + 1, 4), false);
+
+innerProofStartIndex = innerProofStartIndex + 4;
+
+while innerProofDataLength > 0 
+loop 
+
+innerProofByteData = substring(data, innerProofStartIndex, length(data));
+proofId = bytea2numeric(substring(data, innerProofStartIndex + 1, 1), false);
+
+case proofId -- deposit, withdraw
+  when 1, 2 then
+  
+ innerOffset = 2;
+  
+if proofId = 1 then
+  proofType = 'DEPOSIT';
+else 
+  proofType = 'WITHDRAW';
+end if;
+  
+select
+  --   proofType text
+  proofType,
+  --   noteCommitment1 bytea,
+  substring(innerProofByteData, innerOffset + 1, 32),
+  --   noteCommitment2 bytea,
+  substring(innerProofByteData, innerOffset + 32 + 1, 32),
+  --   nullifier1 bytea,
+  substring(innerProofByteData, innerOffset + 32 + 32 + 1, 32),
+  --   nullifier2 bytea,
+  substring(innerProofByteData, innerOffset + 32 + 32 + 32 + 1, 32),
+  --   publicValue numeric,
+  bytea2numeric(substring(innerProofByteData, innerOffset + 32 + 32 + 32 + 32 + 1, 32), false),
+  --   publicOwner bytea,
+  EMPTY_BYTES_12 || substr(
+    innerProofByteData,
+    innerOffset + 32 + 32 + 32 + 32 + 32 + 1,
+    20
+  ),
+  --   assetId numeric
+  bytea2numeric(substr(innerProofByteData, innerOffset + 32 + 32 + 32 + 32 + 32 + 20 + 1, 4), false)
+into innerProof;
+  
+  INNER_PROOF_ENCODED_LENGTH = 1 + 5 * 32 + 20 + 4;
+  
+-- send, account, defi_deposit, defi_claim
+when 3,
+4,
+5,
+6 then
+
+
+if proofId = 3 then
+  proofType = 'SEND';
+elsif proofId = 4 then
+  proofType = 'ACCOUNT';
+elsif proofId = 5 then
+  proofType = 'DEFI_DEPOSIT';
+else
+  proofType = 'DEFI_CLAIM';
+end if;
+
+innerOffset = 2;
+select
+  --   proofType text
+  proofType,
+  --   noteCommitment1 bytea,
+  substring(innerProofByteData, innerOffset + 1, 32),
+  --   noteCommitment2 bytea,
+  substring(innerProofByteData, innerOffset + 32 + 1, 32),
+  --   nullifier1 bytea,
+  substring(innerProofByteData, innerOffset + 32 + 32 + 1, 32),
+  --   nullifier2 bytea,
+  substring(innerProofByteData, innerOffset + 32 + 32 + 32 + 1, 32),
+  --   publicValue bytea,
+  bytea2numeric(EMPTY_BYTES_32, false),
+  --   publicOwner bytea,
+  EMPTY_BYTES_32,
+  --   assetId - NOT VISIBLE in this transaction types
+  null 
+ into innerProof;
+  
+  INNER_PROOF_ENCODED_LENGTH = 1 + 4 * 32;
+
+-- padding
+else
+select
+  -- proofType
+  'PADDING',
+  --   noteCommitment1 bytea,
+  EMPTY_BYTES_32,
+  --   noteCommitment2 bytea,
+  EMPTY_BYTES_32,
+  --   nullifier1 bytea,
+  EMPTY_BYTES_32,
+  --   nullifier2 bytea,
+  EMPTY_BYTES_32,
+  --   publicValue bytea,
+  bytea2numeric(EMPTY_BYTES_32, false),
+  --   publicOwner bytea,
+  EMPTY_BYTES_32,
+  --   assetId - NOT VISIBLE in this transaction types
+  null 
+into innerProof;
+  
+  INNER_PROOF_ENCODED_LENGTH = 1;
+end case;
+
+innerProofs = array_append(innerProofs, innerProof);
+innerProofStartIndex = innerProofStartIndex + INNER_PROOF_ENCODED_LENGTH;
+innerProofDataLength = innerProofDataLength - INNER_PROOF_ENCODED_LENGTH;
+
+end loop;
+
+select
+  -- rollupId
+  bytea2numeric(substring(data, 29, 4), false),
+  -- rollupSize
+  rollupSize,
+  -- dataStartIndex
+  bytea2numeric(substring(data, 93, 4), false),
+  -- oldDataRoot
+  substring(data, 97, 32),
+  -- newDataRoot
+  substring(data, 129, 32),
+  -- oldNullRoot
+  substring(data, 161, 32),
+  -- newNullRoot
+  substring(data, 193, 32),
+  -- oldDataRootsRoot
+  substring(data, 225, 32),
+  -- newDataRootsRoot
+  substring(data, 257, 32),
+  -- oldDefiRoot
+  substring(data, 289, 32),
+  -- newDefiRoot
+  substring(data, 321, 32),
+  -- bridges
+  bridges,
+  -- defiDepositSums
+  defiDepositSums,
+  -- assetIds
+  assetIds,
+  -- totalTxFees
+  totalTxFees,
+  -- defiInteractionNotes
+  defiInteractionNotes,
+  -- prevDefiInteractionHash
+  substring(data, startIndex + 1, 32),
+  -- rollupBeneficiary
+  substring(data, startIndex + 32 + 1, 32),
+  -- numRollupTxs
+  bytea2numeric(substring(data, startIndex + 32 + 32 + 1, 32), false),
+  -- innerProofs
+  innerProofs 
+into proofData;
+
+RETURN proofData;
+
+end;
+
+$$LANGUAGE PLPGSQL;
+
+select
+  "call_block_time",
+--   "_0",
+(
+    select
+      rollupid
+    from
+      aztec_v2.fn_process_aztec_block("_0")
+  ),
+  (
+    select
+      assetIds
+    from
+      aztec_v2.fn_process_aztec_block("_0")
+  ),
+  (
+    select
+      totalTxFees
+    from
+      aztec_v2.fn_process_aztec_block("_0")
+  )
+  
+from
+  aztec_v2."RollupProcessor_call_processRollup"

--- a/ethereum/aztec_v2/insert_daily_token_prices.sql
+++ b/ethereum/aztec_v2/insert_daily_token_prices.sql
@@ -1,0 +1,175 @@
+CREATE OR REPLACE FUNCTION aztec_v2.insert_daily_token_prices((start_time timestamptz, end_time timestamptz=now())) RETURNS integer
+-- CREATE OR REPLACE FUNCTION dune_user_generated.aztec_v2_insert_daily_token_prices(start_time timestamptz, end_time timestamptz=now()) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+
+---------------------------------------------------------------------
+-- Section 1: which tokens we're looking at
+with tokens as (
+  -- Get the relevant components
+  select distinct contract_address as token_address
+  from aztec_v2.view_rollup_bridge_transfers
+  -- from dune_user_generated.aztec_v2_rollup_bridge_transfers
+)
+, tokens_from_paprika as (
+  select distinct contract_address as token_address
+  from prices.usd p 
+  where p.minute >= start_time::date
+    and p.minute < end_time::date
+)
+, missing_tokens as (
+  -- for tokens that are missing from coinpaprika we grab dex prices
+  select t.token_address
+  from tokens t
+  left join tokens_from_paprika tfp on t.token_address = tfp.token_address
+  where tfp.token_address is null
+)
+---------------------------------------------------------------------
+-- Section 2: CoinPaprika Price Feed
+, daily_token_prices_usd_paprika as (
+  select t.token_address
+    , p.symbol
+    , p.minute::date as date
+    , avg(price) as avg_price_usd
+  from tokens t
+  inner join prices.usd p on t.token_address = p.contract_address
+  where p.minute >= start_time::date
+    and p.minute < end_time::date 
+  group by 1,2,3
+)
+----------------------------------------------------------------------
+-- Section 3: Dex Price Feed
+, anchor_prices as (
+  -- this part of the query gets anchor prices for imputation purposes
+  select dcp.date
+    , dcp.token_address
+    , dcp.symbol
+    , dcp.avg_price_usd as avg_price
+  from aztec_v2.daily_token_prices dcp
+  -- from dune_user_generated.aztec_v2_daily_token_prices dcp
+  inner join missing_tokens mt on dcp.token_address = mt.token_address
+  where dcp.date = start_time::date - interval '1 day'
+)
+, daily_token_prices_usd_dex_passing as (
+  -- this part of the query applies some data quality standards to the prices_from_dex data
+  -- to try and smooth out extreme price movements from illiquid DEXes
+  select date
+    , token_address
+    , symbol
+    , avg_price
+  from anchor_prices
+  union
+  select p.hour::date as date
+    , mt.token_address
+    , p.symbol
+    -- , sum(sample_size) as daily_samples
+    , percentile_disc(0.5) within group (order by median_price) as avg_price -- use the median price for the day to remove outliers
+    -- , sum(median_price* sample_size) / sum(sample_size) as avg_price -- sample size weighted average median price
+  from prices.prices_from_dex_data p
+  inner join missing_tokens mt on p.contract_address = mt.token_address
+  where p.hour >= start_time::date
+    and p.hour < end_time::date
+    and sample_size > 0
+  group by 1,2,3
+  having sum(sample_size) > 5 -- minimum of 6 samples required to set a daily price
+     and count(distinct median_price) > 5 -- minimum of 6 unique rows required
+)
+, daily_token_prices_usd_dex_passing_lead as (
+  select date
+        , token_address
+        , symbol
+        , avg_price
+        , lead(date, 1) over (partition by token_address order by date) as next_date
+            -- this gives the day that this particular snapshot value is valid until
+    from daily_token_prices_usd_dex_passing 
+)
+, day_series as (
+  SELECT generate_series(min(date), now(), '1 day') AS day 
+        FROM daily_token_prices_usd_dex_passing
+)
+, imputed_token_prices_dex_usd as (
+    select d.day as date
+        , p.token_address
+        , p.symbol
+        , p.avg_price as avg_price_usd
+    from day_series d 
+    inner join daily_token_prices_usd_dex_passing_lead p
+        on d.day >= p.date
+        and d.day < coalesce(p.next_date,now()::date + 1) -- if it's missing that means it's the last entry in the series
+)
+-------------------------------------------------------------------------------------------------------------------
+-- Section 4: Synthesize with ETH price
+, daily_eth_price_usd as (
+  select minute::date as date
+    , avg(price) as eth_price
+  from prices.layer1_usd p
+  where p.minute >= start_time::date
+    and p.minute < end_time::date
+  and symbol = 'ETH'
+  group by 1
+)
+, paprika_price_feed as (
+  select p.token_address
+    , p.symbol
+    , p.date
+    , 'prices.usd' as data_source
+    , p.avg_price_usd
+    , e.eth_price
+    , p.avg_price_usd / e.eth_price as avg_price_eth
+  from daily_token_prices_usd_paprika p
+  inner join daily_eth_price_usd e on p.date = e.date
+)
+, dex_price_feed as (
+  select p.token_address
+    , p.symbol
+    , p.date
+    , 'prices.prices_from_dex_data' as data_source
+    , p.avg_price_usd
+    , e.eth_price
+    , p.avg_price_usd / e.eth_price as avg_price_eth
+  from imputed_token_prices_dex_usd p
+  inner join daily_eth_price_usd e on p.date = e.date
+)
+, rows as (
+  insert into aztec_v2.daily_token_prices (
+  -- insert into dune_user_generated.aztec_v2_daily_token_prices (
+      token_address 
+    , symbol 
+    , date 
+    , data_source 
+    , avg_price_usd 
+    , eth_price 
+    , avg_price_eth 
+  )
+  select * from paprika_price_feed
+  union 
+  select * from dex_price_feed
+  
+  on conflict(token_address, date) do update set
+    data_source = excluded.data_source
+    , avg_price_usd = EXCLUDED.avg_price_usd
+    , eth_price = EXCLUDED.eth_price
+    , avg_price_eth = EXCLUDED.avg_price_eth
+  returning 1
+)
+select count(*) into r from rows;
+
+RETURN r;
+END
+$function$;
+
+-- backfill starting '2022-05-13'
+SELECT aztec_v2.insert_daily_token_prices('2022-05-13', now());
+-- select dune_user_generated.aztec_v2_insert_daily_token_prices('2022-05-13', now());
+
+-- Have the insert script run four times a day
+-- `start-time` is set to go back three days in time so that entries can be retroactively updated 
+-- in case `dex.trades` or price data falls behind.
+INSERT INTO cron.job (schedule, command)
+VALUES ('0 0,6,12,18 * * *', $$
+    SELECT aztec_v2.insert_daily_token_prices(
+        (SELECT date_trunc('day', now()) - interval '3 days'),
+        (SELECT date_trunc('day', now()) + interval '1 day')); -- the insert function is noninclusive of the end date, so add a day
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/aztec_v2/insert_parsed_rollups.sql
+++ b/ethereum/aztec_v2/insert_parsed_rollups.sql
@@ -1,0 +1,60 @@
+
+-- This insert query is designed to check for non-parsed rollup txns and parse them and then insert them
+CREATE OR REPLACE FUNCTION aztec_v2.insert_parsed_rollups() RETURNS integer
+-- CREATE OR REPLACE FUNCTION dune_user_generated.insert_parsed_rollups() RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+with rows as (
+  -- insert into dune_user_generated.aztec_v2_rollups_parsed_cached ( 
+  insert into aztec_v2.rollups_parsed ( 
+    call_block_time 
+    , contract_address 
+    , call_tx_hash 
+    , rollupid 
+    , rollupsize 
+    , datastartindex 
+    , olddataroot 
+    , newdataroot 
+    , oldnullroot 
+    , newnullroot 
+    , olddatarootsroot 
+    , newdatarootsroot 
+    , olddefiroot 
+    , newdefiroot 
+    , bridges 
+    , defidepositsums 
+    , assetids 
+    , totaltxfees 
+    , defiinteractionnotes 
+    , prevdefiinteractionhash 
+    , rollupbeneficiary 
+    , numrolluptxs 
+    , innerproofs 
+  )
+  select
+    r."call_block_time"
+    , r.contract_address
+    , r.call_tx_hash
+    , (dune_user_generated.fn_process_aztec_block(r."_0")).*
+  from aztec_v2."RollupProcessor_call_processRollup" r
+  -- left join dune_user_generated.aztec_v2_rollups_parsed_cached rp on r.call_tx_hash = rp.call_tx_hash
+  left join aztec_v2.rollups_parsed rp on r.call_tx_hash = rp.call_tx_hash
+  where rp.call_tx_hash is null -- grab rollup txns that haven't been parsed yet
+  returning 1
+)
+select count(*) into r
+from rows;
+return r;
+end
+$function$;
+
+-- backfill the transactions
+select aztec_v2.insert_parsed_rollups();
+
+-- check for non-parsed rollup blocks once every 15 minutes
+INSERT INTO cron.job (schedule, command)
+VALUES ('0,15,30,45 * * * *', $$
+    SELECT aztec_v2.insert_parsed_rollups()
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/ethereum/aztec_v2/rollups_parsed.sql
+++ b/ethereum/aztec_v2/rollups_parsed.sql
@@ -1,0 +1,32 @@
+-- CREATE TABLE IF NOT EXISTS dune_user_generated.aztec_v2_rollups_parsed_cached(
+CREATE TABLE IF NOT EXISTS aztec_v2.rollups_parsed ( 
+  call_block_time timestamp with time zone
+  , contract_address bytea
+  , call_tx_hash bytea
+  , rollupid numeric
+  , rollupsize numeric
+  , datastartindex numeric
+  , olddataroot bytea
+  , newdataroot bytea
+  , oldnullroot bytea
+  , newnullroot bytea
+  , olddatarootsroot bytea
+  , newdatarootsroot bytea
+  , olddefiroot bytea
+  , newdefiroot bytea
+  -- , bridges dune_user_generated.aztec_v2_proof_bridge_data_struct []
+  , bridges aztec_v2.proof_bridge_data_struct []
+  , defidepositsums numeric[]
+  , assetids numeric[]
+  , totaltxfees numeric []
+  , defiinteractionnotes bytea []
+  , prevdefiinteractionhash bytea
+  , rollupbeneficiary bytea
+  , numrolluptxs numeric
+  -- , innerproofs dune_user_generated.aztec_v2_inner_proof_data_struct [] 
+  , innerproofs aztec_v2.inner_proof_data_struct [] 
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS aztec_v2_rollups_parsed_uniq_idx on aztec_v2.rollups_parsed (call_tx_hash);
+CREATE UNIQUE INDEX IF NOT EXISTS aztec_v2_rollups_parsed_block_time_idx on aztec_v2.rollups_parsed (call_block_time);
+CREATE UNIQUE INDEX IF NOT EXISTS aztec_v2_rollups_parsed_rollup_id_idx on aztec_v2.rollups_parsed (rollupid);

--- a/ethereum/aztec_v2/view_daily_bridge_activity.sql
+++ b/ethereum/aztec_v2/view_daily_bridge_activity.sql
@@ -1,0 +1,37 @@
+drop view if exists aztec_v2.view_daily_bridge_activity;
+
+create or replace view aztec_v2.view_daily_bridge_activity as 
+with daily_transfers as (
+    select date_trunc('day', evt_block_time) as date
+        , bridge_protocol
+        , bridge_address
+        , contract_address as token_address
+        , count(*) as num_tfers -- number of transfers
+        , count(distinct evt_tx_hash) as num_rollups -- number of rollups
+        , sum(case when spec_txn_type in ('Bridge to Protocol','Protocol to Bridge') then value_norm else 0 end ) as abs_value_norm
+        , sum(case when spec_txn_type = 'Bridge to Protocol' then value_norm else 0 end ) as input_value_norm
+        , sum(case when spec_txn_type = 'Protocol to Bridge' then value_norm else 0 end ) as output_value_norm
+    from aztec_v2.view_rollup_bridge_transfers
+    where bridge_protocol is not null -- exclude all txns that don't interact with the bridges
+    group by 1,2,3,4
+)
+, daily_volume as (
+    select dt.date
+        , dt.bridge_protocol
+        , dt.bridge_address
+        , dt.token_address
+        , p.symbol
+        , dt.num_rollups
+        , dt.num_tfers
+        , dt.abs_value_norm
+        , dt.abs_value_norm * p.avg_price_usd as abs_volume_usd
+        , dt.abs_value_norm * p.avg_price_eth as abs_volume_eth
+        , dt.input_value_norm * p.avg_price_usd as input_volume_usd
+        , dt.input_value_norm * p.avg_price_eth as input_volume_eth
+        , dt.output_value_norm * p.avg_price_usd as output_volume_usd
+        , dt.output_value_norm * p.avg_price_eth as output_volume_eth
+    from daily_transfers dt
+    -- inner join dune_user_generated.table_aztec_v2_daily_bridged_tokens_prices_cached p on dt.date = p.date and dt.token_address = p.token_address
+    inner join aztec_v2.daily_token_prices p on dt.date = p.date and dt.token_address = p.token_address
+)
+select * from daily_volume

--- a/ethereum/aztec_v2/view_daily_deposits.sql
+++ b/ethereum/aztec_v2/view_daily_deposits.sql
@@ -1,0 +1,33 @@
+drop view if exists aztec_v2.view_daily_deposits;
+
+create or replace view aztec_v2.view_daily_deposits as 
+with daily_transfers as (
+    select date_trunc('day', evt_block_time) as date
+        , contract_address as token_address
+        , count(*) as num_tfers -- number of transfers
+        , count(distinct evt_tx_hash) as num_rollups -- number of rollups
+        , sum(case when spec_txn_type in ('User Deposit','User Withdrawal') then value_norm else 0 end ) as abs_value_norm
+        , sum(case when spec_txn_type = 'User Deposit' then value_norm else 0 end ) as user_deposit_value_norm
+        , sum(case when spec_txn_type = 'User Withdrawal' then value_norm else 0 end ) as user_withdrawal_value_norm
+    from dune_user_generated.aztec_v2_rollup_bridge_transfers
+    where spec_txn_type in ('User Deposit','User Withdrawal')
+    group by 1,2
+)
+, daily_volume as (
+    select dt.date
+        , dt.token_address
+        , p.symbol
+        , dt.num_rollups
+        , dt.num_tfers
+        , dt.abs_value_norm
+        , dt.abs_value_norm * p.avg_price_usd as abs_volume_usd
+        , dt.abs_value_norm * p.avg_price_eth as abs_volume_eth
+        , dt.user_deposit_value_norm * p.avg_price_usd as user_deposits_usd
+        , dt.user_deposit_value_norm * p.avg_price_eth as user_deposits_eth
+        , dt.user_withdrawal_value_norm * p.avg_price_usd as user_withdrawals_usd
+        , dt.user_withdrawal_value_norm * p.avg_price_eth as user_withdrawals_eth
+    from daily_transfers dt
+    -- inner join dune_user_generated.table_aztec_v2_daily_bridged_tokens_prices_cached p on dt.date = p.date and dt.token_address = p.token_address
+    inner join aztec_v2.daily_token_prices p on dt.date = p.date and dt.token_address = p.token_address
+)
+select * from daily_volume

--- a/ethereum/aztec_v2/view_daily_estimated_rollup_tvl.sql
+++ b/ethereum/aztec_v2/view_daily_estimated_rollup_tvl.sql
@@ -1,0 +1,45 @@
+create or replace view aztec_v2.view_daily_estimated_rollup_tvl as 
+with rollup_balance_changes as (
+  select t.evt_block_time::date as date
+    , t.symbol
+    , t.contract_address as token_address
+    , sum(case when t.from_type = 'Rollup' then -1 * value_norm when t.to_type = 'Rollup' then value_norm else 0 end) as net_value_norm
+  from aztec_v2.view_rollup_bridge_transfers t
+  where t.from_type = 'Rollup' or t.to_type = 'Rollup'
+  group by 1,2,3
+)
+, token_balances as (
+  select date
+    , symbol
+    , token_address
+    , sum(net_value_norm) over (partition by symbol,token_address order by date asc rows between unbounded preceding and current row) as balance
+    , lead(date, 1) over (partition by token_address order by date) as next_date
+  from rollup_balance_changes
+)
+, day_series as (
+  select generate_series(min(date), now()::date, interval '1 day') as date
+  from token_balances
+)
+, token_balances_filled as (
+  select d.date
+    , b.symbol
+    , b.token_address
+    , b.balance
+  from day_series d
+  inner join token_balances b
+        on d.date >= b.date
+        and d.date < coalesce(b.next_date,now()::date + 1) -- if it's missing that means it's the last entry in the series
+)
+, token_tvls as (
+  select b.date
+    , b.symbol
+    , b.token_address
+    , b.balance
+    , b.balance * p.avg_price_usd as tvl_usd
+    , b.balance * p.avg_price_eth as tvl_eth
+  from token_balances_filled b
+  -- inner join dune_user_generated.table_aztec_v2_daily_bridged_tokens_prices_cached p on b.date = p.date and b.token_address = p.token_address
+  inner join aztec_v2.daily_token_prices p on b.date = p.date and b.token_address = p.token_address
+  
+)
+select * from token_tvls

--- a/ethereum/aztec_v2/view_deposit_assets.sql
+++ b/ethereum/aztec_v2/view_deposit_assets.sql
@@ -1,0 +1,20 @@
+-- https://dune.com/queries/981259
+create or replace view aztec_v2.view_deposit_assets as
+-- ETH is the default asset that doesn't need to be added
+with assets_added as (
+  select 0 as asset_id 
+      , '\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' as asset_address
+      , null as asset_gas_limit
+      , null as date_added
+  union
+  select "assetId" as asset_id
+      , "assetAddress" as asset_address
+      , "assetGasLimit" as asset_gas_limit
+      , evt_block_time as date_added
+  from aztec_v2."RollupProcessor_evt_AssetAdded"
+)
+select a.*
+  , t.symbol
+  , t.decimals
+from assets_added a
+left join erc20.tokens t on a.asset_address = t.contract_address 

--- a/ethereum/aztec_v2/view_rollup_bridge_transfers.sql
+++ b/ethereum/aztec_v2/view_rollup_bridge_transfers.sql
@@ -1,0 +1,49 @@
+-- this uses the contract aliases to identify and categorize erc20 transactions that involve Aztec Connect 
+
+-- filter txns down to only relevant txns to prevent double counting
+create or replace view aztec_v2.view_rollup_bridge_transfers as 
+with tfers_raw as (
+  select distinct t.*
+    from erc20."ERC20_evt_Transfer" t
+    inner join aztec_v2.contract_labels c 
+      on t."from" = c.contract_address
+      or t."to" = c.contract_address
+)
+, tfers_categorized as (
+  select t.*
+    , tk.symbol
+    , tk.decimals
+    , t.value / 10^(coalesce(tk.decimals,18)) as value_norm
+    , case when to_contract.contract_type is not null and from_contract.contract_type is not null then 'Internal'
+      else 'External'        
+        end as broad_txn_type
+    , case 
+        when from_contract.contract_type is null and to_contract.contract_type = 'Rollup' then 'User Deposit'
+        when to_contract.contract_type is null and from_contract.contract_type = 'Rollup' then 'User Withdrawal'
+        when from_contract.contract_type = 'Rollup' and to_contract.contract_type = 'Bridge' then 'RP to Bridge'
+        when to_contract.contract_type = 'Rollup' and from_contract.contract_type = 'Bridge' then 'Bridge to RP'
+        when from_contract.contract_type = 'Bridge' and to_contract.contract_type is null then 'Bridge to Protocol'
+        when to_contract.contract_type = 'Bridge' and from_contract.contract_type is null then 'Protocol to Bridge'
+        end as spec_txn_type
+    , to_contract.protocol as to_protocol
+    , to_contract.contract_type as to_type
+    , from_contract.protocol as from_protocol
+    , from_contract.contract_type as from_type
+    , case when to_contract.contract_type = 'Bridge' then to_contract.contract_address
+      when from_contract.contract_type = 'Bridge' then from_contract.contract_address
+      else null end
+      as bridge_address
+    , case when to_contract.contract_type = 'Bridge' then to_contract.protocol
+      when from_contract.contract_type = 'Bridge' then from_contract.protocol
+      else null end
+      as bridge_protocol
+    , case when to_contract.contract_type = 'Bridge' then to_contract.version
+      when from_contract.contract_type = 'Bridge' then from_contract.version
+      else null end
+      as bridge_version
+  from tfers_raw t
+  left join erc20.tokens tk on t.contract_address = tk.contract_address
+  left join aztec_v2.contract_labels to_contract on t."to" = to_contract.contract_address
+  left join aztec_v2.contract_labels from_contract on t."from" = from_contract.contract_address
+)
+select * from tfers_categorized

--- a/ethereum/aztec_v2/view_rollup_defi_deposits.sql
+++ b/ethereum/aztec_v2/view_rollup_defi_deposits.sql
@@ -1,0 +1,21 @@
+create or replace view dune_user_generated.aztec_v2_view_rollup_defi_deposits as
+
+with bridge_rollups as (
+select rollupid
+    , (unnest(bridges)).*
+    , (unnest(defiDepositSums)) as defi_deposit_sum
+from aztec_v2.rollups_parsed
+)
+select b.* 
+    , ia.symbol as input_a_symbol
+    , oa.symbol as output_a_symbol
+    , case when b.secondinputinuse then ib.symbol else null end as input_b_symbol
+    , case when b.secondoutputinuse then ob.symbol else null end as output_b_symbol
+    , defi_deposit_sum * 1.0 / 10 ^ (ia.decimals) as defi_deposit_sum_norm -- defi deposit sum is denominated in input asset a
+    
+from bridge_rollups b
+left join aztec_v2.view_deposit_assets ia on ia.asset_id = b.inputassetida
+left join aztec_v2.view_deposit_assets oa on oa.asset_id = b.outputassetida
+left join aztec_v2.view_deposit_assets ib on ib.asset_id = b.inputassetidb
+left join aztec_v2.view_deposit_assets ob on ob.asset_id = b.outputassetidb
+where addressid <> 0 -- address id 0 means no data here

--- a/ethereum/aztec_v2/view_rollup_inner_proofs.sql
+++ b/ethereum/aztec_v2/view_rollup_inner_proofs.sql
@@ -1,0 +1,17 @@
+-- https://dune.com/queries/1007310
+
+create or replace view aztec_v2.rollup_inner_proofs as 
+with inner_proofs as (
+    select rollupid
+        , call_block_time
+        , (unnest(innerproofs)).*
+    from aztec_v2.rollups_parsed
+)
+select i.*
+    , substring(publicowner from 13 for 20) as publicowner_norm -- publicowner is 32 bytes long, with 12 bytes of padding over the 20 bytes of ethereum address
+    , a.symbol
+    , a.decimals
+    , i.publicvalue * 1.0 / 10 ^ (coalesce(a.decimals, 18)) as publicvalue_norm
+from inner_proofs i
+left join aztec_v2.view_deposit_assets a on i.assetid = a.asset_id
+;

--- a/ethereum/aztec_v2/view_rollup_txn_fees.sql
+++ b/ethereum/aztec_v2/view_rollup_txn_fees.sql
@@ -1,0 +1,20 @@
+-- https://dune.com/queries/981250
+create or replace view aztec_v2.view_rollup_txn_fees as
+with tx_fees_unnested as (
+select rollupid
+    , call_block_time
+    , (unnest(assetIds)) as asset_id
+    , (unnest(totalTxFees)) as total_tx_fee
+from aztec_v2.rollups_parsed
+)
+select f.rollupid
+    , f.call_block_time
+    , f.asset_id
+    , a.asset_address
+    , a.symbol
+    , a.decimals
+    , f.total_tx_fee as total_tx_fee_raw
+    , f.total_tx_fee * 1.0 / 10 ^ (a.decimals) as total_tx_fee_norm
+from tx_fees_unnested f
+left join aztec_v2.view_deposit_assets a on f.asset_id = a.asset_id
+where f.asset_id <> 1073741824 -- assetID 1073741824 is null value


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Uses Dune Engine V1 to build out Aztec Connect rollup data parsing and basic views because I haven't figured out how to use Dune Engine V2

The struct definitions that are used in `rollups_parsed` table definition are defined in `fn_process_block`.

I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [X] the filename is unique and ends with .sql
* [X] each sql file is a select statement and has only one view, table or function defined  
* [X] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
