### PR TITLE
Trigger spellbook deploys on spellbook updates in the abstraction repo

### DIFF
--- a/.github/workflows/spellbook_deploy_trigger.yml
+++ b/.github/workflows/spellbook_deploy_trigger.yml
@@ -1,0 +1,17 @@
+name: Trigger Spellbook Deploy to update the spellbook site
+
+on:
+  push:
+    paths:
+      - 'spellbook/**'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create repository dispatch event
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          gh api repos/duneanalytics/spellbook-deploy/dispatches \
+              --raw-field event_type=spellbook-updated

--- a/.github/workflows/spellbook_deploy_trigger.yml
+++ b/.github/workflows/spellbook_deploy_trigger.yml
@@ -9,7 +9,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Create repository dispatch event
+      - name: Create a repository dispatch event to dune spellbook-deploy
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |


### PR DESCRIPTION
this will trigger the workflow in the spellbook-deploy repo every time the spellbook repo is changed, therefore implementing a continuous deploy. 