### PR TITLE
OP2 temporarily comment out kwenta

### DIFF
--- a/optimism2/dex/prices_and_trades_inserts.sql
+++ b/optimism2/dex/prices_and_trades_inserts.sql
@@ -19,7 +19,7 @@ VALUES ('15,30,45,59 * * * *', $$
 	SELECT dex.insert_zipswap( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Zipswap'), now() );
 	SELECT dex.insert_curve( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Curve'), now() );
 	SELECT dex.insert_clipper( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Clipper'), now() );
-	SELECT dex.insert_kwenta( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Kwenta'), now() );
+-- 	SELECT dex.insert_kwenta( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Kwenta'), now() );
 	SELECT dex.insert_wardenswap( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='WardenSwap' AND version = '2'), now() );
 	SELECT dex.insert_rubicon( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Rubicon'), now() );
 	SELECT dex.insert_velodrome( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Velodrome'), now() );


### PR DESCRIPTION
Brief comments on the purpose of your changes:
Optimism dex.trades was halted. I think it's because the `MintableSynthetix` contract was somehow dropped from the database (not sure why), which is used in the Kwenta insert.

Commenting out Kwenta.

See Discord here - once this table is recovered, we can re-add Kwenta back in: https://discord.com/channels/757637422384283659/850326962152538122/997583880473292850


*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
