### PR TITLE
fix synthetix.trades

### DIFF
--- a/ethereum/synthetix/trades.sql
+++ b/ethereum/synthetix/trades.sql
@@ -59,6 +59,9 @@ RETURN r;
 END
 $function$;
 
+--backfill command
+SELECT synthetix.insert_trades((SELECT max(block_time) FROM synthetix.trades));
+
 
 INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', 'SELECT synthetix.insert_trades((SELECT max(block_time) FROM synthetix.trades));')

--- a/ethereum/synthetix/trades.sql
+++ b/ethereum/synthetix/trades.sql
@@ -48,7 +48,7 @@ WITH rows AS (
         trade.evt_index AS evt_index,
         row_number() OVER (PARTITION BY evt_tx_hash, evt_index) AS trade_id
     FROM
-        synthetix."Synthetix_evt_SynthExchange" trade
+        synthetix."SNX_evt_SynthExchange" trade
     WHERE evt_block_time >= start_ts
     AND evt_block_time < end_ts
     ON CONFLICT DO NOTHING


### PR DESCRIPTION
We changed the naming convention of the SNX tables apparently, this ensures that the dex.trades insert will work correctly again

cc: @antonio-mendes 
