### PR TITLE
Opensea: patch error - to avoid division_by_zero

### DIFF
--- a/ethereum/seaport/insert_transactions.sql
+++ b/ethereum/seaport/insert_transactions.sql
@@ -703,6 +703,7 @@ with p1_call as (
                           ,a.*
                       from p4_call a
                     ) a
+             where nft_transfer_count > 0  -- some of trades without NFT happens in match_order
             ) a
 )
 ,p4_txn_level as (

--- a/ethereum/seaport/insert_transfers.sql
+++ b/ethereum/seaport/insert_transfers.sql
@@ -696,6 +696,7 @@ with p1_call as (
                           ,a.*
                       from p4_call a
                     ) a
+             where nft_transfer_count > 0  -- some of trades without NFT happens in match_order
             ) a
 )
 ,p4_transfer_level as (

--- a/spellbook/models/seaport/ethereum/seaport_ethereum_transfers.sql
+++ b/spellbook/models/seaport/ethereum/seaport_ethereum_transfers.sql
@@ -698,6 +698,7 @@ with p1_call as (
                           ,a.*
                       from p4_call a
                     ) a
+             where nft_transfer_count > 0  -- some of trades without NFT happens in match_order
             ) a
 )
 


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Some of the cases transacted with seaport contracts without any NFT.

https://etherscan.io/tx/0xda5ea90ec1cad79968ef47c3f38e5c2b785e76a5e5bd05b538d437d7a364e059
https://etherscan.io/tx/0xb5892d5bdec28c091efa683ae4d178251db587a2295d49e7ae77c0adc235c43d

This patch is to avoid those kinds of cases.

*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
