### PR TITLE
Increase OP Insert Lookbacks to Handle for Delays

### DIFF
--- a/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
+++ b/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
@@ -101,7 +101,7 @@ WHERE NOT EXISTS (
 INSERT INTO cron.job (schedule, command)
 VALUES ('* * * * *', $$
  SELECT ovm2.insert_l1_gas_price_oracle_updates(
-        (SELECT MAX(block_number) FROM ovm2.l1_gas_price_oracle_updates WHERE block_time > NOW() - interval '1 week'),
+        (SELECT MAX(block_number) FROM ovm2.l1_gas_price_oracle_updates WHERE block_time > NOW() - interval '30 days'),
         (SELECT MAX(number) FROM optimism.blocks WHERE "time" > NOW() - interval '1 week')
         );
 $$)


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Increase Insert lookbacks from 7 days to 30 days since the db is over 9 days behind.

This should get merged before it gets within 7 days so that we don't have gaps in data.



*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
