### PR TITLE
OP2 - update insert lookbacks

### DIFF
--- a/optimism2/ovm2/get_contracts/insert_get_contracts.sql
+++ b/optimism2/ovm2/get_contracts/insert_get_contracts.sql
@@ -398,12 +398,12 @@ WHERE NOT EXISTS (
 );
 
 
--- INSERT INTO cron.job (schedule, command)
--- VALUES ('14,29,44,59 * * * *', $$
---  SELECT ovm2.insert_get_contracts(
---         (SELECT MAX("created_time") FROM ovm2.get_contracts WHERE block_time > NOW() - interval '1 month')::timestamptz,
---         (SELECT MAX("time") FROM optimism.blocks WHERE "time" > NOW() - interval '1 week')::timestamptz,
--- 	 NULL::bytea[]
---         );
--- $$)
--- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+INSERT INTO cron.job (schedule, command)
+VALUES ('14,29,44,59 * * * *', $$
+ SELECT ovm2.insert_get_contracts(
+        (SELECT MAX("created_time") FROM ovm2.get_contracts)::timestamptz,
+        (SELECT MAX("time") FROM optimism.blocks WHERE "time" > NOW() - interval '1 month')::timestamptz,
+	 NULL::bytea[]
+        );
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
+++ b/optimism2/ovm2/insert_l1_gas_price_oracle_updates.sql
@@ -101,8 +101,8 @@ WHERE NOT EXISTS (
 INSERT INTO cron.job (schedule, command)
 VALUES ('* * * * *', $$
  SELECT ovm2.insert_l1_gas_price_oracle_updates(
-        (SELECT MAX(block_number) FROM ovm2.l1_gas_price_oracle_updates WHERE block_time > NOW() - interval '1 week'),
-        (SELECT MAX(number) FROM optimism.blocks WHERE "time" > NOW() - interval '1 week')
+        (SELECT MAX(block_number) FROM ovm2.l1_gas_price_oracle_updates WHERE block_time > NOW() - interval '1 month'),
+        (SELECT MAX(number) FROM optimism.blocks WHERE "time" > NOW() - interval '1 month')
         );
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Extend some insert time lookbacks since the db fell behind by > 7 days (if the db gets to within 7 days before this PR, we should look to try to backfill the ~11-7 day period that may have been missed.

*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
