### PR TITLE
[Dex.Trades] Replace GPv2 with Cow Protocol V1

### DIFF
--- a/ethereum/dex/trades/insert_gnosis_protocol.sql
+++ b/ethereum/dex/trades/insert_gnosis_protocol.sql
@@ -76,11 +76,11 @@ WITH rows AS (
 
         UNION ALL
 
-        -- V2
+        -- V2 - Formerly Gnosis Protocol (renamed CoW Protocol)
         SELECT
             t.evt_block_time AS block_time,
-            'Gnosis Protocol' AS project,
-            '2' AS version,
+            'CoW Protocol' AS project,
+            '1' AS version,
             'Aggregator' AS category,
             t.owner AS trader_a,
             NULL::bytea AS trader_b,
@@ -162,15 +162,15 @@ WHERE NOT EXISTS (
     FROM dex.trades
     WHERE block_time > '2021-01-01'
     AND block_time <= now() - interval '20 minutes'
-    AND project = 'Gnosis Protocol'
+    AND project = 'CoW Protocol'
 );
 
 INSERT INTO cron.job (schedule, command)
 VALUES ('*/10 * * * *', $$
     SELECT dex.insert_gnosis_protocol(
-        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Gnosis Protocol'),
+        (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='CoW Protocol'),
         (SELECT now() - interval '20 minutes'),
-        (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='Gnosis Protocol')),
+        (SELECT max(number) FROM ethereum.blocks WHERE time < (SELECT max(block_time) - interval '1 days' FROM dex.trades WHERE project='CoW Protocol')),
         (SELECT MAX(number) FROM ethereum.blocks where time < now() - interval '20 minutes'));
 $$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;


### PR DESCRIPTION
Ever since the passing of [this Gnosis DAO Improvement proposal](https://snapshot.org/#/gnosis.eth/proposal/0x9b12a093e17e92b56d070ed876883d8c2331678ca3945e44f66dd416cfd47a64) on February 4, 2022. The protocol has officially been renamed to `CoW Protocol`. Here we updated `dex.trades` to reflect this change.

This PR comes along with a request to update the existing table:

```sql
UPDATE dex.trades
SET project = 'CoW Protocol',
    version = '1',
WHERE project = 'Gnosis Protocol'
AND version = '2'
-- AND block_time > '2022-02-04' -- February 4, 2022 (when GIP Passed);
```

Note the commented part about from what date the update should take place. I would differ to @fleupold for confirmation on that detail.

We may also want to consider what happens with some of the sub-functions responsible for back filling (like fill 2021 and fill 2022) with these changes. 


Note that, in order to avoid complexity, I have decided to keep the directory structure, filenames and table names the same (i.e. under `gnosis_protocol_v2`). Perhaps when we migrate to the V2 Dune Engine we can update the namespaces.