### PR TITLE
opensea-solana transfers added

### DIFF
--- a/polygon/opensea/backfill_trades.sql
+++ b/polygon/opensea/backfill_trades.sql
@@ -1,0 +1,36 @@
+CREATE OR REPLACE FUNCTION opensea.backfill_trades() RETURNS boolean
+LANGUAGE plpgsql AS $function$
+BEGIN
+
+-- backfill usd_price, fee_usd_price, royalty_usd_amount
+update opensea.trades
+   set usd_amount = new.new_usd_amount
+      ,fee_usd_amount = new.new_fee_usd_amount
+      ,royalty_usd_amount = new.new_royalty_usd_amount
+  from (select a.tx_hash
+              ,a.trade_id
+              ,a.original_amount_raw / 10^p.decimals * p.price as new_usd_amount
+              ,a.fee_amount_raw / 10^p.decimals * p.price as new_fee_usd_amount
+              ,a.royalty_amount_raw / 10^p.decimals * p.price as new_royalty_usd_amount
+          from opensea.trades a
+               inner join prices.usd p on p.contract_address = a.currency_contract
+                            		   and p.minute = date_trunc('minute', a.block_time)
+         where a.usd_amount is null
+        ) as new
+  where trades.tx_hash = new.tx_hash
+    and trades.trade_id = new.trade_id
+;
+
+RETURN TRUE;
+END
+$function$;
+
+-- historical fill
+SELECT opensea.backfill_trades();
+
+-- insert into cronjob
+INSERT INTO cron.job (schedule, command)
+VALUES ('*/35 * * * *', $$
+    SELECT opensea.backfill_trades();
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/polygon/opensea/insert_trades.sql
+++ b/polygon/opensea/insert_trades.sql
@@ -1,0 +1,137 @@
+CREATE OR REPLACE FUNCTION opensea.insert_trades (p_start_ts timestamptz, p_end_ts timestamptz=now()) RETURNS integer
+LANGUAGE plpgsql AS $function$
+DECLARE r integer;
+BEGIN
+
+with iv_raw as (
+    select a.call_block_time as block_time
+          ,concat('\x',substr((a."rightOrder"->'makerAssetData')::text,36,40))::bytea as nft_contract_address
+          ,case when length(a."rightOrder"->>'makerAssetData') = 650 then bytea2numeric(concat('\x00',substr((a."rightOrder"->'makerAssetData')::text,332,64))::bytea)::text
+                else bytea2numeric(concat('\x',substr((a."rightOrder"->'makerAssetData')::text,76,64))::bytea)::text
+           end as nft_token_id
+          ,case when length(a."rightOrder"->>'makerAssetData') = 650 then 'erc1155'
+                else 'erc721' -- 138
+           end as erc_standard
+          ,'Single Item Trade' as trade_type
+          ,(a."rightOrder"->>'makerAddress')::bytea as seller
+          ,(a."leftOrder"->>'makerAddress')::bytea as buyer
+          ,"paymentTokenAddress" as currency_contract
+          ,least("output_matchedFillResults"->'left'->'takerFeePaid', "output_matchedFillResults"->'right'->'makerFeePaid')::numeric as nft_item_count
+          ,least("output_matchedFillResults"->'left'->'makerFeePaid', "output_matchedFillResults"->'right'->'takerFeePaid')::numeric as original_amount_raw
+          ,("feeData"->0->>'recipient')::bytea as fee_receive_address
+          ,("feeData"->0->>'paymentTokenAmount')::numeric as fee_amount_raw
+          ,("feeData"->1->>'recipient')::bytea as royalty_receive_address
+          ,("feeData"->1->>'paymentTokenAmount')::numeric as royalty_amount_raw
+          ,a.call_tx_hash as tx_hash
+          ,a.call_block_number as block_number
+          ,a.contract_address as exchange_contract_address
+          ,a.call_trace_address
+      from opensea_polygon_v2."ZeroExFeeWrapper_call_matchOrders" a
+     where 1=1
+       and call_success
+       and a.call_block_time >= p_start_ts
+       and a.call_block_time < p_end_ts
+)
+,rows as (
+    INSERT INTO opensea.trades (
+           block_time
+          ,nft_contract_address
+          ,nft_token_id
+          ,erc_standard
+          ,platform
+          ,platform_version
+          ,trade_type
+          ,number_of_items
+          ,seller
+          ,buyer
+          ,currency_contract
+          ,original_currency
+          ,original_amount
+          ,original_amount_raw
+          ,usd_amount
+          ,fee_receive_address
+          ,fee_amount
+          ,fee_amount_raw
+          ,fee_usd_amount
+          ,royalty_receive_address
+          ,royalty_amount
+          ,royalty_amount_raw
+          ,royalty_usd_amount
+          ,exchange_contract_address
+          ,block_number
+          ,tx_hash
+          ,tx_from
+          ,tx_to
+          ,trade_id
+    )
+    select a.block_time 
+          ,nft_contract_address
+          ,nft_token_id
+          ,erc_standard
+          ,'OpenSea' as platform
+          ,'1' as platform_version
+          ,trade_type
+          ,nft_item_count as number_of_items
+          ,seller
+          ,buyer
+          ,currency_contract
+          ,p.symbol as origianl_currency
+          ,original_amount_raw / 10^p.decimals as original_amount
+          ,original_amount_raw
+          ,original_amount_raw / 10^p.decimals * p.price as usd_amount
+          ,fee_receive_address
+          ,fee_amount_raw / 10^p.decimals as fee_amount
+          ,fee_amount_raw
+          ,fee_amount_raw / 10^p.decimals * p.price as fee_usd_amount
+          ,royalty_receive_address
+          ,royalty_amount_raw / 10^p.decimals as royalty_amount
+          ,royalty_amount_raw
+          ,royalty_amount_raw / 10^p.decimals * p.price as royalty_usd_amount
+          ,a.exchange_contract_address
+          ,a.block_number
+          ,a.tx_hash
+          ,t."from" as tx_from
+          ,t."to" as tx_to
+          ,row_number() over (partition by a.tx_hash order by call_trace_address) as trade_id
+      from iv_raw a
+           inner join polygon.transactions t on t.hash = a.tx_hash
+                                             and t.block_time >= p_start_ts
+                                             and t.block_time < p_end_ts
+           left join prices.usd p on p.minute = date_trunc('minute', a.block_time)
+                                  and p.contract_address = a.currency_contract
+                                  and p.minute >= p_start_ts
+                                  and p.minute < p_end_ts
+    ON CONFLICT DO NOTHING
+    RETURNING 1
+)
+SELECT count(*) INTO r from rows;
+RETURN r;
+END
+$function$;
+
+-- fill histroy
+SELECT opensea.insert_trades('2021-06-01','2021-07-01');
+SELECT opensea.insert_trades('2021-07-01','2021-08-01');
+SELECT opensea.insert_trades('2021-08-01','2021-09-01');
+SELECT opensea.insert_trades('2021-09-01','2021-10-01');
+SELECT opensea.insert_trades('2021-10-01','2021-11-01');
+SELECT opensea.insert_trades('2021-11-01','2021-12-01');
+SELECT opensea.insert_trades('2021-12-01','2022-01-01');
+SELECT opensea.insert_trades('2022-01-01','2022-02-01');
+SELECT opensea.insert_trades('2022-02-01','2022-03-01');
+SELECT opensea.insert_trades('2022-03-01','2022-04-01');
+SELECT opensea.insert_trades('2022-04-01','2022-05-01');
+SELECT opensea.insert_trades('2022-05-01','2022-06-01');
+SELECT opensea.insert_trades('2022-06-01','2022-07-01');
+SELECT opensea.insert_trades('2022-07-01','2022-08-01');
+SELECT opensea.insert_trades('2022-08-01','2022-09-01');
+
+-- cronjob
+INSERT INTO cron.job (schedule, command)
+VALUES ('*/20 * * * *', $$
+    SELECT opensea.insert_trades(
+            (SELECT MAX(block_time) - interval '6 hours' FROM opensea.trades WHERE platform='OpenSea' AND platform_version = '1')
+           ,(SELECT NOW() - interval '20 minutes')
+        );
+$$)
+ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule; 

--- a/polygon/opensea/trades.sql
+++ b/polygon/opensea/trades.sql
@@ -1,3 +1,6 @@
+CREATE SCHEMA IF NOT EXISTS opensea
+;
+
 CREATE TABLE IF NOT EXISTS opensea.trades (
     block_time timestamptz
    ,nft_contract_address bytea

--- a/polygon/opensea/trades.sql
+++ b/polygon/opensea/trades.sql
@@ -1,0 +1,40 @@
+CREATE TABLE IF NOT EXISTS opensea.trades (
+    block_time timestamptz
+   ,nft_contract_address bytea
+   ,nft_token_id text
+   ,erc_standard text
+   ,platform text
+   ,platform_version text
+   ,trade_type text
+   ,number_of_items numeric
+   ,seller bytea
+   ,buyer bytea
+   ,currency_contract bytea
+   ,original_currency text
+   ,original_amount numeric
+   ,original_amount_raw numeric
+   ,usd_amount numeric
+   ,fee_receive_address bytea
+   ,fee_amount numeric
+   ,fee_amount_raw numeric
+   ,fee_usd_amount numeric
+   ,royalty_receive_address bytea
+   ,royalty_amount numeric
+   ,royalty_amount_raw numeric
+   ,royalty_usd_amount numeric
+   ,exchange_contract_address bytea
+   ,block_number int4
+   ,tx_hash bytea
+   ,tx_from bytea
+   ,tx_to bytea
+   ,trade_id int4
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS opensea_trades_tx_hash_trade_id_idx ON opensea.trades (tx_hash, trade_id);
+CREATE INDEX IF NOT EXISTS opensea_trades_block_time_idx ON opensea.trades (block_time);
+CREATE INDEX IF NOT EXISTS opensea_trades_seller_idx ON opensea.trades (seller);
+CREATE INDEX IF NOT EXISTS opensea_trades_buyer_idx ON opensea.trades (buyer);
+CREATE INDEX IF NOT EXISTS opensea_trades_fee_receive_address_idx ON opensea.trades (fee_receive_address);
+CREATE INDEX IF NOT EXISTS opensea_trades_royalty_receive_address_idx ON opensea.trades (royalty_receive_address);
+CREATE INDEX IF NOT EXISTS opensea_trades_nft_contract_address_nft_token_id_block_time_idx ON opensea.trades (nft_contract_address, nft_token_id, block_time);
+

--- a/spellbook/models/opensea/solana/opensea_solana_schema.yml
+++ b/spellbook/models/opensea/solana/opensea_solana_schema.yml
@@ -68,3 +68,92 @@ models:
       - *project_contract_address
       - *evt_type
       - *unique_trade_id
+
+  - name: opensea_solana_transfers
+    meta:
+      blockchain: solana
+      project: opensea
+      contributors: sohwak
+    config:
+      tags: ['opensea','solana','events']
+    description: >
+        OpenSea transfers on Solana
+    columns:
+      - name: blockchain
+        description: "Blockchain"
+      - name: project
+        description: "Project"
+      - name: version
+        description: "Project version"
+      - name: block_time
+        description: "UTC event block time"
+      - name: token_id
+        description: "NFT Token ID"
+      - name: collection
+        description: "NFT collection name"
+      - name: amount_usd
+        description:  "USD value of the trade at time of execution"
+      - name: token_standard
+        description:  "Token standard"
+      - name: trade_type
+        description: "Identify whether it was a single NFT trade or multiple NFTs traded"
+      - name: number_of_items
+        description:  "Number of items traded"
+      - name: trade_category
+        description:  "How was this NFT traded ? (Direct buy, auction, etc...)"
+      - name: evt_type
+        description:  "Event type (Trade, Mint, Burn)"
+      - name: seller
+        description:  "Seller wallet address"
+      - name: buyer
+        description:  "Buyer wallet address"
+      - name: amount_original
+        description:  "Traded amount in original currency"
+      - name: amount_raw
+        description:   "Traded amount in original currency before decimals correction"
+      - name: currency_symbol
+        description:  "Symbol of original currency used for payment"
+      - name: currency_contract
+        description:  "Contract address of original token used for payment, with ETH contract address swapped for WETH"
+      - name: nft_contract_address
+        description:  "NFT contract address, only if 1 nft was transacted"
+      - name: project_contract_address
+        description:  "Contract address used by the project, in this case wyvern contract"
+      - name: aggregator_name
+        description:  "If the trade was performed via an aggregator, displays aggregator name"
+      - name: aggregator_address
+        description:  "If the trade was performed via an aggregator, displays aggregator address"
+      - name: tx_hash
+        description:  "Transaction hash"
+      - name: block_number
+        description: "Block number in which the transaction was executed "
+      - name: tx_from
+        description:  "Address that initiated the transaction"
+      - name: tx_to
+        description:  "Address that received the transaction"
+      - name: platform_fee_receive_address
+        description:  "Wallet addresses receiving platform fees from the transaction"
+      - name: platform_fee_amount_raw
+        description:  "Raw numerical amount for platform fees"
+      - name: platform_fee_amount
+        description:  "Platform fee amount in original token currency (properly formatted in decimals)"
+      - name: platform_fee_amount_usd
+        description:  "Platform fee amount in USD"
+      - name: platform_fee_amount_usd
+        description:  "Platform fee in % of the amount paid for a given trade"
+      - name: royalty_fee_receive_address
+        description:  "Wallet addresses receiving royalty fees from the transaction"
+      - name: royalty_fee_amount_raw
+        description:  "Raw numerical amount for royalty fees"
+      - name: royalty_fee_amount
+        description:  "Royalty fee amount in original token currency (properly formatted in decimals)"
+      - name: royalty_fee_amount_usd
+        description:  "Royalty fee amount in USD"
+      - name: royalty_fee_percentage
+        description:  "Royalty fee in % of the amount paid for a given trade"
+      - name: royalty_receiver_cnt
+        description:  "Number of Royalty fee addressess because royalty can be paid to multiple addresses"
+      - name: royalty_list
+        description:  "Array list of royalty data consist of royalty_receive_address and fee_amount_raw"
+      - name: unique_trade_id
+        description:  "Unique trade ID"

--- a/spellbook/models/opensea/solana/opensea_solana_transfers.sql
+++ b/spellbook/models/opensea/solana/opensea_solana_transfers.sql
@@ -1,0 +1,133 @@
+{{ config(
+        alias ='transfers',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_trade_id'
+        )
+}}
+
+with iv_raw as (
+    select block_time
+          ,block_slot
+          ,id
+          ,case when array_contains(log_messages, 'Program log: Instruction: Sell') then 'Offer Accepted'
+                when array_contains(log_messages, 'Program log: Instruction: Buy') then 'Buy Now'
+                else 'Other'
+           end purchase_method
+          ,case when array_contains(log_messages, 'Program log: Instruction: Sell') then instructions[6]
+                when array_contains(log_messages, 'Program log: Instruction: Buy') then instructions[7]
+                else instructions[7]
+           end inst
+      from {{ source('solana','transactions') }}
+     where 1=1
+       and success
+{% if is_incremental() %}
+-- this filter will only be applied on an incremental run
+       AND block_date > now() - interval 2 days
+{% endif %} 
+       and block_date > '2022-04-06'
+       AND block_slot > 128251864
+       and array_contains(account_keys, '3o9d13qUvEuuauhFrVom1vuCzgNsJifeaBYDPquaT73Y') -- opensea auction house
+       and array_contains(log_messages, 'Program log: Instruction: ExecuteSale')
+)
+,iv_raw2 as (
+    select a.*
+          ,case when inner_cnt > 3 then royalty_receive_address_cand end as royalty_receive_address
+          ,case when inner_cnt = 4 then inner01 
+                when inner_cnt = 5 then inner01+inner02
+                when inner_cnt = 6 then inner01+inner02+inner03
+                when inner_cnt = 7 then inner01+inner02+inner03+inner04 
+                when inner_cnt = 8 then inner01+inner02+inner03+inner04+inner05
+           end as royalty_amount_raw
+          ,inner_cnt-3 as royalty_receiver_cnt
+          ,case when inner_cnt = 4 then array(concat('{"receive_address":"',addr01,'","amount_raw":',inner01,'}'))
+                when inner_cnt = 5 then array(concat('{"receive_address":"',addr01,'","amount_raw":',inner01,'}'),concat('{"receive_address":"',addr02,'","amount_raw":',inner02,'}'))
+                when inner_cnt = 6 then array(concat('{"receive_address":"',addr01,'","amount_raw":',inner01,'}'),concat('{"receive_address":"',addr02,'","amount_raw":',inner02,'}'),concat('{"receive_address":"',addr03,'","amount_raw":',inner03,'}'))
+                when inner_cnt = 7 then array(concat('{"receive_address":"',addr01,'","amount_raw":',inner01,'}'),concat('{"receive_address":"',addr02,'","amount_raw":',inner02,'}'),concat('{"receive_address":"',addr03,'","amount_raw":',inner03,'}'),concat('{"receive_address":"',addr04,'","amount_raw":',inner04,'}'))
+                when inner_cnt = 8 then array(concat('{"receive_address":"',addr01,'","amount_raw":',inner01,'}'),concat('{"receive_address":"',addr02,'","amount_raw":',inner02,'}'),concat('{"receive_address":"',addr03,'","amount_raw":',inner03,'}'),concat('{"receive_address":"',addr04,'","amount_raw":',inner04,'}'),concat('{"receive_address":"',addr05,'","amount_raw":',inner05,'}'))
+          end as royalty_list
+      from (
+            select a.*
+                  ,conv(concat(substr(indata,15,2),substr(indata,13,2),substr(indata,11,2),substr(indata,9,2),substr(indata,7,2),substr(indata,5,2),substr(indata,3,2),substr(indata,1,2)),16,10)::numeric(20) as original_amount_raw
+                  ,conv(concat(substr(fee_hex,15,2),substr(fee_hex,13,2),substr(fee_hex,11,2),substr(fee_hex,9,2),substr(fee_hex,7,2),substr(fee_hex,5,2),substr(fee_hex,3,2),substr(fee_hex,1,2)),16,10)::numeric(20) as fee_amount_raw
+                  ,conv(concat(substr(hex01,15,2),substr(hex01,13,2),substr(hex01,11,2),substr(hex01,9,2),substr(hex01,7,2),substr(hex01,5,2),substr(hex01,3,2),substr(hex01,1,2)),16,10)::numeric(20) as inner01
+                  ,conv(concat(substr(hex02,15,2),substr(hex02,13,2),substr(hex02,11,2),substr(hex02,9,2),substr(hex02,7,2),substr(hex02,5,2),substr(hex02,3,2),substr(hex02,1,2)),16,10)::numeric(20) as inner02
+                  ,conv(concat(substr(hex03,15,2),substr(hex03,13,2),substr(hex03,11,2),substr(hex03,9,2),substr(hex03,7,2),substr(hex03,5,2),substr(hex03,3,2),substr(hex03,1,2)),16,10)::numeric(20) as inner03
+                  ,conv(concat(substr(hex04,15,2),substr(hex04,13,2),substr(hex04,11,2),substr(hex04,9,2),substr(hex04,7,2),substr(hex04,5,2),substr(hex04,3,2),substr(hex04,1,2)),16,10)::numeric(20) as inner04
+                  ,conv(concat(substr(hex05,15,2),substr(hex05,13,2),substr(hex05,11,2),substr(hex05,9,2),substr(hex05,7,2),substr(hex05,5,2),substr(hex05,3,2),substr(hex05,1,2)),16,10)::numeric(20) as inner05
+              from (
+                    select block_time
+                          ,block_slot
+                          ,id
+                          ,purchase_method
+                          ,inst.account_arguments[0] as buyer
+                          ,inst.account_arguments[1] as seller
+                          ,inst.account_arguments[3] as nft_contract_address
+                          ,inst.account_arguments[5] as original_currency_address
+                          ,inst.account_arguments[10] as exchange_contract_address
+                          ,inst.inner_instructions[0].account_arguments[1] as royalty_receive_address_cand -- royalty can be divided into many addresses but we get first one only
+                          ,inst.inner_instructions[(array_size(inst.inner_instructions)-3)].account_arguments[1] as fee_receive_address
+                          ,substr(base58_decode(inst.data),23,16) as indata
+                          ,substr(base58_decode(inst.inner_instructions[(array_size(inst.inner_instructions)-3)].data)::string,9,16) as fee_hex
+                          ,array_size(inst.inner_instructions) as inner_cnt
+                          ,inst.inner_instructions[0].account_arguments[1] as addr01
+                          ,inst.inner_instructions[1].account_arguments[1] as addr02
+                          ,inst.inner_instructions[2].account_arguments[1] as addr03
+                          ,inst.inner_instructions[3].account_arguments[1] as addr04
+                          ,inst.inner_instructions[4].account_arguments[1] as addr05
+                          ,substr(base58_decode(inst.inner_instructions[0].data)::string,9,16) as hex01
+                          ,substr(base58_decode(inst.inner_instructions[1].data)::string,9,16) as hex02
+                          ,substr(base58_decode(inst.inner_instructions[2].data)::string,9,16) as hex03
+                          ,substr(base58_decode(inst.inner_instructions[3].data)::string,9,16) as hex04
+                          ,substr(base58_decode(inst.inner_instructions[4].data)::string,9,16) as hex05
+                      from iv_raw
+                    ) a
+            ) a
+)
+,iv_nft_trades as (
+    select  'solana' as blockchain
+           ,'opensea' as project
+           ,'v1' as version
+           ,block_time
+           ,nft_contract_address as token_id
+           ,'' as collection
+           ,original_amount_raw / 1e9 * p.price as amount_usd
+           ,'metaplex' as token_standard
+           ,'Single Item Trade' as trade_type
+           ,'1' as number_of_items
+           ,purchase_method as trade_category
+           ,'Trade' as evt_type
+           ,seller
+           ,buyer
+           ,original_amount_raw / 1e9 as amount_original
+           ,original_amount_raw as amount_raw
+           ,'SOL' as currency_symbol
+           ,original_currency_address as currency_contract
+           ,'' as nft_contract_address
+           ,exchange_contract_address as project_contract_address
+           ,'' as aggregator_name
+           ,'' as aggregator_address
+           ,id as tx_hash
+           ,'' as tx_from
+           ,'' as tx_to
+           ,block_slot as block_number
+           ,fee_receive_address as platform_fee_receive_address
+           ,fee_amount_raw as platform_fee_amount_raw
+           ,fee_amount_raw / 1e9 as platform_fee_amount
+           ,fee_amount_raw / 1e9 * p.price as platform_fee_amount_usd
+           ,fee_amount_raw / original_amount_raw * 100 as platform_fee_percentage
+           ,royalty_receive_address as royalty_fee_receive_address
+           ,royalty_amount_raw as royalty_fee_amount_raw
+           ,royalty_amount_raw / 1e9 as royalty_fee_amount
+           ,royalty_amount_raw / 1e9 * p.price as royalty_fee_amount_usd
+           ,royalty_amount_raw / original_amount_raw * 100 as royalty_fee_percentage
+           ,royalty_receiver_cnt
+           ,royalty_list
+           ,id as unique_trade_id
+      from iv_raw2 a
+           left join {{ source('prices', 'usd') }} p on p.minute = date_trunc('minute', block_time)
+                                  and p.symbol = 'SOL'
+)
+select *
+  from iv_nft_trades


### PR DESCRIPTION
Brief comments on the purpose of your changes:

I think I will make it to replace the current `opensea_solana.events`, but I am going to make it as a temporary version, not a fixed version so I just name this as `opensea_solana.transfers`.

Because I'm not sure if it's perfect. and in order to test and confirm, it can't execute with single query because Solana data is too heavy to run with one query.

I'm going to make it `opensea_solana.events` after testing and modifying if needed.

The point is, I want to keep the table in operation until the table in development is complete. If you let me know if there's any other way, I'll apply like that.

*For Dune Engine V2*
I've checked that:

* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
