### PR TITLE
chore(dfi): added DeFiChain's DFI token info

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -2189,3 +2189,8 @@
   symbol: STANDARD
   address: 0xda0c94c73d127ee191955fb46bacd7ff999b2bcd
   decimals: 18
+- name: DeFiChain Token
+  id: dfi-defi-chain
+  symbol: DFI
+  address: 0x8Fc8f8269ebca376D046Ce292dC7eaC40c8D358A
+  decimals: 8


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Following the process listed on [Dune.com's Prices page](https://docs.dune.com/data-tables/prices) and in the [README](https://github.com/duneanalytics/abstractions/tree/master/prices), am adding in DeFiChain's `DFI` token as am working on some analytics queries requiring DFI price feeds.

> [DeFiChain](https://defichain.com/) is a decentralized non-Turing-complete proof-of-stake blockchain created as a hard fork of the Bitcoin network to enable advanced DeFi applications.

* [Etherscan](https://etherscan.io/token/0x8Fc8f8269ebca376D046Ce292dC7eaC40c8D358A)
* [coinpaprika](https://coinpaprika.com/coin/dfi-defi-chain/)

*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
