### PR TITLE
OP2 force newer dex runs & Activate Kwenta

### DIFF
--- a/optimism2/dex/insert_kwenta.sql
+++ b/optimism2/dex/insert_kwenta.sql
@@ -55,7 +55,7 @@ WITH rows AS (
         evt_index,
         row_number() OVER (PARTITION BY project, tx_hash, evt_index, trace_address ORDER BY version, category) AS trade_id
     FROM (
-        --Kwenta - MintableSynthetix_evt_SynthExchange
+        --Kwenta - MintableSynthetix_evt_SynthExchange - renamed to SNX_evt_SynthExchange
         SELECT
             se.evt_block_time AS block_time,
             'Kwenta' AS project,
@@ -74,7 +74,7 @@ WITH rows AS (
             NULL::integer[] AS trace_address,
             se.evt_index
         --Synthetix event uses hash keys for tokens, so we pull ERC20 transfers instead
-        FROM synthetix."MintableSynthetix_evt_SynthExchange" se
+        FROM synthetix."SNX_evt_SynthExchange" se
         -- to-do: Find a way to validate that this is the Synthetix token and not a token with the same symbol
         LEFT JOIN erc20.tokens send
             ON send."symbol" = split_part(encode("fromCurrencyKey", 'escape'),'\',1)

--- a/optimism2/dex/prices_and_trades_inserts.sql
+++ b/optimism2/dex/prices_and_trades_inserts.sql
@@ -20,7 +20,7 @@ VALUES ('15,30,45,59 * * * *', $$
 	SELECT dex.insert_curve( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Curve'), (SELECT max_time FROM ovm2.view_last_updated) );
 	SELECT dex.insert_clipper( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Clipper' AND version = '1'), (SELECT max_time FROM ovm2.view_last_updated) );
 	SELECT dex.insert_clipper_v2( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Clipper' AND version = '2'), (SELECT max_time FROM ovm2.view_last_updated) );
--- 	SELECT dex.insert_kwenta( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Kwenta'), (SELECT max_time FROM ovm2.view_last_updated) );
+	SELECT dex.insert_kwenta( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Kwenta'), (SELECT max_time FROM ovm2.view_last_updated) );
 	SELECT dex.insert_wardenswap( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='WardenSwap' AND version = '2'), (SELECT max_time FROM ovm2.view_last_updated) );
 	SELECT dex.insert_rubicon( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Rubicon'), (SELECT max_time FROM ovm2.view_last_updated) );
 	SELECT dex.insert_velodrome( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Velodrome'), (SELECT max_time FROM ovm2.view_last_updated) );

--- a/optimism2/dex/prices_and_trades_inserts.sql
+++ b/optimism2/dex/prices_and_trades_inserts.sql
@@ -13,20 +13,20 @@ VALUES ('15,30,45,59 * * * *', $$
 	
 ----------
 --DEX Inserts. These should only pull in prices where there is a Chainlink oracle.
-	SELECT dex.insert_uniswap_v3( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Uniswap' AND version = '3'), (SELECT max_time FROM ovm2.view_last_updated) );
-	SELECT dex.insert_oneinch( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='1inch'), (SELECT max_time FROM ovm2.view_last_updated), 0);
-	SELECT dex.insert_zeroex( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project IN ('0x API', 'Matcha')), (SELECT max_time FROM ovm2.view_last_updated) );
-	SELECT dex.insert_zipswap( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Zipswap'), (SELECT max_time FROM ovm2.view_last_updated) );
-	SELECT dex.insert_curve( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Curve'), (SELECT max_time FROM ovm2.view_last_updated) );
-	SELECT dex.insert_clipper( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Clipper' AND version = '1'), (SELECT max_time FROM ovm2.view_last_updated) );
-	SELECT dex.insert_clipper_v2( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Clipper' AND version = '2'), (SELECT max_time FROM ovm2.view_last_updated) );
--- 	SELECT dex.insert_kwenta( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Kwenta'), (SELECT max_time FROM ovm2.view_last_updated) );
-	SELECT dex.insert_wardenswap( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='WardenSwap' AND version = '2'), (SELECT max_time FROM ovm2.view_last_updated) );
-	SELECT dex.insert_rubicon( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Rubicon'), (SELECT max_time FROM ovm2.view_last_updated) );
-	SELECT dex.insert_velodrome( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Velodrome'), (SELECT max_time FROM ovm2.view_last_updated) );
-	SELECT dex.insert_beethoven_x( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Beethoven X'), (SELECT max_time FROM ovm2.view_last_updated) );
-	SELECT dex.insert_sushiswap( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Sushiswap'), (SELECT max_time FROM ovm2.view_last_updated) );
-	SELECT dex.insert_slingshot( (SELECT max(block_time) - interval '1 hour' FROM dex.trades WHERE project='Slingshot'), (SELECT max_time FROM ovm2.view_last_updated) );
+	SELECT dex.insert_uniswap_v3( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Uniswap' AND version = '3'), (SELECT max_time FROM ovm2.view_last_updated) );
+	SELECT dex.insert_oneinch( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='1inch'), (SELECT max_time FROM ovm2.view_last_updated), 0);
+	SELECT dex.insert_zeroex( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project IN ('0x API', 'Matcha')), (SELECT max_time FROM ovm2.view_last_updated) );
+	SELECT dex.insert_zipswap( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Zipswap'), (SELECT max_time FROM ovm2.view_last_updated) );
+	SELECT dex.insert_curve( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Curve'), (SELECT max_time FROM ovm2.view_last_updated) );
+	SELECT dex.insert_clipper( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Clipper' AND version = '1'), (SELECT max_time FROM ovm2.view_last_updated) );
+	SELECT dex.insert_clipper_v2( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Clipper' AND version = '2'), (SELECT max_time FROM ovm2.view_last_updated) );
+-- 	SELECT dex.insert_kwenta( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Kwenta'), (SELECT max_time FROM ovm2.view_last_updated) );
+	SELECT dex.insert_wardenswap( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='WardenSwap' AND version = '2'), (SELECT max_time FROM ovm2.view_last_updated) );
+	SELECT dex.insert_rubicon( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Rubicon'), (SELECT max_time FROM ovm2.view_last_updated) );
+	SELECT dex.insert_velodrome( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Velodrome'), (SELECT max_time FROM ovm2.view_last_updated) );
+	SELECT dex.insert_beethoven_x( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Beethoven X'), (SELECT max_time FROM ovm2.view_last_updated) );
+	SELECT dex.insert_sushiswap( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Sushiswap'), (SELECT max_time FROM ovm2.view_last_updated) );
+	SELECT dex.insert_slingshot( (SELECT COALESCE(max(block_time),'2021-11-11'::date) - interval '1 hour' FROM dex.trades WHERE project='Slingshot'), (SELECT max_time FROM ovm2.view_last_updated) );
 	--ADD REMAINING DEX INSERTS HERE
 --END DEX Inserts
 ----------


### PR DESCRIPTION
Brief comments on the purpose of your changes:
Newer DEXs didn't rerun since their max block time was null. Forcing a rerun by updating the inserts.
This also re-activates Kwenta (contract name changed in the db)

*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
