### PR TITLE
patch division-by-zero on seaport abstraction

### DIFF
--- a/ethereum/nft/trades/insert_seaport.sql
+++ b/ethereum/nft/trades/insert_seaport.sql
@@ -93,6 +93,7 @@ with p1_call as (
                           ,a.*
                       from p1_evt a
                     ) a
+             where nft_transfer_count > 0  -- some of trades without NFT happens in match_order
             ) a
 )
 ,p1_txn_level as (
@@ -503,6 +504,7 @@ with p1_call as (
                           ,a.*
                       from p3_evt a
                     ) a
+             where nft_transfer_count > 0  -- some of trades without NFT happens in match_order
             ) a
 )
 ,p3_txn_level as (

--- a/ethereum/seaport/insert_transfers.sql
+++ b/ethereum/seaport/insert_transfers.sql
@@ -102,6 +102,7 @@ with p1_call as (
                           ,a.*
                       from p1_evt a
                     ) a
+             where nft_transfer_count > 0  -- some of trades without NFT happens in match_order
             ) a
 )
 ,p1_txn_level as (
@@ -512,6 +513,7 @@ with p1_call as (
                           ,a.*
                       from p3_evt a
                     ) a
+             where nft_transfer_count > 0  -- some of trades without NFT happens in match_order
             ) a
 )
 ,p3_txn_level as (


### PR DESCRIPTION
Brief comments on the purpose of your changes:

modified : some "division-by-zero" cases which were not covered in the previous patch.

affected tables:
- `nft.trades`, `platform = 'OpenSea'` : since 20 Aug 2022
- `seaport.transfers`  : since 20 Aug 2022

please backfill affected tables too.

Thank you.

*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
