### PR TITLE
remove swaps from test due to explode

### DIFF
--- a/spellbook/tests/sudoswap/ethereum/sudoswap_ethereum_assert_swaps.sql
+++ b/spellbook/tests/sudoswap/ethereum/sudoswap_ethereum_assert_swaps.sql
@@ -74,14 +74,12 @@ WITH
           ) s
       )
     SELECT
-      COUNT(*) as num_trades,
       COUNT(distinct call_tx_hash) as num_txs
     FROM
       fil_swaps
   ),
   abstractions_swaps as (
     SELECT
-      COUNT(*) as num_trades,
       COUNT(distinct tx_hash) as num_txs
     FROM
         {{ ref('nft_trades') }} nft
@@ -95,17 +93,6 @@ WITH
   ),
   test as (
     SELECT
-      (
-        SELECT
-          num_trades
-        FROM
-          abstractions_swaps
-      ) - (
-        SELECT
-          num_trades
-        FROM
-          raw_swaps
-      ) as trades_mismatch,
       (
         SELECT
           num_txs
@@ -123,7 +110,4 @@ SELECT
 FROM
   test
 WHERE
-  (
-    trades_mismatch > 0
-    OR txs_mismatch > 0
-  )
+  txs_mismatch > 0


### PR DESCRIPTION
Brief comments on the purpose of your changes:


*For Dune Engine V2*
I've checked that:

* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
---

fixing test due to error from exploding swaps. @jeff-dude 
